### PR TITLE
chore(env): 로컬 실행 환경 기준 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Local database
+DATABASE_URL=jdbc:postgresql://localhost:5433/coachdb
+DATABASE_USERNAME=coach
+DATABASE_PASSWORD=coach
+
+# Local Redis
+REDIS_HOST=localhost
+REDIS_PORT=6380
+
+# Backend security
+JWT_SECRET=change-me-to-a-long-random-local-secret
+FRONTEND_URL=http://localhost:3000
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your-github-oauth-client-id
+GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
+
+# AI provider / gateway
+GLM_API_KEY=your-ai-api-key
+GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+GLM_MODEL=glm-4-flash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # INT6-Roadmap-Team06
+
+AI 개발자 성장 코치 서비스입니다. 사용자의 프로필, GitHub 활동, 진단 결과를 바탕으로 주차별 학습 로드맵과 진도 관리를 제공합니다.
+
+## 로컬 실행 준비
+
+루트에서 `.env.example`을 복사해 개인 `.env`를 만듭니다.
+
+```powershell
+Copy-Item .env.example .env
+```
+
+`.env`에는 실제 GitHub OAuth secret, AI API key, JWT secret 같은 개인 값을 넣습니다. `.env`는 Git에 올리지 않습니다.
+
+## DB/Redis 실행
+
+```powershell
+docker compose -f docker/docker-compose.yml up -d
+```
+
+기본 로컬 값은 다음과 같습니다.
+
+- PostgreSQL: `localhost:5433`, database `coachdb`, user/password `coach`
+- Redis: `localhost:6380`
+
+## 백엔드 실행
+
+```powershell
+cd backend
+.\gradlew.bat bootRun
+```
+
+기본 profile은 `local`입니다. GitHub OAuth까지 확인하려면 `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`을 `.env`에 채우고 `local,oauth` profile로 실행합니다.
+
+```powershell
+.\gradlew.bat bootRun --args="--spring.profiles.active=local,oauth"
+```
+
+## 테스트
+
+```powershell
+cd backend
+.\gradlew.bat test
+```

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,8 +1,12 @@
 spring:
+  config:
+    import:
+      - optional:file:.env[.properties]
+      - optional:file:../.env[.properties]
   datasource:
-    url: jdbc:postgresql://localhost:5433/coachdb
-    username: coach
-    password: coach
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5433/coachdb}
+    username: ${DATABASE_USERNAME:coach}
+    password: ${DATABASE_PASSWORD:coach}
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## 연관 이슈

Closes #20

## 변경 요약

- 루트 `.env.example` 추가
- `application-local.yml`에서 local 전용 `.env` optional import 설정
- README에 로컬 DB/Redis, 백엔드 실행, 테스트 방법 정리

## 테스트

실행 내용:

```text
backend\gradlew.bat test
```