### PR TITLE
feat(roadmap): 상세 진도 스냅샷 조회 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshot.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshot.java
@@ -1,0 +1,31 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public record RoadmapDetailSnapshot(
+        Long roadmapId,
+        Integer version,
+        Integer totalWeeks,
+        String summary,
+        Instant createdAt,
+        List<WeekSnapshot> weeks
+) {
+
+    public record WeekSnapshot(
+            Long roadmapWeekId,
+            Integer weekNumber,
+            String topic,
+            String reasonText,
+            String tasksJson,
+            String materialsJson,
+            BigDecimal estimatedHours,
+            ProgressStatus progressStatus,
+            String progressNote,
+            Instant progressUpdatedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshotService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshotService.java
@@ -1,0 +1,89 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class RoadmapDetailSnapshotService {
+
+    private final LearningRoadmapRepository learningRoadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
+    private final RoadmapProgressSnapshotService roadmapProgressSnapshotService;
+
+    public RoadmapDetailSnapshotService(
+            LearningRoadmapRepository learningRoadmapRepository,
+            RoadmapWeekRepository roadmapWeekRepository,
+            RoadmapProgressSnapshotService roadmapProgressSnapshotService
+    ) {
+        this.learningRoadmapRepository = learningRoadmapRepository;
+        this.roadmapWeekRepository = roadmapWeekRepository;
+        this.roadmapProgressSnapshotService = roadmapProgressSnapshotService;
+    }
+
+    public RoadmapDetailSnapshot findSnapshot(Long userId, Long roadmapId) {
+        LearningRoadmap roadmap = learningRoadmapRepository.findByIdAndUserId(roadmapId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        List<RoadmapWeek> roadmapWeeks = roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(roadmapId);
+
+        return new RoadmapDetailSnapshot(
+                roadmap.getId(),
+                roadmap.getVersion(),
+                roadmap.getTotalWeeks(),
+                roadmap.getSummary(),
+                roadmap.getCreatedAt(),
+                toWeekSnapshots(userId, roadmapWeeks)
+        );
+    }
+
+    private List<RoadmapDetailSnapshot.WeekSnapshot> toWeekSnapshots(Long userId, List<RoadmapWeek> roadmapWeeks) {
+        if (roadmapWeeks.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> roadmapWeekIds = roadmapWeeks.stream()
+                .map(RoadmapWeek::getId)
+                .toList();
+        Map<Long, RoadmapProgressSnapshot> progressSnapshotByRoadmapWeekId = toProgressSnapshotMap(
+                roadmapProgressSnapshotService.findSnapshots(userId, roadmapWeekIds)
+        );
+
+        return roadmapWeeks.stream()
+                .map(roadmapWeek -> toWeekSnapshot(roadmapWeek, progressSnapshotByRoadmapWeekId.get(roadmapWeek.getId())))
+                .toList();
+    }
+
+    private Map<Long, RoadmapProgressSnapshot> toProgressSnapshotMap(List<RoadmapProgressSnapshot> progressSnapshots) {
+        Map<Long, RoadmapProgressSnapshot> progressSnapshotByRoadmapWeekId = new HashMap<>();
+        for (RoadmapProgressSnapshot progressSnapshot : progressSnapshots) {
+            progressSnapshotByRoadmapWeekId.put(progressSnapshot.roadmapWeekId(), progressSnapshot);
+        }
+        return progressSnapshotByRoadmapWeekId;
+    }
+
+    private RoadmapDetailSnapshot.WeekSnapshot toWeekSnapshot(
+            RoadmapWeek roadmapWeek,
+            RoadmapProgressSnapshot progressSnapshot
+    ) {
+        return new RoadmapDetailSnapshot.WeekSnapshot(
+                roadmapWeek.getId(),
+                roadmapWeek.getWeekNumber(),
+                roadmapWeek.getTopic(),
+                roadmapWeek.getReasonText(),
+                roadmapWeek.getTasksJson(),
+                roadmapWeek.getMaterialsJson(),
+                roadmapWeek.getEstimatedHours(),
+                progressSnapshot.progressStatus(),
+                progressSnapshot.progressNote(),
+                progressSnapshot.progressUpdatedAt()
+        );
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshotServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapDetailSnapshotServiceTest.java
@@ -1,0 +1,141 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapDetailSnapshotServiceTest {
+
+    @Mock
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Mock
+    private RoadmapWeekRepository roadmapWeekRepository;
+
+    @Mock
+    private RoadmapProgressSnapshotService roadmapProgressSnapshotService;
+
+    @InjectMocks
+    private RoadmapDetailSnapshotService roadmapDetailSnapshotService;
+
+    @Test
+    void findSnapshot_whenRoadmapDoesNotBelongToUser_throwsResourceNotFound() {
+        given(learningRoadmapRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roadmapDetailSnapshotService.findSnapshot(1L, 10L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        verifyNoInteractions(roadmapWeekRepository, roadmapProgressSnapshotService);
+    }
+
+    @Test
+    void findSnapshot_whenRoadmapHasNoWeeks_returnsEmptyWeeksWithoutProgressLookup() {
+        Instant createdAt = Instant.parse("2026-04-28T01:00:00Z");
+        LearningRoadmap roadmap = roadmap(10L, 2, 4, "backend roadmap", createdAt);
+        given(learningRoadmapRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.of(roadmap));
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(10L)).willReturn(List.of());
+
+        RoadmapDetailSnapshot result = roadmapDetailSnapshotService.findSnapshot(1L, 10L);
+
+        assertThat(result).isEqualTo(new RoadmapDetailSnapshot(
+                10L,
+                2,
+                4,
+                "backend roadmap",
+                createdAt,
+                List.of()
+        ));
+        verifyNoInteractions(roadmapProgressSnapshotService);
+    }
+
+    @Test
+    void findSnapshot_whenRoadmapHasWeeks_returnsWeeksWithProgressInWeekNumberOrder() {
+        Instant roadmapCreatedAt = Instant.parse("2026-04-28T01:00:00Z");
+        Instant doneAt = Instant.parse("2026-04-28T02:00:00Z");
+        LearningRoadmap roadmap = roadmap(10L, 2, 2, "backend roadmap", roadmapCreatedAt);
+        RoadmapWeek firstWeek = roadmapWeek(100L, 1, "Redis basics", new BigDecimal("8.0"));
+        RoadmapWeek secondWeek = roadmapWeek(200L, 2, "Cache project", new BigDecimal("10.0"));
+        given(learningRoadmapRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.of(roadmap));
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(10L))
+                .willReturn(List.of(firstWeek, secondWeek));
+        given(roadmapProgressSnapshotService.findSnapshots(1L, List.of(100L, 200L)))
+                .willReturn(List.of(
+                        new RoadmapProgressSnapshot(100L, ProgressStatus.DONE, "완료", doneAt),
+                        new RoadmapProgressSnapshot(200L, ProgressStatus.TODO, null, null)
+                ));
+
+        RoadmapDetailSnapshot result = roadmapDetailSnapshotService.findSnapshot(1L, 10L);
+
+        assertThat(result.roadmapId()).isEqualTo(10L);
+        assertThat(result.weeks()).containsExactly(
+                new RoadmapDetailSnapshot.WeekSnapshot(
+                        100L,
+                        1,
+                        "Redis basics",
+                        "reason for Redis basics",
+                        "[{\"type\":\"READ_DOCS\",\"title\":\"Redis basics task\"}]",
+                        "[{\"type\":\"DOCS\",\"title\":\"Redis basics material\"}]",
+                        new BigDecimal("8.0"),
+                        ProgressStatus.DONE,
+                        "완료",
+                        doneAt
+                ),
+                new RoadmapDetailSnapshot.WeekSnapshot(
+                        200L,
+                        2,
+                        "Cache project",
+                        "reason for Cache project",
+                        "[{\"type\":\"READ_DOCS\",\"title\":\"Cache project task\"}]",
+                        "[{\"type\":\"DOCS\",\"title\":\"Cache project material\"}]",
+                        new BigDecimal("10.0"),
+                        ProgressStatus.TODO,
+                        null,
+                        null
+                )
+        );
+    }
+
+    private LearningRoadmap roadmap(Long id, Integer version, Integer totalWeeks, String summary, Instant createdAt) {
+        LearningRoadmap roadmap = mock(LearningRoadmap.class);
+        given(roadmap.getId()).willReturn(id);
+        given(roadmap.getVersion()).willReturn(version);
+        given(roadmap.getTotalWeeks()).willReturn(totalWeeks);
+        given(roadmap.getSummary()).willReturn(summary);
+        given(roadmap.getCreatedAt()).willReturn(createdAt);
+        return roadmap;
+    }
+
+    private RoadmapWeek roadmapWeek(Long id, Integer weekNumber, String topic, BigDecimal estimatedHours) {
+        RoadmapWeek roadmapWeek = mock(RoadmapWeek.class);
+        given(roadmapWeek.getId()).willReturn(id);
+        given(roadmapWeek.getWeekNumber()).willReturn(weekNumber);
+        given(roadmapWeek.getTopic()).willReturn(topic);
+        given(roadmapWeek.getReasonText()).willReturn("reason for " + topic);
+        given(roadmapWeek.getTasksJson()).willReturn("[{\"type\":\"READ_DOCS\",\"title\":\"" + topic + " task\"}]");
+        given(roadmapWeek.getMaterialsJson()).willReturn("[{\"type\":\"DOCS\",\"title\":\"" + topic + " material\"}]");
+        given(roadmapWeek.getEstimatedHours()).willReturn(estimatedHours);
+        return roadmapWeek;
+    }
+}


### PR DESCRIPTION
Closes #65

## 왜 필요한가
로드맵 상세 API 구현자가 `roadmap_payload`가 아니라 `roadmap_weeks + progress_logs` 기준을 재사용해야 합니다.

## 변경 요약
- roadmap detail snapshot record/service 추가
- 로드맵 소유권 조회와 주차 원본 조립 추가
- 주차별 최신 progress 상태/note/updatedAt 조립 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests com.back.coach.domain.roadmap.RoadmapDetailSnapshotServiceTest` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과