### PR TITLE
feat(progress): 진도 상태 전이 검증 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/ProgressTransitionValidator.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/ProgressTransitionValidator.java
@@ -1,0 +1,32 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+
+import java.util.Map;
+import java.util.Set;
+
+public final class ProgressTransitionValidator {
+
+    private static final Map<ProgressStatus, Set<ProgressStatus>> ALLOWED_TRANSITIONS = Map.of(
+            ProgressStatus.TODO, Set.of(ProgressStatus.IN_PROGRESS, ProgressStatus.DONE, ProgressStatus.SKIPPED),
+            ProgressStatus.IN_PROGRESS, Set.of(ProgressStatus.DONE, ProgressStatus.SKIPPED),
+            ProgressStatus.DONE, Set.of(ProgressStatus.IN_PROGRESS),
+            ProgressStatus.SKIPPED, Set.of(ProgressStatus.IN_PROGRESS)
+    );
+
+    private ProgressTransitionValidator() {
+    }
+
+    public static void validate(ProgressStatus currentStatus, ProgressStatus nextStatus) {
+        if (nextStatus == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "진도 상태는 필수입니다.");
+        }
+
+        ProgressStatus normalizedCurrentStatus = currentStatus == null ? ProgressStatus.TODO : currentStatus;
+        if (!ALLOWED_TRANSITIONS.getOrDefault(normalizedCurrentStatus, Set.of()).contains(nextStatus)) {
+            throw new ServiceException(ErrorCode.CONFLICT, "허용되지 않는 진도 상태 전이입니다.");
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/ProgressTransitionValidatorTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/ProgressTransitionValidatorTest.java
@@ -1,0 +1,78 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProgressTransitionValidatorTest {
+
+    @Test
+    void validate_whenAllowedTransitions_doesNotThrow() {
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.TODO, ProgressStatus.IN_PROGRESS))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.TODO, ProgressStatus.DONE))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.TODO, ProgressStatus.SKIPPED))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.IN_PROGRESS, ProgressStatus.DONE))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.IN_PROGRESS, ProgressStatus.SKIPPED))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.DONE, ProgressStatus.IN_PROGRESS))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(ProgressStatus.SKIPPED, ProgressStatus.IN_PROGRESS))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_whenInitialStatus_allowsProgressStatusesExceptTodo() {
+        assertThatCode(() -> ProgressTransitionValidator.validate(null, ProgressStatus.IN_PROGRESS))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(null, ProgressStatus.DONE))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> ProgressTransitionValidator.validate(null, ProgressStatus.SKIPPED))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_whenInitialStatusToTodo_throwsConflict() {
+        assertThatThrownBy(() -> ProgressTransitionValidator.validate(null, ProgressStatus.TODO))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void validate_whenInvalidTransitions_throwsConflict() {
+        assertConflict(ProgressStatus.DONE, ProgressStatus.TODO);
+        assertConflict(ProgressStatus.SKIPPED, ProgressStatus.TODO);
+        assertConflict(ProgressStatus.IN_PROGRESS, ProgressStatus.TODO);
+    }
+
+    @Test
+    void validate_whenSameStatus_throwsConflict() {
+        assertConflict(ProgressStatus.TODO, ProgressStatus.TODO);
+        assertConflict(ProgressStatus.IN_PROGRESS, ProgressStatus.IN_PROGRESS);
+        assertConflict(ProgressStatus.DONE, ProgressStatus.DONE);
+        assertConflict(ProgressStatus.SKIPPED, ProgressStatus.SKIPPED);
+    }
+
+    @Test
+    void validate_whenNextStatusIsNull_throwsInvalidInput() {
+        assertThatThrownBy(() -> ProgressTransitionValidator.validate(ProgressStatus.TODO, null))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    private void assertConflict(ProgressStatus currentStatus, ProgressStatus nextStatus) {
+        assertThatThrownBy(() -> ProgressTransitionValidator.validate(currentStatus, nextStatus))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+}


### PR DESCRIPTION
﻿Closes #51

## 왜 필요한가
service/API에서 같은 진도 전이 규칙을 재사용하도록 도메인 공통 검증 기준이 필요합니다.

## 변경 요약
- 문서 기준 진도 상태 전이 validator 추가
- 허용/차단 전이 단위 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests "com.back.coach.domain.roadmap.ProgressTransitionValidatorTest"` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
