### PR TITLE
test(domain): 결과 JSONB 샘플 fixture 추가

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/common/JsonbPayloadFixtureTest.java
+++ b/backend/src/test/java/com/back/coach/domain/common/JsonbPayloadFixtureTest.java
@@ -1,0 +1,157 @@
+package com.back.coach.domain.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonbPayloadFixtureTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "fixtures/jsonb/capability-diagnosis-payload.json",
+            "fixtures/jsonb/github-analysis-payload.json",
+            "fixtures/jsonb/learning-roadmap-payload.json",
+            "fixtures/jsonb/roadmap-week-materials.json",
+            "fixtures/jsonb/roadmap-week-tasks.json",
+            "fixtures/jsonb/user-profile-interest-areas.json"
+    })
+    void jsonbFixtures_parseAsJson(String resourcePath) throws IOException {
+        assertThat(readJson(resourcePath)).isNotNull();
+    }
+
+    @Test
+    void capabilityDiagnosisPayload_matchesRequiredShape() throws IOException {
+        JsonNode payload = readJson("fixtures/jsonb/capability-diagnosis-payload.json");
+
+        assertObjectFields(payload, "missingSkills", "strengths", "recommendations", "githubInsights");
+        assertArrayIsNotEmpty(payload.get("missingSkills"));
+        assertObjectFields(payload.get("missingSkills").get(0), "skillName", "severity", "reason", "priorityOrder");
+        assertThat(payload.get("missingSkills").get(0).get("priorityOrder").asInt()).isGreaterThanOrEqualTo(1);
+        assertArrayIsNotEmpty(payload.get("strengths"));
+        assertArrayIsNotEmpty(payload.get("recommendations"));
+        assertObjectFields(payload.get("githubInsights"), "confirmedSkills", "newFromGithub");
+    }
+
+    @Test
+    void githubAnalysisPayload_matchesRequiredShape() throws IOException {
+        JsonNode payload = readJson("fixtures/jsonb/github-analysis-payload.json");
+
+        assertObjectFields(
+                payload,
+                "staticSignals",
+                "repoSummaries",
+                "techTags",
+                "depthEstimates",
+                "evidences",
+                "userCorrections",
+                "finalTechProfile"
+        );
+        assertObjectFields(
+                payload.get("staticSignals"),
+                "primaryLanguages",
+                "activeRepos",
+                "commitFrequency",
+                "contributionPattern"
+        );
+        assertArrayIsNotEmpty(payload.get("staticSignals").get("primaryLanguages"));
+        assertObjectFields(payload.get("staticSignals").get("primaryLanguages").get(0), "lang", "ratio");
+        assertArrayIsNotEmpty(payload.get("repoSummaries"));
+        assertObjectFields(payload.get("repoSummaries").get(0), "repoId", "repoName", "summary", "highlights");
+        assertArrayIsNotEmpty(payload.get("techTags"));
+        assertObjectFields(payload.get("techTags").get(0), "skillName", "tagReason");
+        assertArrayIsNotEmpty(payload.get("depthEstimates"));
+        assertObjectFields(payload.get("depthEstimates").get(0), "skillName", "level", "reason");
+        assertArrayIsNotEmpty(payload.get("evidences"));
+        assertObjectFields(payload.get("evidences").get(0), "repoName", "type", "source", "summary");
+        assertObjectFields(payload.get("finalTechProfile"), "confirmedSkills", "focusAreas");
+    }
+
+    @Test
+    void learningRoadmapPayload_matchesRequiredShapeAndDoesNotContainProgressStatus() throws IOException {
+        JsonNode payload = readJson("fixtures/jsonb/learning-roadmap-payload.json");
+
+        assertObjectFields(payload, "weeks");
+        assertArrayIsNotEmpty(payload.get("weeks"));
+        JsonNode week = payload.get("weeks").get(0);
+        assertObjectFields(week, "weekNumber", "topic", "reason", "tasks", "materials", "estimatedHours");
+        assertArrayIsNotEmpty(week.get("tasks"));
+        assertObjectFields(week.get("tasks").get(0), "type", "title");
+        assertArrayIsNotEmpty(week.get("materials"));
+        assertObjectFields(week.get("materials").get(0), "type", "title", "url");
+        assertThat(containsFieldName(payload, "progressStatus")).isFalse();
+        assertThat(containsFieldName(payload, "progressNote")).isFalse();
+        assertThat(containsFieldName(payload, "progressUpdatedAt")).isFalse();
+    }
+
+    @Test
+    void roadmapWeekTasksAndMaterials_matchRequiredShape() throws IOException {
+        JsonNode tasks = readJson("fixtures/jsonb/roadmap-week-tasks.json");
+        JsonNode materials = readJson("fixtures/jsonb/roadmap-week-materials.json");
+
+        assertArrayIsNotEmpty(tasks);
+        assertObjectFields(tasks.get(0), "type", "title");
+        assertArrayIsNotEmpty(materials);
+        assertObjectFields(materials.get(0), "type", "title", "url");
+    }
+
+    @Test
+    void userProfileInterestAreas_matchRequiredShape() throws IOException {
+        JsonNode interestAreas = readJson("fixtures/jsonb/user-profile-interest-areas.json");
+
+        assertArrayIsNotEmpty(interestAreas);
+        for (JsonNode interestArea : interestAreas) {
+            assertThat(interestArea.isTextual()).isTrue();
+        }
+    }
+
+    private JsonNode readJson(String resourcePath) throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            assertThat(inputStream).as(resourcePath).isNotNull();
+            return objectMapper.readTree(inputStream);
+        }
+    }
+
+    private void assertObjectFields(JsonNode node, String... expectedFieldNames) {
+        assertThat(node).isNotNull();
+        assertThat(node.isObject()).isTrue();
+        assertThat(fieldNames(node)).contains(expectedFieldNames);
+    }
+
+    private void assertArrayIsNotEmpty(JsonNode node) {
+        assertThat(node).isNotNull();
+        assertThat(node.isArray()).isTrue();
+        assertThat(node.size()).isPositive();
+    }
+
+    private List<String> fieldNames(JsonNode node) {
+        List<String> fieldNames = new ArrayList<>();
+        node.fieldNames().forEachRemaining(fieldNames::add);
+        return fieldNames;
+    }
+
+    private boolean containsFieldName(JsonNode node, String fieldName) {
+        if (node.isObject() && node.has(fieldName)) {
+            return true;
+        }
+
+        Iterator<JsonNode> elements = node.elements();
+        while (elements.hasNext()) {
+            if (containsFieldName(elements.next(), fieldName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/src/test/resources/fixtures/jsonb/capability-diagnosis-payload.json
+++ b/backend/src/test/resources/fixtures/jsonb/capability-diagnosis-payload.json
@@ -1,0 +1,27 @@
+{
+  "missingSkills": [
+    {
+      "skillName": "Redis",
+      "severity": "HIGH",
+      "reason": "Needs cache and session design practice",
+      "priorityOrder": 1
+    }
+  ],
+  "strengths": [
+    "Spring Boot",
+    "JPA"
+  ],
+  "recommendations": [
+    "Study Redis data structures and TTL",
+    "Apply caching to a small backend project"
+  ],
+  "githubInsights": {
+    "confirmedSkills": [
+      "Java",
+      "Spring Boot"
+    ],
+    "newFromGithub": [
+      "Redis"
+    ]
+  }
+}

--- a/backend/src/test/resources/fixtures/jsonb/github-analysis-payload.json
+++ b/backend/src/test/resources/fixtures/jsonb/github-analysis-payload.json
@@ -1,0 +1,62 @@
+{
+  "staticSignals": {
+    "primaryLanguages": [
+      {
+        "lang": "Java",
+        "ratio": 0.6
+      }
+    ],
+    "activeRepos": 12,
+    "commitFrequency": "WEEKLY",
+    "contributionPattern": "CONSISTENT"
+  },
+  "repoSummaries": [
+    {
+      "repoId": "9001",
+      "repoName": "team06/ai-growth-coach",
+      "summary": "Spring Boot backend service",
+      "highlights": [
+        "Redis cache",
+        "Batch processing"
+      ]
+    }
+  ],
+  "techTags": [
+    {
+      "skillName": "Redis",
+      "tagReason": "Cache configuration and TTL usage were found"
+    }
+  ],
+  "depthEstimates": [
+    {
+      "skillName": "Redis",
+      "level": "APPLIED",
+      "reason": "Cache keys and TTL are used beyond dependency setup"
+    }
+  ],
+  "evidences": [
+    {
+      "repoName": "team06/ai-growth-coach",
+      "type": "CODE",
+      "source": "src/main/java/com/back/coach/config/CacheConfig.java",
+      "summary": "RedisTemplate and TTL configuration"
+    }
+  ],
+  "userCorrections": [
+    {
+      "skillName": "Redis",
+      "correction": "Used for cache only, not Pub/Sub"
+    }
+  ],
+  "finalTechProfile": {
+    "confirmedSkills": [
+      "Java",
+      "Spring Boot",
+      "Redis"
+    ],
+    "focusAreas": [
+      "Backend",
+      "Performance"
+    ]
+  }
+}

--- a/backend/src/test/resources/fixtures/jsonb/learning-roadmap-payload.json
+++ b/backend/src/test/resources/fixtures/jsonb/learning-roadmap-payload.json
@@ -1,0 +1,27 @@
+{
+  "weeks": [
+    {
+      "weekNumber": 1,
+      "topic": "Redis fundamentals",
+      "reason": "Redis is useful for backend performance and portfolio projects",
+      "tasks": [
+        {
+          "type": "READ_DOCS",
+          "title": "Read Redis data structures and TTL documentation"
+        },
+        {
+          "type": "BUILD_EXAMPLE",
+          "title": "Build a simple cache example"
+        }
+      ],
+      "materials": [
+        {
+          "type": "DOCS",
+          "title": "Redis Documentation",
+          "url": "https://redis.io/docs"
+        }
+      ],
+      "estimatedHours": 8
+    }
+  ]
+}

--- a/backend/src/test/resources/fixtures/jsonb/roadmap-week-materials.json
+++ b/backend/src/test/resources/fixtures/jsonb/roadmap-week-materials.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "DOCS",
+    "title": "Redis Documentation",
+    "url": "https://redis.io/docs"
+  }
+]

--- a/backend/src/test/resources/fixtures/jsonb/roadmap-week-tasks.json
+++ b/backend/src/test/resources/fixtures/jsonb/roadmap-week-tasks.json
@@ -1,0 +1,6 @@
+[
+  {
+    "type": "READ_DOCS",
+    "title": "Read Redis documentation"
+  }
+]

--- a/backend/src/test/resources/fixtures/jsonb/user-profile-interest-areas.json
+++ b/backend/src/test/resources/fixtures/jsonb/user-profile-interest-areas.json
@@ -1,0 +1,5 @@
+[
+  "Backend",
+  "Performance",
+  "AI Service"
+]


### PR DESCRIPTION
Closes #61

## 왜 필요한가
분석/진단/로드맵 결과 JSONB를 여러 기능이 같은 key 기준으로 재사용해야 합니다.

## 변경 요약
- 계약 부록 기준 JSONB fixture 추가
- 필수 key와 핵심 shape 검증 테스트 추가
- roadmap payload에 progress 상태가 섞이지 않는 규칙 검증 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests com.back.coach.domain.common.JsonbPayloadFixtureTest` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과