### PR TITLE
feat(progress): 최신 진도 스냅샷 조회 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshot.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshot.java
@@ -1,0 +1,13 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+
+import java.time.Instant;
+
+public record RoadmapProgressSnapshot(
+        Long roadmapWeekId,
+        ProgressStatus progressStatus,
+        String progressNote,
+        Instant progressUpdatedAt
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshotService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshotService.java
@@ -1,0 +1,49 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
+import com.back.coach.global.code.ProgressStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class RoadmapProgressSnapshotService {
+
+    private final ProgressLogRepository progressLogRepository;
+
+    public RoadmapProgressSnapshotService(ProgressLogRepository progressLogRepository) {
+        this.progressLogRepository = progressLogRepository;
+    }
+
+    public List<RoadmapProgressSnapshot> findSnapshots(Long userId, List<Long> roadmapWeekIds) {
+        if (roadmapWeekIds == null || roadmapWeekIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ProgressLog> progressLogs = progressLogRepository
+                .findByUserIdAndRoadmapWeekIdInOrderByCreatedAtDesc(userId, roadmapWeekIds);
+        Map<Long, ProgressLog> latestByRoadmapWeekId = new HashMap<>();
+        for (ProgressLog progressLog : progressLogs) {
+            latestByRoadmapWeekId.putIfAbsent(progressLog.getRoadmapWeekId(), progressLog);
+        }
+
+        return roadmapWeekIds.stream()
+                .map(roadmapWeekId -> toSnapshot(roadmapWeekId, latestByRoadmapWeekId.get(roadmapWeekId)))
+                .toList();
+    }
+
+    private RoadmapProgressSnapshot toSnapshot(Long roadmapWeekId, ProgressLog progressLog) {
+        if (progressLog == null) {
+            return new RoadmapProgressSnapshot(roadmapWeekId, ProgressStatus.TODO, null, null);
+        }
+        return new RoadmapProgressSnapshot(
+                roadmapWeekId,
+                progressLog.getStatus(),
+                progressLog.getNote(),
+                progressLog.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/ProgressLogRepository.java
@@ -3,12 +3,15 @@ package com.back.coach.domain.roadmap.repository;
 import com.back.coach.domain.roadmap.entity.ProgressLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ProgressLogRepository extends JpaRepository<ProgressLog, Long> {
 
     List<ProgressLog> findByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(Long userId, Long roadmapWeekId);
+
+    List<ProgressLog> findByUserIdAndRoadmapWeekIdInOrderByCreatedAtDesc(Long userId, Collection<Long> roadmapWeekIds);
 
     Optional<ProgressLog> findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(Long userId, Long roadmapWeekId);
 

--- a/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshotServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapProgressSnapshotServiceTest.java
@@ -1,0 +1,93 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
+import com.back.coach.global.code.ProgressStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapProgressSnapshotServiceTest {
+
+    @Mock
+    private ProgressLogRepository progressLogRepository;
+
+    @InjectMocks
+    private RoadmapProgressSnapshotService roadmapProgressSnapshotService;
+
+    @Test
+    void findSnapshots_whenNoProgressLog_returnsTodoSnapshot() {
+        given(progressLogRepository.findByUserIdAndRoadmapWeekIdInOrderByCreatedAtDesc(1L, List.of(10L)))
+                .willReturn(List.of());
+
+        List<RoadmapProgressSnapshot> result = roadmapProgressSnapshotService.findSnapshots(1L, List.of(10L));
+
+        assertThat(result).containsExactly(new RoadmapProgressSnapshot(10L, ProgressStatus.TODO, null, null));
+    }
+
+    @Test
+    void findSnapshots_whenMultipleLogsForSameWeek_usesLatestLog() {
+        Instant latestTime = Instant.parse("2026-04-28T01:00:00Z");
+        ProgressLog latestLog = progressLog(10L, ProgressStatus.DONE, "완료", latestTime);
+        ProgressLog oldLog = progressLogWithRoadmapWeekId(10L);
+        given(progressLogRepository.findByUserIdAndRoadmapWeekIdInOrderByCreatedAtDesc(1L, List.of(10L)))
+                .willReturn(List.of(latestLog, oldLog));
+
+        List<RoadmapProgressSnapshot> result = roadmapProgressSnapshotService.findSnapshots(1L, List.of(10L));
+
+        assertThat(result).containsExactly(new RoadmapProgressSnapshot(10L, ProgressStatus.DONE, "완료", latestTime));
+    }
+
+    @Test
+    void findSnapshots_whenMultipleWeeks_preservesRequestedOrder() {
+        Instant skippedAt = Instant.parse("2026-04-28T01:00:00Z");
+        Instant doneAt = Instant.parse("2026-04-28T02:00:00Z");
+        ProgressLog doneLog = progressLog(20L, ProgressStatus.DONE, "완료", doneAt);
+        ProgressLog skippedLog = progressLog(30L, ProgressStatus.SKIPPED, "건너뜀", skippedAt);
+        List<Long> roadmapWeekIds = List.of(30L, 10L, 20L);
+        given(progressLogRepository.findByUserIdAndRoadmapWeekIdInOrderByCreatedAtDesc(1L, roadmapWeekIds))
+                .willReturn(List.of(doneLog, skippedLog));
+
+        List<RoadmapProgressSnapshot> result = roadmapProgressSnapshotService.findSnapshots(1L, roadmapWeekIds);
+
+        assertThat(result).containsExactly(
+                new RoadmapProgressSnapshot(30L, ProgressStatus.SKIPPED, "건너뜀", skippedAt),
+                new RoadmapProgressSnapshot(10L, ProgressStatus.TODO, null, null),
+                new RoadmapProgressSnapshot(20L, ProgressStatus.DONE, "완료", doneAt)
+        );
+    }
+
+    @Test
+    void findSnapshots_whenRoadmapWeekIdsIsEmpty_returnsEmptyListWithoutRepositoryCall() {
+        List<RoadmapProgressSnapshot> result = roadmapProgressSnapshotService.findSnapshots(1L, List.of());
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(progressLogRepository);
+    }
+
+    private ProgressLog progressLog(Long roadmapWeekId, ProgressStatus status, String note, Instant createdAt) {
+        ProgressLog progressLog = mock(ProgressLog.class);
+        given(progressLog.getRoadmapWeekId()).willReturn(roadmapWeekId);
+        given(progressLog.getStatus()).willReturn(status);
+        given(progressLog.getNote()).willReturn(note);
+        given(progressLog.getCreatedAt()).willReturn(createdAt);
+        return progressLog;
+    }
+
+    private ProgressLog progressLogWithRoadmapWeekId(Long roadmapWeekId) {
+        ProgressLog progressLog = mock(ProgressLog.class);
+        given(progressLog.getRoadmapWeekId()).willReturn(roadmapWeekId);
+        return progressLog;
+    }
+}


### PR DESCRIPTION
﻿Closes #59

## 왜 필요한가
로드맵 조회와 대시보드에서 같은 최신 진도 계산 기준을 재사용해야 합니다.

## 변경 요약
- 주차별 최신 progress snapshot record/service 추가
- 사용자 + 여러 roadmapWeekId 기준 progress log 조회 repository 메서드 추가
- 기본 TODO, 최신 로그 선택, 요청 순서 유지 규칙 단위 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests "com.back.coach.domain.roadmap.RoadmapProgressSnapshotServiceTest"` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과
