### PR TITLE
test(context): Docker 없는 wiring 검증 추가

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("org.testcontainers:postgresql:1.20.6")
   testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+  testRuntimeOnly("com.h2database:h2")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
   testImplementation("org.wiremock:wiremock-standalone:3.12.1")
 }

--- a/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/ApplicationIntegrationTest.java
@@ -2,7 +2,6 @@ package com.back.coach;
 
 import com.back.coach.support.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -10,7 +9,6 @@ import org.springframework.context.ApplicationContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
-@Tag("pr-gate")
 class ApplicationIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/back/coach/ContextWiringTest.java
+++ b/backend/src/test/java/com/back/coach/ContextWiringTest.java
@@ -1,0 +1,26 @@
+package com.back.coach;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("wiring-test")
+@Tag("pr-gate")
+class ContextWiringTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    @DisplayName("Docker 없이 애플리케이션 컨텍스트 wiring이 완료된다")
+    void contextLoadsWithoutDocker() {
+        assertThat(applicationContext).isNotNull();
+    }
+}

--- a/backend/src/test/resources/application-wiring-test.yml
+++ b/backend/src/test/resources/application-wiring-test.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:coach_wiring_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: none
+  flyway:
+    enabled: false
+  cache:
+    type: simple
+
+ai:
+  gateway:
+    api-key: wiring-test-dummy
+    base-url: http://localhost:0
+    model: wiring-test-model
+
+security:
+  jwt:
+    secret: wiring-test-jwt-secret-key-for-tests-only-do-not-use-in-production-0123456789
+    access-ttl-seconds: 900
+    refresh-ttl-seconds: 86400
+
+management:
+  health:
+    redis:
+      enabled: false


### PR DESCRIPTION
Closes #37

## 왜 필요한가

단위 테스트는 Spring bean 등록 누락을 놓칠 수 있고, PR 게이트가 Testcontainers에 묶이면 Docker 없는 환경에서 불필요하게 실패할 수 있습니다.

## 변경 요약

- Docker 없이 실행되는 context wiring 테스트 추가
- wiring-test 프로필과 테스트 전용 H2 런타임 의존성 추가
- Testcontainers 기반 ApplicationIntegrationTest를 PR 게이트에서 분리

## 테스트

- PASS: backend에서 .\\gradlew.bat test
- PASS: backend에서 .\\gradlew.bat prIntegrationTest
- PASS: backend에서 .\\gradlew.bat prVerification
- FAIL: backend에서 .\\gradlew.bat integrationTest
  - 사유: 로컬 Docker/Testcontainers 실행 환경 없음