### PR TITLE
feat(domain): v1 핵심 도메인 저장 기반 완성

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubConnection.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubConnection.java
@@ -1,0 +1,45 @@
+package com.back.coach.domain.github.entity;
+
+import com.back.coach.global.code.GithubAccessType;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "github_connections")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GithubConnection extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "github_user_id", nullable = false, length = 100)
+    private String githubUserId;
+
+    @Column(name = "github_login", nullable = false, length = 100)
+    private String githubLogin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "access_type", nullable = false, length = 30)
+    private GithubAccessType accessType;
+
+    @CreatedDate
+    @Column(name = "connected_at", nullable = false, updatable = false)
+    private Instant connectedAt;
+
+    @Column(name = "disconnected_at")
+    private Instant disconnectedAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubProject.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubProject.java
@@ -1,0 +1,59 @@
+package com.back.coach.domain.github.entity;
+
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "github_projects")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GithubProject extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "github_connection_id", nullable = false)
+    private Long githubConnectionId;
+
+    @Column(name = "repo_node_id", length = 100)
+    private String repoNodeId;
+
+    @Column(name = "repo_full_name", nullable = false, length = 200)
+    private String repoFullName;
+
+    @Column(name = "repo_url", nullable = false)
+    private String repoUrl;
+
+    @Column(name = "primary_language", length = 50)
+    private String primaryLanguage;
+
+    @Column(name = "default_branch", length = 100)
+    private String defaultBranch;
+
+    @Column(name = "is_selected", nullable = false)
+    private Boolean selected;
+
+    @Column(name = "is_core_repo", nullable = false)
+    private Boolean coreRepo;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata_payload", nullable = false, columnDefinition = "jsonb")
+    private String metadataPayload;
+
+    @CreatedDate
+    @Column(name = "synced_at", nullable = false, updatable = false)
+    private Instant syncedAt;
+}

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.github.repository;
+
+import com.back.coach.domain.github.entity.GithubConnection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GithubConnectionRepository extends JpaRepository<GithubConnection, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubProjectRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubProjectRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.github.repository;
+
+import com.back.coach.domain.github.entity.GithubProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GithubProjectRepository extends JpaRepository<GithubProject, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/entity/JobRole.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/entity/JobRole.java
@@ -1,0 +1,28 @@
+package com.back.coach.domain.jobrole.entity;
+
+import com.back.coach.global.jpa.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "job_roles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobRole extends BaseTimeEntity {
+
+    @Column(name = "role_code", nullable = false, length = 50)
+    private String roleCode;
+
+    @Column(name = "role_name", nullable = false, length = 100)
+    private String roleName;
+
+    @Column(name = "description", columnDefinition = "text")
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean active;
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/entity/SkillRequirement.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/entity/SkillRequirement.java
@@ -1,0 +1,28 @@
+package com.back.coach.domain.jobrole.entity;
+
+import com.back.coach.global.jpa.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "skill_requirements")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SkillRequirement extends BaseTimeEntity {
+
+    @Column(name = "job_role_id", nullable = false)
+    private Long jobRoleId;
+
+    @Column(name = "skill_name", nullable = false, length = 100)
+    private String skillName;
+
+    @Column(name = "category", nullable = false, length = 50)
+    private String category;
+
+    @Column(name = "importance", nullable = false)
+    private Integer importance;
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.jobrole.repository;
+
+import com.back.coach.domain.jobrole.entity.JobRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobRoleRepository extends JpaRepository<JobRole, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/repository/SkillRequirementRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/repository/SkillRequirementRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.jobrole.repository;
+
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SkillRequirementRepository extends JpaRepository<SkillRequirement, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/entity/User.java
+++ b/backend/src/main/java/com/back/coach/domain/user/entity/User.java
@@ -1,0 +1,35 @@
+package com.back.coach.domain.user.entity;
+
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.jpa.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "password_hash")
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider", nullable = false, length = 30)
+    private AuthProvider authProvider;
+
+    @Column(name = "provider_user_id")
+    private String providerUserId;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean active;
+}

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.user.repository;
+
+import com.back.coach.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/backend/src/test/java/com/back/coach/domain/DomainStorageMappingIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/DomainStorageMappingIntegrationTest.java
@@ -3,15 +3,25 @@ package com.back.coach.domain;
 import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
 import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
 import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.entity.GithubConnection;
