### PR TITLE
chore(security): JWT Security 공통 골격 보강

### DIFF
--- a/backend/src/main/java/com/back/coach/global/security/AuthenticatedUser.java
+++ b/backend/src/main/java/com/back/coach/global/security/AuthenticatedUser.java
@@ -1,0 +1,17 @@
+package com.back.coach.global.security;
+
+import java.security.Principal;
+
+public record AuthenticatedUser(Long userId) implements Principal {
+
+    public AuthenticatedUser {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId must not be null");
+        }
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(userId);
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/com/back/coach/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final SecurityErrorResponseWriter responseWriter;
+
+    public JwtAccessDeniedHandler(SecurityErrorResponseWriter responseWriter) {
+        this.responseWriter = responseWriter;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        responseWriter.write(request, response, ErrorCode.FORBIDDEN);
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/back/coach/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final SecurityErrorResponseWriter responseWriter;
+
+    public JwtAuthenticationEntryPoint(SecurityErrorResponseWriter responseWriter) {
+        this.responseWriter = responseWriter;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        responseWriter.write(request, response, ErrorCode.UNAUTHORIZED);
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/coach/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider tokenProvider;
+    private final SecurityErrorResponseWriter responseWriter;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, SecurityErrorResponseWriter responseWriter) {
+        this.tokenProvider = tokenProvider;
+        this.responseWriter = responseWriter;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization == null || authorization.isBlank()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!authorization.startsWith(BEARER_PREFIX)) {
+            responseWriter.write(request, response, ErrorCode.AUTH_INVALID_TOKEN);
+            return;
+        }
+
+        try {
+            AuthenticatedUser user = tokenProvider.parseAccessToken(authorization.substring(BEARER_PREFIX.length()).trim());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(user, null, List.of());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (ServiceException e) {
+            SecurityContextHolder.clearContext();
+            responseWriter.write(request, response, e.getErrorCode(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/JwtProperties.java
+++ b/backend/src/main/java/com/back/coach/global/security/JwtProperties.java
@@ -1,0 +1,23 @@
+package com.back.coach.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.jwt")
+public record JwtProperties(
+        String secret,
+        long accessTtlSeconds,
+        long refreshTtlSeconds
+) {
+
+    public JwtProperties {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalArgumentException("security.jwt.secret must not be blank");
+        }
+        if (accessTtlSeconds <= 0) {
+            throw new IllegalArgumentException("security.jwt.access-ttl-seconds must be positive");
+        }
+        if (refreshTtlSeconds <= 0) {
+            throw new IllegalArgumentException("security.jwt.refresh-ttl-seconds must be positive");
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/back/coach/global/security/JwtTokenProvider.java
@@ -1,0 +1,110 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String TOKEN_TYPE_CLAIM = "type";
+    private static final String ACCESS_TOKEN_TYPE = "access";
+    private static final String REFRESH_TOKEN_TYPE = "refresh";
+
+    private final JwtProperties properties;
+    private final Clock clock;
+    private final SecretKey key;
+
+    @Autowired
+    public JwtTokenProvider(JwtProperties properties) {
+        this(properties, Clock.systemUTC());
+    }
+
+    JwtTokenProvider(JwtProperties properties, Clock clock) {
+        this.properties = properties;
+        this.clock = clock;
+        this.key = createKey(properties.secret());
+    }
+
+    public String createAccessToken(Long userId) {
+        return createToken(userId, ACCESS_TOKEN_TYPE, properties.accessTtlSeconds());
+    }
+
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, REFRESH_TOKEN_TYPE, properties.refreshTtlSeconds());
+    }
+
+    public AuthenticatedUser parseAccessToken(String token) {
+        Claims claims = parseClaims(token);
+        if (!ACCESS_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class))) {
+            throw new ServiceException(ErrorCode.AUTH_INVALID_TOKEN, ErrorCode.AUTH_INVALID_TOKEN.getDefaultMessage());
+        }
+        return new AuthenticatedUser(parseUserId(claims.getSubject()));
+    }
+
+    private String createToken(Long userId, String tokenType, long ttlSeconds) {
+        if (userId == null) {
+            throw new IllegalArgumentException("userId must not be null");
+        }
+        Instant issuedAt = Instant.now(clock);
+        Instant expiresAt = issuedAt.plusSeconds(ttlSeconds);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim(TOKEN_TYPE_CLAIM, tokenType)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiresAt))
+                .signWith(key, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        if (token == null || token.isBlank()) {
+            throw new ServiceException(ErrorCode.AUTH_INVALID_TOKEN, ErrorCode.AUTH_INVALID_TOKEN.getDefaultMessage());
+        }
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .clock(() -> Date.from(Instant.now(clock)))
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new ServiceException(ErrorCode.AUTH_EXPIRED_TOKEN, ErrorCode.AUTH_EXPIRED_TOKEN.getDefaultMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new ServiceException(ErrorCode.AUTH_INVALID_TOKEN, ErrorCode.AUTH_INVALID_TOKEN.getDefaultMessage());
+        }
+    }
+
+    private Long parseUserId(String subject) {
+        try {
+            return Long.valueOf(subject);
+        } catch (NumberFormatException e) {
+            throw new ServiceException(ErrorCode.AUTH_INVALID_TOKEN, ErrorCode.AUTH_INVALID_TOKEN.getDefaultMessage());
+        }
+    }
+
+    private SecretKey createKey(String secret) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(secret.getBytes(StandardCharsets.UTF_8));
+            return Keys.hmacShaKeyFor(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is required", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
@@ -2,25 +2,49 @@ package com.back.coach.global.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+            JwtAccessDeniedHandler jwtAccessDeniedHandler
+    ) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .formLogin(form -> form.disable())
             .httpBasic(basic -> basic.disable())
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+            )
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/api/v1/auth/**",
+                    "/oauth2/**",
+                    "/login/oauth2/**",
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/actuator/health",
+                    "/actuator/info"
+                ).permitAll()
+                .requestMatchers("/api/**").authenticated()
                 .anyRequest().permitAll()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/back/coach/global/security/SecurityErrorResponseWriter.java
+++ b/backend/src/main/java/com/back/coach/global/security/SecurityErrorResponseWriter.java
@@ -1,0 +1,47 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.logging.TraceIdFilter;
+import com.back.coach.global.response.ApiErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class SecurityErrorResponseWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public SecurityErrorResponseWriter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void write(HttpServletRequest request, HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        write(request, response, errorCode, errorCode.getDefaultMessage());
+    }
+
+    public void write(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            ErrorCode errorCode,
+            String message
+    ) throws IOException {
+        if (response.isCommitted()) {
+            return;
+        }
+
+        ApiErrorResponse body = ApiErrorResponse.of(errorCode, message)
+                .withTraceId(MDC.get(TraceIdFilter.MDC_KEY));
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/JwtTokenProviderTest.java
@@ -1,0 +1,70 @@
+package com.back.coach.global.security;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+    private static final JwtProperties PROPERTIES = new JwtProperties(
+            "test-secret-key-for-jwt-provider",
+            900,
+            86_400
+    );
+
+    @Test
+    void createAccessToken_andParseUserId() {
+        JwtTokenProvider provider = new JwtTokenProvider(PROPERTIES);
+
+        String token = provider.createAccessToken(10L);
+
+        assertThat(provider.parseAccessToken(token).userId()).isEqualTo(10L);
+    }
+
+    @Test
+    void refreshToken_isNotAcceptedAsAccessToken() {
+        JwtTokenProvider provider = new JwtTokenProvider(PROPERTIES);
+        String token = provider.createRefreshToken(10L);
+
+        assertThatThrownBy(() -> provider.parseAccessToken(token))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+    }
+
+    @Test
+    void expiredAccessToken_throwsExpiredTokenError() {
+        Instant issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+        JwtProperties shortTtl = new JwtProperties("test-secret-key-for-expired-token", 1, 60);
+        JwtTokenProvider issuer = new JwtTokenProvider(shortTtl, fixedClock(issuedAt));
+        JwtTokenProvider parser = new JwtTokenProvider(shortTtl, fixedClock(issuedAt.plusSeconds(2)));
+
+        String token = issuer.createAccessToken(10L);
+
+        assertThatThrownBy(() -> parser.parseAccessToken(token))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_EXPIRED_TOKEN);
+    }
+
+    @Test
+    void invalidToken_throwsInvalidTokenError() {
+        JwtTokenProvider provider = new JwtTokenProvider(PROPERTIES);
+
+        assertThatThrownBy(() -> provider.parseAccessToken("invalid-token"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+    }
+
+    private static Clock fixedClock(Instant instant) {
+        return Clock.fixed(instant, ZoneOffset.UTC);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/SecurityConfigTest.java
@@ -1,0 +1,123 @@
+package com.back.coach.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringJUnitWebConfig(SecurityConfigTest.TestConfig.class)
+@TestPropertySource(properties = {
+        "security.jwt.secret=test-secret-key-for-security-config",
+        "security.jwt.access-ttl-seconds=900",
+        "security.jwt.refresh-ttl-seconds=86400"
+})
+class SecurityConfigTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private JwtTokenProvider tokenProvider;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void protectedApi_withoutToken_returnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/profiles/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    @Test
+    void protectedApi_withValidAccessToken_returnsAuthenticatedUser() throws Exception {
+        String token = tokenProvider.createAccessToken(10L);
+
+        mockMvc.perform(get("/api/v1/profiles/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(content().string("10"));
+    }
+
+    @Test
+    void protectedApi_withInvalidToken_returnsInvalidTokenError() throws Exception {
+        mockMvc.perform(get("/api/v1/profiles/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_INVALID_TOKEN"))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 토큰입니다."));
+    }
+
+    @Test
+    void publicAuthApi_withoutToken_isPermitted() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/ping"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string("ok"));
+    }
+
+    @RestController
+    static class TestApiController {
+
+        @GetMapping(path = "/api/v1/profiles/me", produces = MediaType.TEXT_PLAIN_VALUE)
+        String me(Authentication authentication) {
+            AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+            return user.getName();
+        }
+
+        @GetMapping(path = "/api/v1/auth/ping", produces = MediaType.TEXT_PLAIN_VALUE)
+        String ping() {
+            return "ok";
+        }
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @Import({
+            SecurityConfig.class,
+            JwtAuthenticationFilter.class,
+            JwtTokenProvider.class,
+            JwtAuthenticationEntryPoint.class,
+            JwtAccessDeniedHandler.class,
+            SecurityErrorResponseWriter.class
+    })
+    static class TestConfig {
+
+        @Bean
+        TestApiController testApiController() {
+            return new TestApiController();
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+    }
+}


### PR DESCRIPTION
## 연관 이슈

Closes #29

## 왜 필요한가

- 보호 API에서 `userId`를 요청 body로 받지 않고 JWT 인증 컨텍스트에서 식별하기 위한 기반입니다.
- 이후 프로필, 진단, 로드맵 API가 같은 인증 방식과 에러 응답을 재사용할 수 있습니다.

## 변경 요약

- JWT 설정 properties, token provider, 인증 principal 추가
- Bearer token 필터와 인증 실패/권한 실패 JSON 응답 추가
- `/api/**` 보호와 공개 경로 기준 정리
- JWT 생성/파싱, 보호 API 인증 테스트 추가

## 테스트

```text
backend 디렉터리에서 .\gradlew.bat test
```