### PR TITLE
refactor(api): API 응답 계약 정렬

### DIFF
--- a/backend/src/main/java/com/back/coach/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/back/coach/global/response/ApiResponse.java
@@ -1,11 +1,26 @@
 package com.back.coach.global.response;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public record ApiResponse<T>(
-        boolean success,
-        T data
+        T data,
+        Map<String, Object> meta
 ) {
 
+    public ApiResponse {
+        meta = normalizeMeta(meta);
+    }
+
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data);
+        return new ApiResponse<>(data, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data, Map<String, Object> meta) {
+        return new ApiResponse<>(data, meta);
+    }
+
+    private static Map<String, Object> normalizeMeta(Map<String, Object> meta) {
+        return (meta == null || meta.isEmpty()) ? Map.of() : new LinkedHashMap<>(meta);
     }
 }

--- a/backend/src/test/java/com/back/coach/global/response/ApiResponseTest.java
+++ b/backend/src/test/java/com/back/coach/global/response/ApiResponseTest.java
@@ -1,0 +1,62 @@
+package com.back.coach.global.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 카나리: docs/03_api_spec_aligned.md 의 성공 응답 스키마를 어기지 않도록 한다.
+ *   { "data": ..., "meta": { ... } }
+ */
+class ApiResponseTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void success_defaultMeta_serializesDataAndEmptyMetaOnly() {
+        ApiResponse<Map<String, String>> body = ApiResponse.success(Map.of("message", "ok"));
+
+        JsonNode json = mapper.valueToTree(body);
+
+        assertThat(fieldNames(json)).containsExactlyInAnyOrder("data", "meta");
+        assertThat(json.has("success")).isFalse();
+        assertThat(json.get("data").get("message").asText()).isEqualTo("ok");
+        assertThat(json.get("meta").isObject()).isTrue();
+        assertThat(json.get("meta").isEmpty()).isTrue();
+    }
+
+    @Test
+    void success_customMeta_preservesMetaValues() {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("latestVersion", 3);
+        meta.put("traceId", "trace-123");
+
+        ApiResponse<Map<String, String>> body = ApiResponse.success(Map.of("message", "ok"), meta);
+
+        JsonNode json = mapper.valueToTree(body);
+
+        assertThat(json.get("meta").get("latestVersion").asInt()).isEqualTo(3);
+        assertThat(json.get("meta").get("traceId").asText()).isEqualTo("trace-123");
+    }
+
+    @Test
+    void constructor_nullMeta_normalizesToEmptyObject() {
+        ApiResponse<String> body = new ApiResponse<>("ok", null);
+
+        JsonNode json = mapper.valueToTree(body);
+
+        assertThat(json.get("meta").isObject()).isTrue();
+        assertThat(json.get("meta").isEmpty()).isTrue();
+    }
+
+    private static java.util.List<String> fieldNames(JsonNode node) {
+        java.util.List<String> names = new java.util.ArrayList<>();
+        node.fieldNames().forEachRemaining(names::add);
+        return names;
+    }
+}


### PR DESCRIPTION
## 연관 이슈

Closes #24

## 변경 요약

- 성공 응답을 `{ data, meta }` 구조로 정렬
- 성공 응답에서 `success` 필드 제거
- 기본/custom meta 직렬화 스키마 테스트 추가

## 테스트

실행 내용:

```text
backend\gradlew.bat test
```