### PR TITLE
feat(dashboard): 최신 결과 스냅샷 조회 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/dashboard/DashboardSnapshot.java
+++ b/backend/src/main/java/com/back/coach/domain/dashboard/DashboardSnapshot.java
@@ -1,0 +1,60 @@
+package com.back.coach.domain.dashboard;
+
+import com.back.coach.global.code.CurrentLevel;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record DashboardSnapshot(
+        Long userId,
+        ProfileSummary profile,
+        GithubAnalysisSummary githubAnalysis,
+        DiagnosisSummary diagnosis,
+        RoadmapSummary roadmap
+) {
+
+    public record ProfileSummary(
+            Long profileId,
+            Long jobRoleId,
+            CurrentLevel currentLevel,
+            Integer weeklyStudyHours,
+            LocalDate targetDate,
+            Instant updatedAt
+    ) {
+    }
+
+    public record GithubAnalysisSummary(
+            Long githubAnalysisId,
+            Integer version,
+            String summary,
+            Instant createdAt
+    ) {
+    }
+
+    public record DiagnosisSummary(
+            Long diagnosisId,
+            Integer version,
+            String summary,
+            Instant createdAt
+    ) {
+    }
+
+    public record RoadmapSummary(
+            Long roadmapId,
+            Integer version,
+            Integer totalWeeks,
+            String summary,
+            Instant createdAt,
+            ProgressSummary progress
+    ) {
+    }
+
+    public record ProgressSummary(
+            int totalWeeks,
+            int todoWeeks,
+            int inProgressWeeks,
+            int doneWeeks,
+            int skippedWeeks
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/dashboard/DashboardSnapshotService.java
+++ b/backend/src/main/java/com/back/coach/domain/dashboard/DashboardSnapshotService.java
@@ -1,0 +1,137 @@
+package com.back.coach.domain.dashboard;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.RoadmapProgressSnapshot;
+import com.back.coach.domain.roadmap.RoadmapProgressSnapshotService;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.global.code.ProgressStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DashboardSnapshotService {
+
+    private final UserProfileRepository userProfileRepository;
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final LearningRoadmapRepository learningRoadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
+    private final RoadmapProgressSnapshotService roadmapProgressSnapshotService;
+
+    public DashboardSnapshotService(
+            UserProfileRepository userProfileRepository,
+            GithubAnalysisRepository githubAnalysisRepository,
+            CapabilityDiagnosisRepository capabilityDiagnosisRepository,
+            LearningRoadmapRepository learningRoadmapRepository,
+            RoadmapWeekRepository roadmapWeekRepository,
+            RoadmapProgressSnapshotService roadmapProgressSnapshotService
+    ) {
+        this.userProfileRepository = userProfileRepository;
+        this.githubAnalysisRepository = githubAnalysisRepository;
+        this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
+        this.learningRoadmapRepository = learningRoadmapRepository;
+        this.roadmapWeekRepository = roadmapWeekRepository;
+        this.roadmapProgressSnapshotService = roadmapProgressSnapshotService;
+    }
+
+    public DashboardSnapshot findSnapshot(Long userId) {
+        return new DashboardSnapshot(
+                userId,
+                userProfileRepository.findByUserId(userId)
+                        .map(this::toProfileSummary)
+                        .orElse(null),
+                githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                        .map(this::toGithubAnalysisSummary)
+                        .orElse(null),
+                capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                        .map(this::toDiagnosisSummary)
+                        .orElse(null),
+                learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                        .map(roadmap -> toRoadmapSummary(userId, roadmap))
+                        .orElse(null)
+        );
+    }
+
+    private DashboardSnapshot.ProfileSummary toProfileSummary(UserProfile profile) {
+        return new DashboardSnapshot.ProfileSummary(
+                profile.getId(),
+                profile.getJobRoleId(),
+                profile.getCurrentLevel(),
+                profile.getWeeklyStudyHours(),
+                profile.getTargetDate(),
+                profile.getUpdatedAt()
+        );
+    }
+
+    private DashboardSnapshot.GithubAnalysisSummary toGithubAnalysisSummary(GithubAnalysis githubAnalysis) {
+        return new DashboardSnapshot.GithubAnalysisSummary(
+                githubAnalysis.getId(),
+                githubAnalysis.getVersion(),
+                githubAnalysis.getSummary(),
+                githubAnalysis.getCreatedAt()
+        );
+    }
+
+    private DashboardSnapshot.DiagnosisSummary toDiagnosisSummary(CapabilityDiagnosis diagnosis) {
+        return new DashboardSnapshot.DiagnosisSummary(
+                diagnosis.getId(),
+                diagnosis.getVersion(),
+                diagnosis.getSummary(),
+                diagnosis.getCreatedAt()
+        );
+    }
+
+    private DashboardSnapshot.RoadmapSummary toRoadmapSummary(Long userId, LearningRoadmap roadmap) {
+        List<RoadmapWeek> roadmapWeeks = roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(roadmap.getId());
+        List<Long> roadmapWeekIds = roadmapWeeks.stream()
+                .map(RoadmapWeek::getId)
+                .toList();
+        List<RoadmapProgressSnapshot> progressSnapshots = roadmapProgressSnapshotService.findSnapshots(userId, roadmapWeekIds);
+
+        return new DashboardSnapshot.RoadmapSummary(
+                roadmap.getId(),
+                roadmap.getVersion(),
+                roadmap.getTotalWeeks(),
+                roadmap.getSummary(),
+                roadmap.getCreatedAt(),
+                toProgressSummary(progressSnapshots)
+        );
+    }
+
+    private DashboardSnapshot.ProgressSummary toProgressSummary(List<RoadmapProgressSnapshot> progressSnapshots) {
+        int todoWeeks = 0;
+        int inProgressWeeks = 0;
+        int doneWeeks = 0;
+        int skippedWeeks = 0;
+
+        for (RoadmapProgressSnapshot progressSnapshot : progressSnapshots) {
+            ProgressStatus progressStatus = progressSnapshot.progressStatus();
+            if (progressStatus == ProgressStatus.TODO) {
+                todoWeeks++;
+            } else if (progressStatus == ProgressStatus.IN_PROGRESS) {
+                inProgressWeeks++;
+            } else if (progressStatus == ProgressStatus.DONE) {
+                doneWeeks++;
+            } else if (progressStatus == ProgressStatus.SKIPPED) {
+                skippedWeeks++;
+            }
+        }
+
+        return new DashboardSnapshot.ProgressSummary(
+                progressSnapshots.size(),
+                todoWeeks,
+                inProgressWeeks,
+                doneWeeks,
+                skippedWeeks
+        );
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/dashboard/DashboardSnapshotServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/dashboard/DashboardSnapshotServiceTest.java
@@ -1,0 +1,228 @@
+package com.back.coach.domain.dashboard;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.RoadmapProgressSnapshot;
+import com.back.coach.domain.roadmap.RoadmapProgressSnapshotService;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.ProgressStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardSnapshotServiceTest {
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Mock
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Mock
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Mock
+    private RoadmapWeekRepository roadmapWeekRepository;
+
+    @Mock
+    private RoadmapProgressSnapshotService roadmapProgressSnapshotService;
+
+    @InjectMocks
+    private DashboardSnapshotService dashboardSnapshotService;
+
+    @Test
+    void findSnapshot_whenNoResultExists_returnsUserIdAndNullSummaries() {
+        givenNoLatestResults(1L);
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.userId()).isEqualTo(1L);
+        assertThat(result.profile()).isNull();
+        assertThat(result.githubAnalysis()).isNull();
+        assertThat(result.diagnosis()).isNull();
+        assertThat(result.roadmap()).isNull();
+        verifyNoInteractions(roadmapWeekRepository, roadmapProgressSnapshotService);
+    }
+
+    @Test
+    void findSnapshot_whenLatestResultsExist_returnsLatestSummaries() {
+        Instant profileUpdatedAt = Instant.parse("2026-04-28T01:00:00Z");
+        Instant githubAnalysisCreatedAt = Instant.parse("2026-04-28T02:00:00Z");
+        Instant diagnosisCreatedAt = Instant.parse("2026-04-28T03:00:00Z");
+        Instant roadmapCreatedAt = Instant.parse("2026-04-28T04:00:00Z");
+        UserProfile profile = userProfile(10L, profileUpdatedAt);
+        GithubAnalysis githubAnalysis = githubAnalysis(20L, 3, "latest analysis", githubAnalysisCreatedAt);
+        CapabilityDiagnosis diagnosis = diagnosis(30L, 4, "latest diagnosis", diagnosisCreatedAt);
+        LearningRoadmap roadmap = roadmap(40L, 2, 8, "latest roadmap", roadmapCreatedAt);
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.of(profile));
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.of(githubAnalysis));
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.of(diagnosis));
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.of(roadmap));
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(40L)).willReturn(List.of());
+        given(roadmapProgressSnapshotService.findSnapshots(1L, List.of())).willReturn(List.of());
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.profile()).isEqualTo(new DashboardSnapshot.ProfileSummary(
+                10L,
+                100L,
+                CurrentLevel.JUNIOR,
+                12,
+                LocalDate.of(2026, 12, 31),
+                profileUpdatedAt
+        ));
+        assertThat(result.githubAnalysis()).isEqualTo(new DashboardSnapshot.GithubAnalysisSummary(
+                20L,
+                3,
+                "latest analysis",
+                githubAnalysisCreatedAt
+        ));
+        assertThat(result.diagnosis()).isEqualTo(new DashboardSnapshot.DiagnosisSummary(
+                30L,
+                4,
+                "latest diagnosis",
+                diagnosisCreatedAt
+        ));
+        assertThat(result.roadmap()).isEqualTo(new DashboardSnapshot.RoadmapSummary(
+                40L,
+                2,
+                8,
+                "latest roadmap",
+                roadmapCreatedAt,
+                new DashboardSnapshot.ProgressSummary(0, 0, 0, 0, 0)
+        ));
+    }
+
+    @Test
+    void findSnapshot_whenLatestRoadmapHasProgressSnapshots_calculatesProgressCounts() {
+        LearningRoadmap roadmap = roadmap(40L, 2, 4, "latest roadmap", Instant.parse("2026-04-28T04:00:00Z"));
+        givenEmptyLatestResultsExceptRoadmap(1L, roadmap);
+        List<RoadmapWeek> roadmapWeeks = List.of(
+                roadmapWeek(10L),
+                roadmapWeek(20L),
+                roadmapWeek(30L),
+                roadmapWeek(40L)
+        );
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(40L))
+                .willReturn(roadmapWeeks);
+        given(roadmapProgressSnapshotService.findSnapshots(1L, List.of(10L, 20L, 30L, 40L)))
+                .willReturn(List.of(
+                        progressSnapshot(10L, ProgressStatus.TODO),
+                        progressSnapshot(20L, ProgressStatus.IN_PROGRESS),
+                        progressSnapshot(30L, ProgressStatus.DONE),
+                        progressSnapshot(40L, ProgressStatus.SKIPPED)
+                ));
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.roadmap().progress()).isEqualTo(new DashboardSnapshot.ProgressSummary(4, 1, 1, 1, 1));
+    }
+
+    @Test
+    void findSnapshot_whenLatestRoadmapHasNoWeeks_returnsZeroProgressCounts() {
+        LearningRoadmap roadmap = roadmap(40L, 2, 4, "latest roadmap", Instant.parse("2026-04-28T04:00:00Z"));
+        givenEmptyLatestResultsExceptRoadmap(1L, roadmap);
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(40L)).willReturn(List.of());
+        given(roadmapProgressSnapshotService.findSnapshots(1L, List.of())).willReturn(List.of());
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.roadmap().progress()).isEqualTo(new DashboardSnapshot.ProgressSummary(0, 0, 0, 0, 0));
+    }
+
+    private void givenNoLatestResults(Long userId) {
+        given(userProfileRepository.findByUserId(userId)).willReturn(Optional.empty());
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.empty());
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.empty());
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.empty());
+    }
+
+    private void givenEmptyLatestResultsExceptRoadmap(Long userId, LearningRoadmap roadmap) {
+        given(userProfileRepository.findByUserId(userId)).willReturn(Optional.empty());
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.empty());
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.empty());
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId))
+                .willReturn(Optional.of(roadmap));
+    }
+
+    private UserProfile userProfile(Long id, Instant updatedAt) {
+        UserProfile userProfile = mock(UserProfile.class);
+        given(userProfile.getId()).willReturn(id);
+        given(userProfile.getJobRoleId()).willReturn(100L);
+        given(userProfile.getCurrentLevel()).willReturn(CurrentLevel.JUNIOR);
+        given(userProfile.getWeeklyStudyHours()).willReturn(12);
+        given(userProfile.getTargetDate()).willReturn(LocalDate.of(2026, 12, 31));
+        given(userProfile.getUpdatedAt()).willReturn(updatedAt);
+        return userProfile;
+    }
+
+    private GithubAnalysis githubAnalysis(Long id, Integer version, String summary, Instant createdAt) {
+        GithubAnalysis githubAnalysis = mock(GithubAnalysis.class);
+        given(githubAnalysis.getId()).willReturn(id);
+        given(githubAnalysis.getVersion()).willReturn(version);
+        given(githubAnalysis.getSummary()).willReturn(summary);
+        given(githubAnalysis.getCreatedAt()).willReturn(createdAt);
+        return githubAnalysis;
+    }
+
+    private CapabilityDiagnosis diagnosis(Long id, Integer version, String summary, Instant createdAt) {
+        CapabilityDiagnosis diagnosis = mock(CapabilityDiagnosis.class);
+        given(diagnosis.getId()).willReturn(id);
+        given(diagnosis.getVersion()).willReturn(version);
+        given(diagnosis.getSummary()).willReturn(summary);
+        given(diagnosis.getCreatedAt()).willReturn(createdAt);
+        return diagnosis;
+    }
+
+    private LearningRoadmap roadmap(Long id, Integer version, Integer totalWeeks, String summary, Instant createdAt) {
+        LearningRoadmap roadmap = mock(LearningRoadmap.class);
+        given(roadmap.getId()).willReturn(id);
+        given(roadmap.getVersion()).willReturn(version);
+        given(roadmap.getTotalWeeks()).willReturn(totalWeeks);
+        given(roadmap.getSummary()).willReturn(summary);
+        given(roadmap.getCreatedAt()).willReturn(createdAt);
+        return roadmap;
+    }
+
+    private RoadmapWeek roadmapWeek(Long id) {
+        RoadmapWeek roadmapWeek = mock(RoadmapWeek.class);
+        given(roadmapWeek.getId()).willReturn(id);
+        return roadmapWeek;
+    }
+
+    private RoadmapProgressSnapshot progressSnapshot(Long roadmapWeekId, ProgressStatus progressStatus) {
+        return new RoadmapProgressSnapshot(roadmapWeekId, progressStatus, null, null);
+    }
+}


### PR DESCRIPTION
Closes #63

## 왜 필요한가
대시보드/API 구현자가 같은 최신 결과 기준과 progress 계산 기준을 재사용해야 합니다.

## 변경 요약
- dashboard snapshot record/service 추가
- 최신 프로필, GitHub 분석, 진단, 로드맵 요약 조립 추가
- 최신 로드맵 주차별 progress 상태 count 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests com.back.coach.domain.dashboard.DashboardSnapshotServiceTest` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과