### PR TITLE
feat(roadmap): 진도 append-only 저장 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressCommandResult.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressCommandResult.java
@@ -1,0 +1,13 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+
+import java.time.Instant;
+
+public record RoadmapProgressCommandResult(
+        Long progressLogId,
+        Long roadmapWeekId,
+        ProgressStatus status,
+        Instant savedAt
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/RoadmapProgressCommandService.java
@@ -1,0 +1,84 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoadmapProgressCommandService {
+
+    private static final int MAX_NOTE_LENGTH = 1000;
+
+    private final LearningRoadmapRepository learningRoadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
+    private final ProgressLogRepository progressLogRepository;
+
+    public RoadmapProgressCommandService(
+            LearningRoadmapRepository learningRoadmapRepository,
+            RoadmapWeekRepository roadmapWeekRepository,
+            ProgressLogRepository progressLogRepository
+    ) {
+        this.learningRoadmapRepository = learningRoadmapRepository;
+        this.roadmapWeekRepository = roadmapWeekRepository;
+        this.progressLogRepository = progressLogRepository;
+    }
+
+    public RoadmapProgressCommandResult appendProgress(
+            Long userId,
+            Long roadmapId,
+            Long roadmapWeekId,
+            ProgressStatus nextStatus,
+            String note
+    ) {
+        validateNextStatus(nextStatus);
+        validateNote(note);
+        ensureRoadmapBelongsToUser(userId, roadmapId);
+        ensureRoadmapWeekBelongsToRoadmap(roadmapId, roadmapWeekId);
+        ProgressTransitionValidator.validate(currentStatus(userId, roadmapWeekId), nextStatus);
+
+        ProgressLog progressLog = ProgressLog.create(userId, roadmapWeekId, nextStatus, note);
+        ProgressLog savedProgressLog = progressLogRepository.save(progressLog);
+
+        return new RoadmapProgressCommandResult(
+                savedProgressLog.getId(),
+                savedProgressLog.getRoadmapWeekId(),
+                savedProgressLog.getStatus(),
+                savedProgressLog.getCreatedAt()
+        );
+    }
+
+    private void validateNextStatus(ProgressStatus nextStatus) {
+        if (nextStatus == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "진도 상태는 필수입니다.");
+        }
+    }
+
+    private void validateNote(String note) {
+        if (note != null && note.length() > MAX_NOTE_LENGTH) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "진도 메모는 1000자를 넘을 수 없습니다.");
+        }
+    }
+
+    private ProgressStatus currentStatus(Long userId, Long roadmapWeekId) {
+        return progressLogRepository.findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(userId, roadmapWeekId)
+                .map(ProgressLog::getStatus)
+                .orElse(null);
+    }
+
+    private void ensureRoadmapBelongsToUser(Long userId, Long roadmapId) {
+        if (learningRoadmapRepository.findByIdAndUserId(roadmapId, userId).isEmpty()) {
+            throw new ServiceException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+
+    private void ensureRoadmapWeekBelongsToRoadmap(Long roadmapId, Long roadmapWeekId) {
+        if (roadmapWeekRepository.findByIdAndRoadmapId(roadmapWeekId, roadmapId).isEmpty()) {
+            throw new ServiceException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/ProgressLog.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/ProgressLog.java
@@ -42,4 +42,14 @@ public class ProgressLog extends BaseEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    public static ProgressLog create(Long userId, Long roadmapWeekId, ProgressStatus status, String note) {
+        ProgressLog progressLog = new ProgressLog();
+        progressLog.userId = userId;
+        progressLog.roadmapWeekId = roadmapWeekId;
+        progressLog.status = status;
+        progressLog.note = note;
+        progressLog.completedAt = status == ProgressStatus.DONE ? Instant.now() : null;
+        return progressLog;
+    }
 }

--- a/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapProgressCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/RoadmapProgressCommandServiceTest.java
@@ -1,0 +1,243 @@
+package com.back.coach.domain.roadmap;
+
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.ProgressLog;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.ProgressLogRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapProgressCommandServiceTest {
+
+    @Mock
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Mock
+    private RoadmapWeekRepository roadmapWeekRepository;
+
+    @Mock
+    private ProgressLogRepository progressLogRepository;
+
+    @InjectMocks
+    private RoadmapProgressCommandService roadmapProgressCommandService;
+
+    @Test
+    void appendProgress_whenRoadmapDoesNotBelongToUser_throwsResourceNotFound() {
+        given(learningRoadmapRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.DONE,
+                "완료"
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        verifyNoInteractions(roadmapWeekRepository, progressLogRepository);
+    }
+
+    @Test
+    void appendProgress_whenRoadmapWeekDoesNotBelongToRoadmap_throwsResourceNotFound() {
+        givenRoadmapBelongsToUser(1L, 10L);
+        given(roadmapWeekRepository.findByIdAndRoadmapId(100L, 10L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.DONE,
+                "완료"
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        verifyNoInteractions(progressLogRepository);
+    }
+
+    @Test
+    void appendProgress_whenInitialStatusToDone_savesNewProgressLogWithCompletedAt() {
+        Instant savedAt = Instant.parse("2026-04-28T01:00:00Z");
+        ProgressLog savedProgressLog = savedProgressLog(900L, 100L, ProgressStatus.DONE, savedAt);
+        givenRoadmapBelongsToUser(1L, 10L);
+        givenRoadmapWeekBelongsToRoadmap(10L, 100L);
+        given(progressLogRepository.findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(1L, 100L))
+                .willReturn(Optional.empty());
+        given(progressLogRepository.save(any(ProgressLog.class)))
+                .willReturn(savedProgressLog);
+
+        RoadmapProgressCommandResult result = roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.DONE,
+                "TTL 정리 완료"
+        );
+
+        ArgumentCaptor<ProgressLog> captor = ArgumentCaptor.forClass(ProgressLog.class);
+        verify(progressLogRepository).save(captor.capture());
+        ProgressLog savedArgument = captor.getValue();
+        assertThat(savedArgument.getUserId()).isEqualTo(1L);
+        assertThat(savedArgument.getRoadmapWeekId()).isEqualTo(100L);
+        assertThat(savedArgument.getStatus()).isEqualTo(ProgressStatus.DONE);
+        assertThat(savedArgument.getNote()).isEqualTo("TTL 정리 완료");
+        assertThat(savedArgument.getCompletedAt()).isNotNull();
+        assertThat(result).isEqualTo(new RoadmapProgressCommandResult(
+                900L,
+                100L,
+                ProgressStatus.DONE,
+                savedAt
+        ));
+    }
+
+    @Test
+    void appendProgress_whenAllowedTransition_savesNewProgressLogWithoutCompletedAtForNonDone() {
+        Instant savedAt = Instant.parse("2026-04-28T01:00:00Z");
+        ProgressLog latestProgressLog = latestProgressLog(100L, ProgressStatus.DONE);
+        ProgressLog savedProgressLog = savedProgressLog(901L, 100L, ProgressStatus.IN_PROGRESS, savedAt);
+        givenRoadmapBelongsToUser(1L, 10L);
+        givenRoadmapWeekBelongsToRoadmap(10L, 100L);
+        given(progressLogRepository.findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(1L, 100L))
+                .willReturn(Optional.of(latestProgressLog));
+        given(progressLogRepository.save(any(ProgressLog.class)))
+                .willReturn(savedProgressLog);
+
+        RoadmapProgressCommandResult result = roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.IN_PROGRESS,
+                "다시 보완"
+        );
+
+        ArgumentCaptor<ProgressLog> captor = ArgumentCaptor.forClass(ProgressLog.class);
+        verify(progressLogRepository).save(captor.capture());
+        ProgressLog savedArgument = captor.getValue();
+        assertThat(savedArgument.getStatus()).isEqualTo(ProgressStatus.IN_PROGRESS);
+        assertThat(savedArgument.getCompletedAt()).isNull();
+        assertThat(result).isEqualTo(new RoadmapProgressCommandResult(
+                901L,
+                100L,
+                ProgressStatus.IN_PROGRESS,
+                savedAt
+        ));
+    }
+
+    @Test
+    void appendProgress_whenSameStatus_throwsConflict() {
+        ProgressLog latestProgressLog = latestProgressLog(100L, ProgressStatus.DONE);
+        givenRoadmapBelongsToUser(1L, 10L);
+        givenRoadmapWeekBelongsToRoadmap(10L, 100L);
+        given(progressLogRepository.findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(1L, 100L))
+                .willReturn(Optional.of(latestProgressLog));
+
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.DONE,
+                null
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void appendProgress_whenForbiddenTransition_throwsConflict() {
+        ProgressLog latestProgressLog = latestProgressLog(100L, ProgressStatus.DONE);
+        givenRoadmapBelongsToUser(1L, 10L);
+        givenRoadmapWeekBelongsToRoadmap(10L, 100L);
+        given(progressLogRepository.findTopByUserIdAndRoadmapWeekIdOrderByCreatedAtDesc(1L, 100L))
+                .willReturn(Optional.of(latestProgressLog));
+
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.TODO,
+                null
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void appendProgress_whenNextStatusIsNull_throwsInvalidInput() {
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(1L, 10L, 100L, null, null))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        verifyNoInteractions(learningRoadmapRepository, roadmapWeekRepository, progressLogRepository);
+    }
+
+    @Test
+    void appendProgress_whenNoteIsTooLong_throwsInvalidInput() {
+        String tooLongNote = "a".repeat(1001);
+
+        assertThatThrownBy(() -> roadmapProgressCommandService.appendProgress(
+                1L,
+                10L,
+                100L,
+                ProgressStatus.DONE,
+                tooLongNote
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+        verifyNoInteractions(learningRoadmapRepository, roadmapWeekRepository, progressLogRepository);
+    }
+
+    private void givenRoadmapBelongsToUser(Long userId, Long roadmapId) {
+        LearningRoadmap roadmap = mock(LearningRoadmap.class);
+        given(learningRoadmapRepository.findByIdAndUserId(roadmapId, userId)).willReturn(Optional.of(roadmap));
+    }
+
+    private void givenRoadmapWeekBelongsToRoadmap(Long roadmapId, Long roadmapWeekId) {
+        RoadmapWeek roadmapWeek = mock(RoadmapWeek.class);
+        given(roadmapWeekRepository.findByIdAndRoadmapId(roadmapWeekId, roadmapId)).willReturn(Optional.of(roadmapWeek));
+    }
+
+    private ProgressLog latestProgressLog(Long roadmapWeekId, ProgressStatus status) {
+        ProgressLog progressLog = mock(ProgressLog.class);
+        given(progressLog.getStatus()).willReturn(status);
+        return progressLog;
+    }
+
+    private ProgressLog savedProgressLog(
+            Long progressLogId,
+            Long roadmapWeekId,
+            ProgressStatus status,
+            Instant createdAt
+    ) {
+        ProgressLog progressLog = mock(ProgressLog.class);
+        given(progressLog.getId()).willReturn(progressLogId);
+        given(progressLog.getRoadmapWeekId()).willReturn(roadmapWeekId);
+        given(progressLog.getStatus()).willReturn(status);
+        given(progressLog.getCreatedAt()).willReturn(createdAt);
+        return progressLog;
+    }
+}


### PR DESCRIPTION
Closes #67

## 왜 필요한가
진도 저장 API 구현자가 같은 append-only/상태 전이 규칙을 재사용해야 합니다.

## 변경 요약
- progress command service 추가
- ProgressLog 생성 factory 추가
- 소유권/소속 확인, 상태 전이, note 길이, append 저장 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests com.back.coach.domain.roadmap.RoadmapProgressCommandServiceTest` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과