### PR TITLE
chore(logging): traceId 로그 패턴 설정

### DIFF
--- a/backend/src/main/java/com/back/coach/global/logging/TraceIdFilter.java
+++ b/backend/src/main/java/com/back/coach/global/logging/TraceIdFilter.java
@@ -13,7 +13,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.UUID;
 
-// TODO(observability): add %X{traceId} to logback-spring.xml so every log line carries the trace id.
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class TraceIdFilter extends OncePerRequestFilter {

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] traceId=%X{traceId:-none} %logger{36} - %msg%n"/>
+
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/backend/src/test/java/com/back/coach/global/logging/LogbackSpringConfigTest.java
+++ b/backend/src/test/java/com/back/coach/global/logging/LogbackSpringConfigTest.java
@@ -1,0 +1,26 @@
+package com.back.coach.global.logging;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class LogbackSpringConfigTest {
+
+    @Test
+    void logbackSpringXml_consolePatternIncludesTraceIdMdc() {
+        assertThatCode(() -> {
+            try (InputStream input = getClass().getClassLoader().getResourceAsStream("logback-spring.xml")) {
+                assertThat(input).isNotNull();
+
+                String config = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+
+                assertThat(config).contains("CONSOLE_LOG_PATTERN");
+                assertThat(config).contains("traceId=%X{traceId:-none}");
+            }
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
﻿Closes #53

## 왜 필요한가
장애나 예외를 응답 traceId와 서버 로그로 연결해 추적할 수 있어야 합니다.

## 변경 요약
- Logback console pattern에 MDC traceId 추가
- TraceIdFilter의 logback TODO 제거
- 로그 패턴 설정 회귀 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests "com.back.coach.ContextLoadsTest"` 통과
- `backend`에서 `./gradlew.bat test --tests "com.back.coach.global.logging.LogbackSpringConfigTest"` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