+import com.back.coach.domain.github.entity.GithubProject;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.github.repository.GithubConnectionRepository;
+import com.back.coach.domain.github.repository.GithubProjectRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.jobrole.repository.SkillRequirementRepository;
 import com.back.coach.domain.roadmap.entity.LearningRoadmap;
 import com.back.coach.domain.roadmap.entity.ProgressLog;
 import com.back.coach.domain.roadmap.entity.RoadmapWeek;
 import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
 import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
 import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.User;
 import com.back.coach.domain.user.entity.UserProfile;
 import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserRepository;
 import com.back.coach.domain.user.repository.UserProfileRepository;
 import com.back.coach.domain.user.repository.UserSkillRepository;
 import com.back.coach.support.IntegrationTest;
@@ -33,10 +43,15 @@ class DomainStorageMappingIntegrationTest {
     private EntityManager entityManager;
 
     @Test
-    @DisplayName("B 담당 저장소 Repository bean이 등록된다")
+    @DisplayName("v1 핵심 저장소 Repository bean이 등록된다")
     void repositoriesAreRegistered() {
+        assertThat(applicationContext.getBean(UserRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(JobRoleRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(SkillRequirementRepository.class)).isNotNull();
         assertThat(applicationContext.getBean(UserProfileRepository.class)).isNotNull();
         assertThat(applicationContext.getBean(UserSkillRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(GithubConnectionRepository.class)).isNotNull();
+        assertThat(applicationContext.getBean(GithubProjectRepository.class)).isNotNull();
         assertThat(applicationContext.getBean(GithubAnalysisRepository.class)).isNotNull();
         assertThat(applicationContext.getBean(CapabilityDiagnosisRepository.class)).isNotNull();
         assertThat(applicationContext.getBean(LearningRoadmapRepository.class)).isNotNull();
@@ -45,10 +60,15 @@ class DomainStorageMappingIntegrationTest {
     }
 
     @Test
-    @DisplayName("B 담당 저장 Entity가 JPA metamodel에 등록된다")
+    @DisplayName("v1 핵심 저장 Entity가 JPA metamodel에 등록된다")
     void entitiesAreMapped() {
+        assertMapped(User.class);
+        assertMapped(JobRole.class);
+        assertMapped(SkillRequirement.class);
         assertMapped(UserProfile.class);
         assertMapped(UserSkill.class);
+        assertMapped(GithubConnection.class);
+        assertMapped(GithubProject.class);
         assertMapped(GithubAnalysis.class);
         assertMapped(CapabilityDiagnosis.class);
         assertMapped(LearningRoadmap.class);


### PR DESCRIPTION
Closes #45

## 왜 필요한가

로그인, GitHub 연동, 프로필 기능이 같은 DB 계약을 기준으로 구현되려면 남은 핵심 Entity/Repository가 먼저 필요합니다.

## 변경 요약

- User Entity/Repository 추가
- JobRole, SkillRequirement Entity/Repository 추가
- GithubConnection, GithubProject Entity/Repository 추가
- v1 핵심 저장 매핑 통합 테스트 범위 확장

## 테스트

- PASS: backend에서 .\\gradlew.bat test
- PASS: backend에서 .\\gradlew.bat prIntegrationTest
- PASS: backend에서 .\\gradlew.bat prVerification
- FAIL: backend에서 .\\gradlew.bat integrationTest
  - 사유: 로컬 Docker/Testcontainers 실행 환경 없음