### PR TITLE
chore(seed): 직무 기술 기준 데이터 추가

### DIFF
--- a/backend/src/main/resources/db/migration/V2__seed_job_role_skill_requirements.sql
+++ b/backend/src/main/resources/db/migration/V2__seed_job_role_skill_requirements.sql
@@ -1,0 +1,39 @@
+INSERT INTO job_roles (role_code, role_name, description, is_active)
+VALUES
+    (
+        'BACKEND_DEVELOPER',
+        '백엔드 개발자',
+        'Java와 Spring Boot 기반 API 서버, 데이터 저장소, 캐시, 배포 역량을 기준으로 진단하는 v1 기본 직무',
+        TRUE
+    )
+ON CONFLICT (role_code) DO UPDATE
+SET role_name = EXCLUDED.role_name,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    updated_at = now();
+
+WITH backend_role AS (
+    SELECT id
+    FROM job_roles
+    WHERE role_code = 'BACKEND_DEVELOPER'
+)
+INSERT INTO skill_requirements (job_role_id, skill_name, category, importance)
+SELECT backend_role.id, seed.skill_name, seed.category, seed.importance
+FROM backend_role
+CROSS JOIN (
+    VALUES
+        ('Java', 'LANGUAGE', 5),
+        ('Spring Boot', 'FRAMEWORK', 5),
+        ('REST API', 'API', 5),
+        ('JPA', 'DATA_ACCESS', 4),
+        ('SQL', 'DATABASE', 4),
+        ('PostgreSQL', 'DATABASE', 4),
+        ('Redis', 'CACHE', 3),
+        ('JUnit', 'TESTING', 3),
+        ('Docker', 'INFRA', 3),
+        ('Git/GitHub', 'COLLABORATION', 3)
+) AS seed(skill_name, category, importance)
+ON CONFLICT (job_role_id, skill_name) DO UPDATE
+SET category = EXCLUDED.category,
+    importance = EXCLUDED.importance,
+    updated_at = now();

--- a/backend/src/test/java/com/back/coach/global/jpa/DbContractIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/global/jpa/DbContractIntegrationTest.java
@@ -57,6 +57,37 @@ class DbContractIntegrationTest {
                 .doesNotContain("createDate", "modifyDate");
     }
 
+    @Test
+    @DisplayName("기본 백엔드 직무와 기술 요구사항 seed data가 생성된다")
+    void jobRoleSeedDataExists() {
+        Long backendRoleId = jdbcTemplate.queryForObject("""
+                SELECT id
+                FROM job_roles
+                WHERE role_code = 'BACKEND_DEVELOPER'
+                """, Long.class);
+
+        assertThat(backendRoleId).isNotNull();
+
+        Set<String> skillNames = Set.copyOf(jdbcTemplate.queryForList("""
+                SELECT skill_name
+                FROM skill_requirements
+                WHERE job_role_id = ?
+                """, String.class, backendRoleId));
+
+        assertThat(skillNames)
+                .contains("Java", "Spring Boot", "REST API", "PostgreSQL", "Redis")
+                .hasSizeGreaterThanOrEqualTo(10);
+
+        Integer springBootImportance = jdbcTemplate.queryForObject("""
+                SELECT importance
+                FROM skill_requirements
+                WHERE job_role_id = ?
+                  AND skill_name = 'Spring Boot'
+                """, Integer.class, backendRoleId);
+
+        assertThat(springBootImportance).isEqualTo(5);
+    }
+
     private boolean tableExists(String tableName) {
         Boolean exists = jdbcTemplate.queryForObject("""
                 SELECT EXISTS (


### PR DESCRIPTION
Closes #47

## 왜 필요한가

프로필 입력과 역량 진단이 자유 텍스트가 아니라 같은 직무/기술 기준표를 바라보려면 기본 JobRole, SkillRequirement 데이터가 필요합니다.

## 변경 요약

- BACKEND_DEVELOPER 직무 seed data 추가
- 백엔드 핵심 기술 요구사항 seed data 추가
- Flyway seed data 검증 통합 테스트 추가

## 테스트

- PASS: backend에서 .\\gradlew.bat test
- PASS: backend에서 .\\gradlew.bat prIntegrationTest
- PASS: backend에서 .\\gradlew.bat prVerification
- FAIL: backend에서 .\\gradlew.bat integrationTest
  - 사유: 로컬 Docker/Testcontainers 실행 환경 없음