### PR TITLE
chore(github): GitHub API client 계약 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ FRONTEND_URL=http://localhost:3000
 # GitHub OAuth
 GITHUB_CLIENT_ID=your-github-oauth-client-id
 GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
+GITHUB_API_BASE_URL=https://api.github.com
 
 # AI provider / gateway
 AI_GATEWAY_API_KEY=your-ai-gateway-api-key

--- a/backend/src/main/java/com/back/coach/external/github/GithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/GithubApiClient.java
@@ -1,0 +1,8 @@
+package com.back.coach.external.github;
+
+import java.util.List;
+
+public interface GithubApiClient {
+
+    List<GithubRepositoryMetadata> listAuthenticatedUserRepositories(String accessToken);
+}

--- a/backend/src/main/java/com/back/coach/external/github/GithubApiConfig.java
+++ b/backend/src/main/java/com/back/coach/external/github/GithubApiConfig.java
@@ -1,0 +1,18 @@
+package com.back.coach.external.github;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(GithubApiProperties.class)
+public class GithubApiConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/backend/src/main/java/com/back/coach/external/github/GithubApiProperties.java
+++ b/backend/src/main/java/com/back/coach/external/github/GithubApiProperties.java
@@ -1,0 +1,13 @@
+package com.back.coach.external.github;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "github.api")
+public record GithubApiProperties(String baseUrl) {
+
+    public GithubApiProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalArgumentException("github.api.base-url must not be blank");
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/external/github/GithubRepositoryMetadata.java
+++ b/backend/src/main/java/com/back/coach/external/github/GithubRepositoryMetadata.java
@@ -1,0 +1,10 @@
+package com.back.coach.external.github;
+
+public record GithubRepositoryMetadata(
+        String nodeId,
+        String fullName,
+        String htmlUrl,
+        String primaryLanguage,
+        String defaultBranch
+) {
+}

--- a/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
@@ -1,0 +1,118 @@
+package com.back.coach.external.github;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Component
+public class RestGithubApiClient implements GithubApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(RestGithubApiClient.class);
+    private static final ParameterizedTypeReference<List<RepositoryResponse>> REPOSITORY_LIST_TYPE =
+            new ParameterizedTypeReference<>() {
+            };
+
+    private final GithubApiProperties properties;
+    private final RestClient restClient;
+
+    @Autowired
+    public RestGithubApiClient(GithubApiProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = restClientBuilder
+                .requestFactory(new SimpleClientHttpRequestFactory())
+                .baseUrl(properties.baseUrl())
+                .build();
+    }
+
+    RestGithubApiClient(GithubApiProperties properties) {
+        this(properties, RestClient.builder());
+    }
+
+    @Override
+    public List<GithubRepositoryMetadata> listAuthenticatedUserRepositories(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "GitHub access token is empty");
+        }
+        try {
+            List<RepositoryResponse> response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/user/repos")
+                            .queryParam("per_page", 100)
+                            .queryParam("sort", "updated")
+                            .queryParam("affiliation", "owner,collaborator,organization_member")
+                            .build())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .headers(headers -> setHeaders(headers, accessToken))
+                    .retrieve()
+                    .onStatus(status -> status.value() == HttpStatus.UNAUTHORIZED.value(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.UNAUTHORIZED);
+                            })
+                    .onStatus(status -> status.value() == HttpStatus.FORBIDDEN.value(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.FORBIDDEN);
+                            })
+                    .onStatus(status -> status.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.RATE_LIMIT_EXCEEDED);
+                            })
+                    .onStatus(status -> status.isError(),
+                            (request, responseEntity) -> {
+                                throw new ServiceException(ErrorCode.EXTERNAL_SERVICE_TEMPORARILY_UNAVAILABLE);
+                            })
+                    .body(REPOSITORY_LIST_TYPE);
+
+            if (response == null) {
+                throw new ServiceException(ErrorCode.EXTERNAL_SERVICE_TEMPORARILY_UNAVAILABLE);
+            }
+            return response.stream()
+                    .map(RepositoryResponse::toMetadata)
+                    .toList();
+        } catch (ServiceException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            ErrorCode mapped = classify(e);
+            log.warn("GitHub API call failed (baseUrl={}, code={}, type={}, message={})",
+                    properties.baseUrl(), mapped, e.getClass().getSimpleName(), e.getMessage());
+            throw new ServiceException(mapped, mapped.getDefaultMessage());
+        }
+    }
+
+    private void setHeaders(HttpHeaders headers, String accessToken) {
+        headers.setBearerAuth(accessToken);
+        headers.set(HttpHeaders.ACCEPT, "application/vnd.github+json");
+    }
+
+    private ErrorCode classify(RuntimeException e) {
+        if (e instanceof ResourceAccessException) {
+            return ErrorCode.EXTERNAL_SERVICE_TEMPORARILY_UNAVAILABLE;
+        }
+        return ErrorCode.EXTERNAL_SERVICE_TEMPORARILY_UNAVAILABLE;
+    }
+
+    private record RepositoryResponse(
+            @JsonProperty("node_id") String nodeId,
+            @JsonProperty("full_name") String fullName,
+            @JsonProperty("html_url") String htmlUrl,
+            @JsonProperty("language") String language,
+            @JsonProperty("default_branch") String defaultBranch
+    ) {
+
+        private GithubRepositoryMetadata toMetadata() {
+            return new GithubRepositoryMetadata(nodeId, fullName, htmlUrl, language, defaultBranch);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -66,3 +66,7 @@ ai:
   concurrency:
     max-concurrent-calls: 4
     queue-timeout-seconds: 180
+
+github:
+  api:
+    base-url: ${GITHUB_API_BASE_URL:https://api.github.com}

--- a/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
@@ -1,0 +1,137 @@
+package com.back.coach.external.github;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RestGithubApiClientTest {
+
+    private WireMockServer wireMock;
+    private RestGithubApiClient client;
+
+    @BeforeEach
+    void setUp() {
+        wireMock = new WireMockServer(options().dynamicPort());
+        wireMock.start();
+        client = new RestGithubApiClient(
+                new GithubApiProperties("http://127.0.0.1:" + wireMock.port())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMock.stop();
+    }
+
+    @Test
+    void blankAccessToken_throwsInvalidInput() {
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories(""))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories(null))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    void listAuthenticatedUserRepositories_callsGithubAndMapsRepositoryMetadata() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [
+                                  {
+                                    "node_id": "R_kgDO123",
+                                    "full_name": "team06/coach",
+                                    "html_url": "https://github.com/team06/coach",
+                                    "language": "Java",
+                                    "default_branch": "main"
+                                  }
+                                ]
+                                """)));
+
+        List<GithubRepositoryMetadata> result = client.listAuthenticatedUserRepositories("token-123");
+
+        assertThat(result).containsExactly(new GithubRepositoryMetadata(
+                "R_kgDO123",
+                "team06/coach",
+                "https://github.com/team06/coach",
+                "Java",
+                "main"
+        ));
+        wireMock.verify(getRequestedFor(urlPathEqualTo("/user/repos"))
+                .withHeader("Authorization", equalTo("Bearer token-123"))
+                .withHeader("Accept", equalTo("application/vnd.github+json"))
+                .withQueryParam("per_page", equalTo("100"))
+                .withQueryParam("sort", equalTo("updated"))
+                .withQueryParam("affiliation", equalTo("owner,collaborator,organization_member")));
+    }
+
+    @Test
+    void unauthorizedResponse_throwsUnauthorized() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse().withStatus(401)));
+
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories("bad-token"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    void forbiddenResponse_throwsForbidden() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse().withStatus(403)));
+
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories("token-123"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void rateLimitedResponse_throwsRateLimitExceeded() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse().withStatus(429)));
+
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories("token-123"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    void serverErrorResponse_throwsExternalServiceUnavailable() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> client.listAuthenticatedUserRepositories("token-123"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.EXTERNAL_SERVICE_TEMPORARILY_UNAVAILABLE);
+    }
+
+    @Test
+    void properties_rejectsBlankBaseUrl() {
+        assertThatThrownBy(() -> new GithubApiProperties(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("github.api.base-url must not be blank");
+    }
+}


### PR DESCRIPTION
﻿Closes #57

## 왜 필요한가
GitHub 저장소 메타데이터 수집 기능을 구현할 때 서비스 코드가 GitHub REST API 호출 방식에 직접 묶이지 않도록 외부 연동 경계가 필요합니다.

## 변경 요약
- GitHub API client 인터페이스와 RestClient 구현 추가
- GitHub API base URL 설정과 `.env.example` key 추가
- 저장소 목록 조회의 URL, 헤더, 응답/오류 매핑 WireMock 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests "com.back.coach.external.github.RestGithubApiClientTest"` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
