### PR TITLE
chore(ai): AI Gateway HTTP 계약과 환경변수 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,6 @@ GITHUB_CLIENT_ID=your-github-oauth-client-id
 GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
 
 # AI provider / gateway
-GLM_API_KEY=your-ai-api-key
-GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-GLM_MODEL=glm-4-flash
+AI_GATEWAY_API_KEY=your-ai-gateway-api-key
+AI_GATEWAY_BASE_URL=http://localhost:0
+AI_GATEWAY_MODEL=default

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayConfig.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayConfig.java
@@ -1,9 +1,18 @@
 package com.back.coach.external.llm;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 @EnableConfigurationProperties(AiGatewayProperties.class)
 public class AiGatewayConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
 }

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -4,14 +4,24 @@ import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
 
 /**
  * Team AI Gateway client boundary.
  *
- * <p>Domain services depend on {@link LlmClient} only. The actual Gateway HTTP
- * contract is intentionally not implemented until the team endpoint, request
- * body, and response body are fixed.
+ * <p>Minimum HTTP contract:
+ * <ul>
+ *   <li>POST /v1/completions</li>
+ *   <li>request: { "model": "...", "prompt": "..." }</li>
+ *   <li>response: { "text": "..." }</li>
+ * </ul>
  */
 @Component
 public class AiGatewayLlmClient implements LlmClient {
@@ -19,9 +29,19 @@ public class AiGatewayLlmClient implements LlmClient {
     private static final Logger log = LoggerFactory.getLogger(AiGatewayLlmClient.class);
 
     private final AiGatewayProperties properties;
+    private final RestClient restClient;
 
-    public AiGatewayLlmClient(AiGatewayProperties properties) {
+    @Autowired
+    public AiGatewayLlmClient(AiGatewayProperties properties, RestClient.Builder restClientBuilder) {
         this.properties = properties;
+        this.restClient = restClientBuilder
+                .requestFactory(new SimpleClientHttpRequestFactory())
+                .baseUrl(properties.baseUrl())
+                .build();
+    }
+
+    AiGatewayLlmClient(AiGatewayProperties properties) {
+        this(properties, RestClient.builder());
     }
 
     @Override
@@ -30,20 +50,51 @@ public class AiGatewayLlmClient implements LlmClient {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "prompt is empty");
         }
         try {
-            // TODO(integration): Wire this to the team AI Gateway once its HTTP contract is fixed.
-            throw new UnsupportedOperationException("AI Gateway call not wired yet");
-        } catch (UnsupportedOperationException e) {
-            log.warn("AI Gateway call not yet implemented (model={}, promptLen={})", properties.model(), prompt.length());
-            throw new ServiceException(ErrorCode.ANALYSIS_FAILED, "AI Gateway 호출이 아직 구현되지 않았습니다.");
+            CompletionResponse response = restClient.post()
+                    .uri("/v1/completions")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .headers(headers -> setAuthorization(headers, properties.apiKey()))
+                    .body(new CompletionRequest(properties.model(), prompt))
+                    .retrieve()
+                    .onStatus(status -> status.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.LLM_RATE_LIMITED);
+                            })
+                    .onStatus(status -> status.value() == HttpStatus.GATEWAY_TIMEOUT.value(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.LLM_TIMEOUT);
+                            })
+                    .onStatus(status -> status.isError(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.ANALYSIS_FAILED);
+                            })
+                    .body(CompletionResponse.class);
+
+            if (response == null || response.text() == null || response.text().isBlank()) {
+                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            }
+            return response.text();
+        } catch (ServiceException e) {
+            throw e;
         } catch (RuntimeException e) {
             ErrorCode mapped = classify(e);
-            log.warn("AI Gateway call failed (model={}, code={}, type={})",
-                    properties.model(), mapped, e.getClass().getSimpleName());
+            log.warn("AI Gateway call failed (model={}, code={}, type={}, message={})",
+                    properties.model(), mapped, e.getClass().getSimpleName(), e.getMessage());
             throw new ServiceException(mapped, mapped.getDefaultMessage());
         }
     }
 
