### PR TITLE
chore(ci): PR 단계에 최소 통합 검증 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -102,6 +102,14 @@ jobs:
       - name: Run full backend verification
         run: ./gradlew --no-daemon fullVerification
 
+      - name: Upload integration test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-report-full
+          path: backend/build/reports/tests/integrationTest
+          if-no-files-found: warn
+
       - name: Upload Jacoco HTML report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -48,8 +48,16 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Run fast backend tests
-        run: ./gradlew --no-daemon test
+      - name: Run PR backend verification
+        run: ./gradlew --no-daemon prVerification
+
+      - name: Upload PR integration test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-integration-test-report
+          path: backend/build/reports/tests/prIntegrationTest
+          if-no-files-found: warn
 
       - name: Upload Jacoco HTML report
         if: failure()

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -97,6 +97,17 @@ tasks.test {
 
 val testSourceSet = the<JavaPluginExtension>().sourceSets.getByName("test")
 
+val prIntegrationTest = tasks.register<Test>("prIntegrationTest") {
+  description = "Runs integration tests that must pass before merging a PR."
+  group = "verification"
+  testClassesDirs = testSourceSet.output.classesDirs
+  classpath = testSourceSet.runtimeClasspath
+  useJUnitPlatform {
+    includeTags("pr-gate")
+  }
+  shouldRunAfter(tasks.test)
+}
+
 val integrationTest = tasks.register<Test>("integrationTest") {
   description = "Runs integration tests that require Spring Boot and Testcontainers."
   group = "verification"
@@ -106,6 +117,12 @@ val integrationTest = tasks.register<Test>("integrationTest") {
     includeTags("integration")
   }
   shouldRunAfter(tasks.test)
+}
+
+tasks.register("prVerification") {
+  description = "Runs fast tests and PR-gate integration tests."
+  group = "verification"
+  dependsOn(tasks.test, prIntegrationTest)
 }
 
 tasks.register("fullVerification") {

--- a/backend/src/main/java/com/back/coach/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/back/coach/global/config/JacksonConfig.java
@@ -1,0 +1,19 @@
+package com.back.coach.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper objectMapper() {
+        return JsonMapper.builder()
+                .findAndAddModules()
+                .build();
+    }
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -10,5 +10,5 @@ spring:
 ai:
   gateway:
     api-key: test-key
-    base-url: http://localhost:${wiremock.server.port}
+    base-url: http://localhost:0
     model: test-model

--- a/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
@@ -2,6 +2,7 @@ package com.back.coach;
 
 import com.back.coach.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -9,6 +10,7 @@ import org.springframework.context.ApplicationContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
+@Tag("pr-gate")
 class ApplicationIntegrationTest {
 
     @Autowired

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -7,14 +7,16 @@ spring:
 
 # 컨텍스트 로드용 더미 값. 실제 호출은 stub 또는 mock 으로 대체.
 ai:
-  glm:
+  gateway:
     api-key: test-dummy
     base-url: http://localhost:0
-    model: glm-4-flash
+    model: test-model
 
 security:
   jwt:
     secret: test-jwt-secret-key-for-tests-only-do-not-use-in-production-0123456789
+    access-ttl-seconds: 900
+    refresh-ttl-seconds: 86400
 
 logging:
   level:


### PR DESCRIPTION
## 연관 이슈

Closes #33

## 왜 필요한가

- PR에서는 빠른 테스트만 실행되어 Spring context wiring 문제가 merge 후 `dev`에서 처음 발견될 수 있었습니다.
- `SecurityErrorResponseWriter`가 필요로 하는 `ObjectMapper` Bean 누락으로 통합 테스트 컨텍스트가 실패했습니다.
- 모든 full verification을 PR에 넣지는 않고, `dev`를 깨뜨릴 수 있는 최소 통합 검증만 PR 단계로 당깁니다.

## 변경 요약

- `pr-gate` 태그와 `prIntegrationTest`, `prVerification` Gradle 태스크를 추가했습니다.
- `ApplicationIntegrationTest`를 PR 게이트 통합 테스트로 지정했습니다.
- 테스트 프로필 설정을 `ai.gateway.*`, `security.jwt.*` 기준으로 정리했습니다.
- 공용 `ObjectMapper` Bean을 등록해 보안 예외 응답 writer의 의존성 누락을 해결했습니다.
- PR/full verification 실패 시 통합 테스트 리포트를 artifact로 업로드하도록 변경했습니다.

## 테스트

```text
.\gradlew.bat test
.\gradlew.bat prIntegrationTest
.\gradlew.bat prVerification --dry-run
.\gradlew.bat fullVerification --dry-run
git diff --check
```

- 로컬 `test` 통과
- 로컬 `prVerification --dry-run`, `fullVerification --dry-run` 통과
- 로컬 `prIntegrationTest`는 Docker 미실행으로 실패
- GitHub Actions `backend-ci` 통과: https://github.com/Programmers-Intern-Program/INT6-Roadmap-Team06/actions/runs/24976585720