### PR TITLE
chore(ci): Jacoco 검증 범위 최적화

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,22 +59,6 @@ jobs:
           path: backend/build/reports/tests/prIntegrationTest
           if-no-files-found: warn
 
-      - name: Upload Jacoco HTML report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-html-report-pr
-          path: backend/build/reports/jacoco/test/html
-          if-no-files-found: warn
-
-      - name: Upload Jacoco XML report
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-xml-report-pr
-          path: backend/build/reports/jacoco/test/jacocoTestReport.xml
-          if-no-files-found: warn
-
   backend-full-verification:
     name: backend-full-verification
     if: github.event_name == 'push'

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -93,7 +93,6 @@ tasks.test {
   useJUnitPlatform {
     excludeTags("integration")
   }
-  finalizedBy(tasks.jacocoTestReport)
 }
 
 val testSourceSet = the<JavaPluginExtension>().sourceSets.getByName("test")


### PR DESCRIPTION
﻿Closes #55

## 왜 필요한가
PR 단계의 대기 시간을 줄이면서 통합 브랜치의 커버리지 확인은 유지해야 합니다.
PR 검증과 full 검증의 책임 분리

## 변경 요약
- Gradle에서 `test` 완료 후 Jacoco 리포트가 자동 생성되지 않도록 조정
- PR job의 Jacoco HTML/XML artifact 업로드 제거
- `fullVerification`과 push job의 Jacoco 리포트 생성/업로드는 유지

## 테스트
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
- `backend`에서 `./gradlew.bat fullVerification` 통과
