### PR TITLE
feat(domain): B 담당 도메인 저장 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/entity/CapabilityDiagnosis.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/entity/CapabilityDiagnosis.java
@@ -1,0 +1,57 @@
+package com.back.coach.domain.diagnosis.entity;
+
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "capability_diagnoses")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CapabilityDiagnosis extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "profile_id", nullable = false)
+    private Long profileId;
+
+    @Column(name = "github_analysis_id", nullable = false)
+    private Long githubAnalysisId;
+
+    @Column(name = "job_role_id", nullable = false)
+    private Long jobRoleId;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_level", nullable = false, length = 30)
+    private CurrentLevel currentLevel;
+
+    @Column(name = "summary", nullable = false, columnDefinition = "text")
+    private String summary;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "diagnosis_payload", nullable = false, columnDefinition = "jsonb")
+    private String diagnosisPayload;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.diagnosis.repository;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CapabilityDiagnosisRepository extends JpaRepository<CapabilityDiagnosis, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubAnalysis.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubAnalysis.java
@@ -1,0 +1,44 @@
+package com.back.coach.domain.github.entity;
+
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "github_analyses")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GithubAnalysis extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "github_connection_id", nullable = false)
+    private Long githubConnectionId;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "summary", nullable = false, columnDefinition = "text")
+    private String summary;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "analysis_payload", nullable = false, columnDefinition = "jsonb")
+    private String analysisPayload;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.github.repository;
+
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GithubAnalysisRepository extends JpaRepository<GithubAnalysis, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/LearningRoadmap.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/LearningRoadmap.java
@@ -1,0 +1,47 @@
+package com.back.coach.domain.roadmap.entity;
+
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "learning_roadmaps")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LearningRoadmap extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "diagnosis_id", nullable = false)
+    private Long diagnosisId;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "total_weeks", nullable = false)
+    private Integer totalWeeks;
+
+    @Column(name = "summary", nullable = false, columnDefinition = "text")
+    private String summary;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "roadmap_payload", nullable = false, columnDefinition = "jsonb")
+    private String roadmapPayload;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/ProgressLog.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/ProgressLog.java
@@ -1,0 +1,45 @@
+package com.back.coach.domain.roadmap.entity;
+
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "progress_logs")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgressLog extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "roadmap_week_id", nullable = false)
+    private Long roadmapWeekId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ProgressStatus status;
+
+    @Column(name = "note", columnDefinition = "text")
+    private String note;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/RoadmapWeek.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/RoadmapWeek.java
@@ -1,0 +1,43 @@
+package com.back.coach.domain.roadmap.entity;
+
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "roadmap_weeks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoadmapWeek extends BaseEntity {
+
+    @Column(name = "roadmap_id", nullable = false)
+    private Long roadmapId;
+
+    @Column(name = "week_number", nullable = false)
+    private Integer weekNumber;
+
+    @Column(name = "topic", nullable = false)
+    private String topic;
+
+    @Column(name = "reason_text", nullable = false, columnDefinition = "text")
+    private String reasonText;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "tasks_json", nullable = false, columnDefinition = "jsonb")
+    private String tasksJson;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "materials_json", nullable = false, columnDefinition = "jsonb")
+    private String materialsJson;
+
+    @Column(name = "estimated_hours", nullable = false, precision = 4, scale = 1)
+    private BigDecimal estimatedHours;
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.roadmap.repository;
+
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningRoadmapRepository extends JpaRepository<LearningRoadmap, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.roadmap.repository;
+
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProgressLogRepository extends JpaRepository<ProgressLog, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/RoadmapWeekRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/RoadmapWeekRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.roadmap.repository;
+
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoadmapWeekRepository extends JpaRepository<RoadmapWeek, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/entity/UserProfile.java
+++ b/backend/src/main/java/com/back/coach/domain/user/entity/UserProfile.java
@@ -1,0 +1,49 @@
+package com.back.coach.domain.user.entity;
+
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.jpa.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "user_profiles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfile extends BaseTimeEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "job_role_id", nullable = false)
+    private Long jobRoleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_level", nullable = false, length = 30)
+    private CurrentLevel currentLevel;
+
+    @Column(name = "weekly_study_hours")
+    private Integer weeklyStudyHours;
+
+    @Column(name = "target_date")
+    private LocalDate targetDate;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "interest_areas_json", nullable = false, columnDefinition = "jsonb")
+    private String interestAreasJson;
+
+    @Column(name = "resume_asset_id")
+    private Long resumeAssetId;
+
+    @Column(name = "portfolio_asset_id")
+    private Long portfolioAssetId;
+}

--- a/backend/src/main/java/com/back/coach/domain/user/entity/UserSkill.java
+++ b/backend/src/main/java/com/back/coach/domain/user/entity/UserSkill.java
@@ -1,0 +1,44 @@
+package com.back.coach.domain.user.entity;
+
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "user_skills")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSkill extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "skill_name", nullable = false, length = 100)
+    private String skillName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "proficiency_level", length = 30)
+    private ProficiencyLevel proficiencyLevel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 30)
+    private SkillSourceType sourceType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.user.repository;
+
+import com.back.coach.domain.user.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.user.repository;
+
+import com.back.coach.domain.user.entity.UserSkill;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSkillRepository extends JpaRepository<UserSkill, Long> {
+}

--- a/backend/src/test/java/com/back/coach/domain/DomainStorageMappingIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/DomainStorageMappingIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.back.coach.domain;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.support.IntegrationTest;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class DomainStorageMappingIntegrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("B 담당 저장소 Repository bean이 등록된다")
+    void repositoriesAreRegistered() {
+        assertThat(applicationContext.getBean(UserProfileRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(UserSkillRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(GithubAnalysisRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(CapabilityDiagnosisRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(LearningRoadmapRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(RoadmapWeekRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(ProgressLogRepository.class)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("B 담당 저장 Entity가 JPA metamodel에 등록된다")
+    void entitiesAreMapped() {
+        assertMapped(UserProfile.class);
+        assertMapped(UserSkill.class);
+        assertMapped(GithubAnalysis.class);
+        assertMapped(CapabilityDiagnosis.class);
+        assertMapped(LearningRoadmap.class);
+        assertMapped(RoadmapWeek.class);
+        assertMapped(ProgressLog.class);
+    }
+
+    private void assertMapped(Class<?> entityType) {
+        assertThat(entityManager.getMetamodel().entity(entityType)).isNotNull();
+    }
+}


### PR DESCRIPTION
Closes #41

## 왜 필요한가

DB 스키마는 있지만 Entity/Repository가 없으면 이후 API와 서비스가 저장 계약을 기준으로 구현될 수 없습니다.

## 변경 요약

- 프로필/기술 저장 Entity와 Repository 추가
- GitHub 분석/역량 진단 결과 이력 Entity와 Repository 추가
- 로드맵/주차/진도 로그 Entity와 Repository 추가
- 저장 매핑 통합 테스트 추가

## 테스트

- PASS: backend에서 .\\gradlew.bat test
- PASS: backend에서 .\\gradlew.bat prIntegrationTest
- PASS: backend에서 .\\gradlew.bat prVerification
- FAIL: backend에서 .\\gradlew.bat integrationTest
  - 사유: 로컬 Docker/Testcontainers 실행 환경 없음