### PR TITLE
feat(api): 진도 저장 API 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressController.java
+++ b/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressController.java
@@ -1,0 +1,43 @@
+package com.back.coach.api.roadmap;
+
+import com.back.coach.domain.roadmap.RoadmapProgressCommandResult;
+import com.back.coach.domain.roadmap.RoadmapProgressCommandService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/roadmaps/{roadmapId}/progress", produces = MediaType.APPLICATION_JSON_VALUE)
+public class RoadmapProgressController {
+
+    private final RoadmapProgressCommandService roadmapProgressCommandService;
+
+    public RoadmapProgressController(RoadmapProgressCommandService roadmapProgressCommandService) {
+        this.roadmapProgressCommandService = roadmapProgressCommandService;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<RoadmapProgressResponse> appendProgress(
+            Authentication authentication,
+            @PathVariable Long roadmapId,
+            @Valid @RequestBody RoadmapProgressRequest request
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        RoadmapProgressCommandResult result = roadmapProgressCommandService.appendProgress(
+                authenticatedUser.userId(),
+                roadmapId,
+                request.roadmapWeekId(),
+                request.status(),
+                request.note()
+        );
+
+        return ApiResponse.success(RoadmapProgressResponse.from(result));
+    }
+}

--- a/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressRequest.java
+++ b/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressRequest.java
@@ -1,0 +1,12 @@
+package com.back.coach.api.roadmap;
+
+import com.back.coach.global.code.ProgressStatus;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RoadmapProgressRequest(
+        @NotNull Long roadmapWeekId,
+        @NotNull ProgressStatus status,
+        @Size(max = 1000) String note
+) {
+}

--- a/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressResponse.java
+++ b/backend/src/main/java/com/back/coach/api/roadmap/RoadmapProgressResponse.java
@@ -1,0 +1,23 @@
+package com.back.coach.api.roadmap;
+
+import com.back.coach.domain.roadmap.RoadmapProgressCommandResult;
+import com.back.coach.global.code.ProgressStatus;
+
+import java.time.Instant;
+
+public record RoadmapProgressResponse(
+        String progressLogId,
+        String roadmapWeekId,
+        ProgressStatus status,
+        Instant savedAt
+) {
+
+    public static RoadmapProgressResponse from(RoadmapProgressCommandResult result) {
+        return new RoadmapProgressResponse(
+                String.valueOf(result.progressLogId()),
+                String.valueOf(result.roadmapWeekId()),
+                result.status(),
+                result.savedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/back/coach/global/config/JacksonConfig.java
@@ -1,6 +1,7 @@
 package com.back.coach.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,7 @@ public class JacksonConfig {
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
                 .findAndAddModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .build();
     }
 }

--- a/backend/src/test/java/com/back/coach/api/roadmap/RoadmapProgressControllerTest.java
+++ b/backend/src/test/java/com/back/coach/api/roadmap/RoadmapProgressControllerTest.java
@@ -1,0 +1,165 @@
+package com.back.coach.api.roadmap;
+
+import com.back.coach.domain.roadmap.RoadmapProgressCommandResult;
+import com.back.coach.domain.roadmap.RoadmapProgressCommandService;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapProgressControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private RoadmapProgressCommandService roadmapProgressCommandService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new RoadmapProgressController(roadmapProgressCommandService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void appendProgress_whenValidRequest_returnsProgressResponse() throws Exception {
+        Instant savedAt = Instant.parse("2026-04-28T01:00:00Z");
+        given(roadmapProgressCommandService.appendProgress(1L, 10L, 100L, ProgressStatus.DONE, "완료"))
+                .willReturn(new RoadmapProgressCommandResult(900L, 100L, ProgressStatus.DONE, savedAt));
+
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L,
+                                "status", "DONE",
+                                "note", "완료"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.progressLogId").value("900"))
+                .andExpect(jsonPath("$.data.roadmapWeekId").value("100"))
+                .andExpect(jsonPath("$.data.status").value("DONE"))
+                .andExpect(jsonPath("$.data.savedAt").value("2026-04-28T01:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(roadmapProgressCommandService).appendProgress(1L, 10L, 100L, ProgressStatus.DONE, "완료");
+    }
+
+    @Test
+    void appendProgress_whenRoadmapWeekIdMissing_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "status", "DONE"
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(roadmapProgressCommandService);
+    }
+
+    @Test
+    void appendProgress_whenStatusMissing_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(roadmapProgressCommandService);
+    }
+
+    @Test
+    void appendProgress_whenNoteIsTooLong_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L,
+                                "status", "DONE",
+                                "note", "a".repeat(1001)
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(roadmapProgressCommandService);
+    }
+
+    @Test
+    void appendProgress_whenServiceThrowsResourceNotFound_returnsNotFound() throws Exception {
+        given(roadmapProgressCommandService.appendProgress(any(), any(), any(), any(), any()))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L,
+                                "status", "DONE"
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void appendProgress_whenServiceThrowsConflict_returnsConflict() throws Exception {
+        given(roadmapProgressCommandService.appendProgress(any(), any(), any(), any(), any()))
+                .willThrow(new ServiceException(ErrorCode.CONFLICT));
+
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L,
+                                "status", "DONE"
+                        ))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CONFLICT"));
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}


### PR DESCRIPTION
Closes #69

## 왜 필요한가
로드맵 진도 변경 요청이 같은 append-only 저장 규칙과 상태 전이 검증을 타야 합니다.

## 변경 요약
- progress 저장 controller/request/response 추가
- API 응답의 시간 값을 ISO 문자열로 반환하도록 Jackson 설정 조정
- 정상 저장, 요청 검증, 서비스 예외 매핑 테스트 추가

## 테스트
- `backend`에서 `./gradlew.bat test --tests com.back.coach.api.roadmap.RoadmapProgressControllerTest` 통과
- `backend`에서 `./gradlew.bat test` 통과
- `backend`에서 `./gradlew.bat prVerification` 통과