### PR TITLE
feat(domain): 사용자 소유권과 version 최신 조회 규칙 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/common/OwnershipValidator.java
+++ b/backend/src/main/java/com/back/coach/domain/common/OwnershipValidator.java
@@ -1,0 +1,24 @@
+package com.back.coach.domain.common;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+
+import java.util.Objects;
+
+public final class OwnershipValidator {
+
+    private OwnershipValidator() {
+    }
+
+    public static void requireOwned(boolean owned) {
+        if (!owned) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    public static void requireSameUser(Long expectedUserId, Long actualUserId) {
+        if (expectedUserId == null || !Objects.equals(expectedUserId, actualUserId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/common/ResultVersionService.java
+++ b/backend/src/main/java/com/back/coach/domain/common/ResultVersionService.java
@@ -1,0 +1,37 @@
+package com.back.coach.domain.common;
+
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResultVersionService {
+
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final LearningRoadmapRepository learningRoadmapRepository;
+
+    public int nextGithubAnalysisVersion(Long userId) {
+        return nextVersion(githubAnalysisRepository.findMaxVersionByUserId(userId));
+    }
+
+    public int nextCapabilityDiagnosisVersion(Long userId) {
+        return nextVersion(capabilityDiagnosisRepository.findMaxVersionByUserId(userId));
+    }
+
+    public int nextLearningRoadmapVersion(Long userId) {
+        return nextVersion(learningRoadmapRepository.findMaxVersionByUserId(userId));
+    }
+
+    private int nextVersion(Integer currentMaxVersion) {
+        if (currentMaxVersion == null) {
+            return 1;
+        }
+        return currentMaxVersion + 1;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
@@ -2,6 +2,19 @@ package com.back.coach.domain.diagnosis.repository;
 
 import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CapabilityDiagnosisRepository extends JpaRepository<CapabilityDiagnosis, Long> {
+
+    Optional<CapabilityDiagnosis> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    Optional<CapabilityDiagnosis> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
+
+    @Query("select max(c.version) from CapabilityDiagnosis c where c.userId = :userId")
+    Integer findMaxVersionByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
@@ -2,6 +2,19 @@ package com.back.coach.domain.github.repository;
 
 import com.back.coach.domain.github.entity.GithubAnalysis;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface GithubAnalysisRepository extends JpaRepository<GithubAnalysis, Long> {
+
+    Optional<GithubAnalysis> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    Optional<GithubAnalysis> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
+
+    @Query("select max(g.version) from GithubAnalysis g where g.userId = :userId")
+    Integer findMaxVersionByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
@@ -3,5 +3,14 @@ package com.back.coach.domain.github.repository;
 import com.back.coach.domain.github.entity.GithubConnection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface GithubConnectionRepository extends JpaRepository<GithubConnection, Long> {
+
+    List<GithubConnection> findByUserIdOrderByConnectedAtDesc(Long userId);
+
+    Optional<GithubConnection> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubProjectRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubProjectRepository.java
@@ -3,5 +3,14 @@ package com.back.coach.domain.github.repository;
 import com.back.coach.domain.github.entity.GithubProject;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface GithubProjectRepository extends JpaRepository<GithubProject, Long> {
+
+    List<GithubProject> findByUserIdAndGithubConnectionId(Long userId, Long githubConnectionId);
+
+    Optional<GithubProject> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
@@ -2,6 +2,19 @@ package com.back.coach.domain.roadmap.repository;
 
 import com.back.coach.domain.roadmap.entity.LearningRoadmap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface LearningRoadmapRepository extends JpaRepository<LearningRoadmap, Long> {
+
+    Optional<LearningRoadmap> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    Optional<LearningRoadmap> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
+
+    @Query("select max(l.version) from LearningRoadmap l where l.userId = :userId")
+    Integer findMaxVersionByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
@@ -3,5 +3,14 @@ package com.back.coach.domain.roadmap.repository;
 import com.back.coach.domain.roadmap.entity.ProgressLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ProgressLogRepository extends JpaRepository<ProgressLog, Long> {
+
+    List<ProgressLog> findByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(Long userId, Long roadmapWeekId);
+
+    Optional<ProgressLog> findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(Long userId, Long roadmapWeekId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/RoadmapWeekRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/RoadmapWeekRepository.java
@@ -3,5 +3,12 @@ package com.back.coach.domain.roadmap.repository;
 import com.back.coach.domain.roadmap.entity.RoadmapWeek;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RoadmapWeekRepository extends JpaRepository<RoadmapWeek, Long> {
+
+    List<RoadmapWeek> findByRoadmapIdOrderByWeekNumberAsc(Long roadmapId);
+
+    Optional<RoadmapWeek> findByIdAndRoadmapId(Long id, Long roadmapId);
 }

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
@@ -3,5 +3,11 @@ package com.back.coach.domain.user.repository;
 import com.back.coach.domain.user.entity.UserProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+
+    Optional<UserProfile> findByUserId(Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
@@ -3,5 +3,11 @@ package com.back.coach.domain.user.repository;
 import com.back.coach.domain.user.entity.UserSkill;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserSkillRepository extends JpaRepository<UserSkill, Long> {
+
+    List<UserSkill> findByUserIdOrderBySkillNameAsc(Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/test/java/com/back/coach/domain/common/OwnershipValidatorTest.java
+++ b/backend/src/test/java/com/back/coach/domain/common/OwnershipValidatorTest.java
@@ -1,0 +1,33 @@
+package com.back.coach.domain.common;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OwnershipValidatorTest {
+
+    @Test
+    void requireOwned_whenOwned_doesNotThrow() {
+        assertThatCode(() -> OwnershipValidator.requireOwned(true))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void requireOwned_whenNotOwned_throwsForbidden() {
+        assertThatThrownBy(() -> OwnershipValidator.requireOwned(false))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void requireSameUser_whenDifferentUser_throwsForbidden() {
+        assertThatThrownBy(() -> OwnershipValidator.requireSameUser(1L, 2L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/common/ResultVersionServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/common/ResultVersionServiceTest.java
@@ -1,0 +1,56 @@
+package com.back.coach.domain.common;
+
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ResultVersionServiceTest {
+
+    @Mock
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Mock
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Mock
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @InjectMocks
+    private ResultVersionService resultVersionService;
+
+    @Test
+    void nextGithubAnalysisVersion_whenNoPreviousResult_returnsOne() {
+        given(githubAnalysisRepository.findMaxVersionByUserId(1L)).willReturn(null);
+
+        int nextVersion = resultVersionService.nextGithubAnalysisVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(1);
+    }
+
+    @Test
+    void nextCapabilityDiagnosisVersion_whenPreviousResultExists_returnsNextVersion() {
+        given(capabilityDiagnosisRepository.findMaxVersionByUserId(1L)).willReturn(3);
+
+        int nextVersion = resultVersionService.nextCapabilityDiagnosisVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(4);
+    }
+
+    @Test
+    void nextLearningRoadmapVersion_whenPreviousResultExists_returnsNextVersion() {
+        given(learningRoadmapRepository.findMaxVersionByUserId(1L)).willReturn(2);
+
+        int nextVersion = resultVersionService.nextLearningRoadmapVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
﻿Closes #49

## 왜 필요한가
사용자별 분석/진단/로드맵 결과를 덮어쓰지 않고 version 이력으로 남기고, 이후 보호 API가 현재 사용자 소유 데이터만 다루도록 공통 조회 기준이 필요합니다.

## 변경 요약
- 사용자 소유권 검증 유틸 추가
- 주요 저장소에 userId 소유권 조회, 최신 version 조회, max version 조회 메서드 추가
- 다음 결과 version 계산 서비스 추가
- 소유권/version 계산 단위 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prIntegrationTest` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
- `backend`에서 `./gradlew.bat integrationTest --rerun-tasks` 통과
- `backend`에서 `./gradlew.bat fullVerification` 통과