+    private void setAuthorization(HttpHeaders headers, String apiKey) {
+        if (apiKey != null && !apiKey.isBlank()) {
+            headers.setBearerAuth(apiKey);
+        }
+    }
+
     private ErrorCode classify(RuntimeException e) {
+        if (e instanceof ResourceAccessException) {
+            return ErrorCode.LLM_TIMEOUT;
+        }
         String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
         if (msg.contains("timeout") || msg.contains("timed out")) {
             return ErrorCode.LLM_TIMEOUT;
@@ -55,5 +106,11 @@ public class AiGatewayLlmClient implements LlmClient {
             return ErrorCode.LLM_INVALID_RESPONSE;
         }
         return ErrorCode.ANALYSIS_FAILED;
+    }
+
+    private record CompletionRequest(String model, String prompt) {
+    }
+
+    private record CompletionResponse(String text) {
     }
 }

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -2,16 +2,38 @@ package com.back.coach.external.llm;
 
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AiGatewayLlmClientTest {
 
-    private final AiGatewayLlmClient client = new AiGatewayLlmClient(
-            new AiGatewayProperties("dummy", "http://localhost:0", "test-model")
-    );
+    private WireMockServer wireMock;
+    private AiGatewayLlmClient client;
+
+    @BeforeEach
+    void setUp() {
+        wireMock = new WireMockServer(options().dynamicPort());
+        wireMock.start();
+        client = new AiGatewayLlmClient(
+                new AiGatewayProperties("dummy-key", "http://127.0.0.1:" + wireMock.port(), "test-model")
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMock.stop();
+    }
 
     @Test
     void blankPrompt_throwsInvalidInput() {
@@ -27,14 +49,58 @@ class AiGatewayLlmClientTest {
     }
 
     @Test
-    void unwiredGatewayCall_throwsAnalysisFailed() {
+    void complete_callsGatewayAndReturnsText() {
+        wireMock.stubFor(post("/v1/completions")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"text\":\"ok\"}")));
+
+        String result = client.complete("hello");
+
+        assertThat(result).isEqualTo("ok");
+        wireMock.verify(postRequestedFor(urlEqualTo("/v1/completions"))
+                .withHeader("Authorization", com.github.tomakehurst.wiremock.client.WireMock.equalTo("Bearer dummy-key"))
+                .withRequestBody(equalToJson("""
+                        {
+                          "model": "test-model",
+                          "prompt": "hello"
+                        }
+                        """)));
+    }
+
+    @Test
+    void rateLimitedResponse_throwsRateLimitedError() {
+        wireMock.stubFor(post("/v1/completions")
+                .willReturn(aResponse().withStatus(429)));
+
         assertThatThrownBy(() -> client.complete("hello"))
                 .isInstanceOf(ServiceException.class)
-                .satisfies(e -> {
-                    ServiceException se = (ServiceException) e;
-                    assertThat(se.getErrorCode()).isEqualTo(ErrorCode.ANALYSIS_FAILED);
-                    assertThat(se.getMessage()).isEqualTo("AI Gateway 호출이 아직 구현되지 않았습니다.");
-                });
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.LLM_RATE_LIMITED);
+    }
+
+    @Test
+    void gatewayTimeoutResponse_throwsTimeoutError() {
+        wireMock.stubFor(post("/v1/completions")
+                .willReturn(aResponse().withStatus(504)));
+
+        assertThatThrownBy(() -> client.complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.LLM_TIMEOUT);
+    }
+
+    @Test
+    void blankTextResponse_throwsInvalidResponseError() {
+        wireMock.stubFor(post("/v1/completions")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"text\":\"\"}")));
+
+        assertThatThrownBy(() -> client.complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
     }
 
     @Test


### PR DESCRIPTION
## 연관 이슈

Closes #35

## 왜 필요한가

- 실제 설정은 `AI_GATEWAY_*`를 보는데 `.env.example`만 `GLM_*`라 로컬 실행자가 잘못된 키를 넣을 수 있었습니다.
- AI 호출 경계를 최소 HTTP 계약과 테스트로 닫아야 후속 도메인 서비스가 `LlmClient`만 믿고 사용할 수 있습니다.

## 변경 요약

- `.env.example`을 `AI_GATEWAY_*` 기준으로 정렬
- `POST /v1/completions` 최소 계약 추가: `{ model, prompt } -> { text }`
- `AiGatewayLlmClient`를 `RestClient` 기반 HTTP 호출로 전환
- 429, 504, 빈 응답을 공통 LLM 에러로 매핑
- WireMock 기반 성공/실패 테스트 추가

## 테스트

```text
backend 디렉터리에서 .\gradlew.bat test
```