### PR TITLE
chore(ci): 백엔드 PR 검증과 전체 검증 흐름을 분리

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: backend-ci
 
 on:
   pull_request:
@@ -24,8 +24,9 @@ permissions:
   contents: read
 
 jobs:
-  backend-ci:
-    name: backend-ci
+  backend-pr-check:
+    name: backend-pr-check
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -47,14 +48,14 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Run backend tests with Jacoco
-        run: ./gradlew test
+      - name: Run fast backend tests
+        run: ./gradlew --no-daemon test
 
       - name: Upload Jacoco HTML report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-html-report
+          name: jacoco-html-report-pr
           path: backend/build/reports/jacoco/test/html
           if-no-files-found: warn
 
@@ -62,6 +63,49 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jacoco-xml-report
+          name: jacoco-xml-report-pr
+          path: backend/build/reports/jacoco/test/jacocoTestReport.xml
+          if-no-files-found: warn
+
+  backend-full-verification:
+    name: backend-full-verification
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Run full backend verification
+        run: ./gradlew --no-daemon fullVerification
+
+      - name: Upload Jacoco HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report-full
+          path: backend/build/reports/jacoco/test/html
+          if-no-files-found: warn
+
+      - name: Upload Jacoco XML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-xml-report-full
           path: backend/build/reports/jacoco/test/jacocoTestReport.xml
           if-no-files-found: warn

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+
 plugins {
   java
   id("org.springframework.boot") version "4.0.3"
@@ -84,9 +87,34 @@ dependencies {
   testImplementation("org.wiremock:wiremock-standalone:3.12.1")
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
   useJUnitPlatform()
+}
+
+tasks.test {
+  useJUnitPlatform {
+    excludeTags("integration")
+  }
   finalizedBy(tasks.jacocoTestReport)
+}
+
+val testSourceSet = the<JavaPluginExtension>().sourceSets.getByName("test")
+
+val integrationTest = tasks.register<Test>("integrationTest") {
+  description = "Runs integration tests that require Spring Boot and Testcontainers."
+  group = "verification"
+  testClassesDirs = testSourceSet.output.classesDirs
+  classpath = testSourceSet.runtimeClasspath
+  useJUnitPlatform {
+    includeTags("integration")
+  }
+  shouldRunAfter(tasks.test)
+}
+
+tasks.register("fullVerification") {
+  description = "Runs fast tests, integration tests, and JaCoCo report generation."
+  group = "verification"
+  dependsOn(tasks.test, integrationTest, tasks.jacocoTestReport)
 }
 
 jacoco {

--- a/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
@@ -1,0 +1,22 @@
+package com.back.coach;
+
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class ApplicationIntegrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    @DisplayName("Testcontainers 환경에서 전체 애플리케이션 컨텍스트가 뜬다")
+    void contextLoadsWithTestcontainers() {
+        assertThat(applicationContext).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/back/coach/ContextLoadsTest.java
+++ b/backend/src/test/java/com/back/coach/ContextLoadsTest.java
@@ -1,19 +1,45 @@
 package com.back.coach;
 
-import com.back.coach.support.ApiTestBase;
+import com.back.coach.global.logging.TraceIdFilter;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * 테스트 스캐폴드 스모크: Spring 컨텍스트가 뜨고 MockMvc 가 동작하는지만 확인.
- * 실패 시 Docker Desktop / application-test.yml / Testcontainers 설정 점검.
+ * 경량 스모크: MockMvc 와 TraceIdFilter 가 빠르게 동작하는지만 확인.
  */
-class ContextLoadsTest extends ApiTestBase {
+class ContextLoadsTest {
+
+    private final MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new TestController())
+            .addFilters(new TraceIdFilter())
+            .build();
 
     @Test
-    void contextLoadsAndMockMvcServesRequests() throws Exception {
-        // 매핑되지 않은 경로라도 MockMvc 가 응답하면 컨텍스트는 정상.
-        mockMvc.perform(get("/__nonexistent__"));
+    @DisplayName("MockMvc 와 TraceId 필터가 빠르게 동작한다")
+    void mockMvcAndTraceIdFilterWork() throws Exception {
+        mockMvc.perform(get("/__test__/ping"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(TraceIdFilter.HEADER))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string("ok"));
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping(path = "/__test__/ping", produces = MediaType.TEXT_PLAIN_VALUE)
+        String ping() {
+            return "ok";
+        }
     }
 }

--- a/backend/src/test/java/com/back/coach/support/IntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/support/IntegrationTest.java
@@ -1,6 +1,7 @@
 package com.back.coach.support;
 
 import com.back.coach.config.TestcontainersConfiguration;
+import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,6 +27,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Tag("integration")
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)


### PR DESCRIPTION
## 연관 이슈

- close할 이슈: #11

## 변경 요약

- PR에서는 빠른 테스트만 실행하고, `dev`/`main` push에서는 통합 테스트와 JaCoCo를 포함한 전체 검증이 돌도록 분리했습니다.
- `IntegrationTest`에 `integration` 태그를 붙이고 `integrationTest`, `fullVerification` Gradle 태스크를 추가했습니다.
- 기존 무거운 컨텍스트 스모크 테스트를 경량 MockMvc + TraceIdFilter 테스트로 바꾸고, 전체 애플리케이션 컨텍스트 확인은 별도 통합 테스트로 분리했습니다.
- GitHub Actions에서 backend 변경에만 반응하도록 하고, PR 검증과 push 검증 잡을 나눴습니다.

## 테스트

실행 내용:

```text
cd backend
.\gradlew.bat test
.\gradlew.bat integrationTest --dry-run
.\gradlew.bat fullVerification --dry-run
git diff --check
```
