### PR TITLE
chore(security): Swagger JWT와 CORS 개발 설정

### DIFF
--- a/backend/src/main/java/com/back/coach/global/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/back/coach/global/config/OpenApiConfig.java
@@ -1,0 +1,26 @@
+package com.back.coach.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String BEARER_AUTH_SCHEME = "bearerAuth";
+
+    @Bean
+    OpenAPI openAPI() {
+        SecurityScheme bearerScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes(BEARER_AUTH_SCHEME, bearerScheme))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH_SCHEME));
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
@@ -3,15 +3,22 @@ package com.back.coach.global.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, SecurityCorsProperties.class})
 public class SecurityConfig {
 
     @Bean
@@ -19,9 +26,11 @@ public class SecurityConfig {
             HttpSecurity http,
             JwtAuthenticationFilter jwtAuthenticationFilter,
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
-            JwtAccessDeniedHandler jwtAccessDeniedHandler
+            JwtAccessDeniedHandler jwtAccessDeniedHandler,
+            CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
         http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource))
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .formLogin(form -> form.disable())
@@ -47,5 +56,31 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource(SecurityCorsProperties properties) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(properties.allowedOrigins());
+        configuration.setAllowedMethods(List.of(
+                HttpMethod.GET.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.PATCH.name(),
+                HttpMethod.DELETE.name(),
+                HttpMethod.OPTIONS.name()
+        ));
+        configuration.setAllowedHeaders(List.of(
+                HttpHeaders.AUTHORIZATION,
+                HttpHeaders.CONTENT_TYPE,
+                "X-Requested-With",
+                "X-Trace-Id"
+        ));
+        configuration.setExposedHeaders(List.of("X-Trace-Id"));
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/backend/src/main/java/com/back/coach/global/security/SecurityCorsProperties.java
+++ b/backend/src/main/java/com/back/coach/global/security/SecurityCorsProperties.java
@@ -1,0 +1,28 @@
+package com.back.coach.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "security.cors")
+public record SecurityCorsProperties(
+        List<String> allowedOrigins
+) {
+
+    private static final List<String> DEFAULT_ALLOWED_ORIGINS = List.of("http://localhost:3000");
+
+    public SecurityCorsProperties {
+        allowedOrigins = normalize(allowedOrigins);
+    }
+
+    private static List<String> normalize(List<String> origins) {
+        if (origins == null || origins.isEmpty()) {
+            return DEFAULT_ALLOWED_ORIGINS;
+        }
+        List<String> normalized = origins.stream()
+                .filter(origin -> origin != null && !origin.isBlank())
+                .map(String::trim)
+                .toList();
+        return normalized.isEmpty() ? DEFAULT_ALLOWED_ORIGINS : normalized;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -42,6 +42,8 @@ management:
       show-details: always
 
 security:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
   jwt:
     secret: ${JWT_SECRET:dev-jwt-secret-key-change-in-production-f8e7d6c5b4a39281706958473625140a}
     access-ttl-seconds: 900

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiConfigTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiConfigTest.java
@@ -1,0 +1,26 @@
+package com.back.coach.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenApiConfigTest {
+
+    @Test
+    void openApi_hasBearerJwtSecurityScheme() {
+        OpenAPI openAPI = new OpenApiConfig().openAPI();
+
+        SecurityScheme scheme = openAPI.getComponents()
+                .getSecuritySchemes()
+                .get(OpenApiConfig.BEARER_AUTH_SCHEME);
+
+        assertThat(scheme.getType()).isEqualTo(SecurityScheme.Type.HTTP);
+        assertThat(scheme.getScheme()).isEqualTo("bearer");
+        assertThat(scheme.getBearerFormat()).isEqualTo("JWT");
+        assertThat(openAPI.getSecurity())
+                .anySatisfy(requirement ->
+                        assertThat(requirement).containsKey(OpenApiConfig.BEARER_AUTH_SCHEME));
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/SecurityConfigTest.java
@@ -21,7 +21,9 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,7 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "security.jwt.secret=test-secret-key-for-security-config",
         "security.jwt.access-ttl-seconds=900",
-        "security.jwt.refresh-ttl-seconds=86400"
+        "security.jwt.refresh-ttl-seconds=86400",
+        "security.cors.allowed-origins=http://localhost:3000"
 })
 class SecurityConfigTest {
 
@@ -81,6 +84,16 @@ class SecurityConfigTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
                 .andExpect(content().string("ok"));
+    }
+
+    @Test
+    void corsPreflight_fromLocalFrontend_isPermitted() throws Exception {
+        mockMvc.perform(options("/api/v1/profiles/me")
+                        .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET,POST,PUT,PATCH,DELETE,OPTIONS"));
     }
 
     @RestController


### PR DESCRIPTION
Closes #39

## 왜 필요한가

보호 API를 Swagger와 프론트 로컬 환경에서 바로 테스트하려면 JWT Authorize 버튼과 CORS 기준이 필요합니다.

## 변경 요약

- Swagger/OpenAPI Bearer JWT security scheme 추가
- security.cors.allowed-origins 설정과 local 기본 origin 추가
- SecurityConfig에 CORS 연결 및 preflight 테스트 추가

## 테스트

- PASS: backend에서 .\\gradlew.bat test
- PASS: backend에서 .\\gradlew.bat prIntegrationTest
- PASS: backend에서 .\\gradlew.bat prVerification
- FAIL: backend에서 .\\gradlew.bat integrationTest
  - 사유: 로컬 Docker/Testcontainers 실행 환경 없음