### PR TITLE
feat(roadmap): 로드맵 상세 조회 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
@@ -1,0 +1,44 @@
+package com.back.coach.domain.roadmap.controller;
+
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
+import com.back.coach.domain.roadmap.service.RoadmapDetailSnapshotService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/roadmaps", produces = MediaType.APPLICATION_JSON_VALUE)
+public class RoadmapDetailController {
+
+    private final RoadmapDetailSnapshotService roadmapDetailSnapshotService;
+    private final ObjectMapper objectMapper;
+
+    public RoadmapDetailController(
+            RoadmapDetailSnapshotService roadmapDetailSnapshotService,
+            ObjectMapper objectMapper
+    ) {
+        this.roadmapDetailSnapshotService = roadmapDetailSnapshotService;
+        this.objectMapper = objectMapper;
+    }
+
+    @GetMapping("/{roadmapId}")
+    public ApiResponse<RoadmapDetailResponse> findRoadmap(
+            Authentication authentication,
+            @PathVariable Long roadmapId
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        RoadmapDetailSnapshot snapshot = roadmapDetailSnapshotService.findSnapshot(
+                authenticatedUser.userId(),
+                roadmapId
+        );
+
+        return ApiResponse.success(RoadmapDetailResponse.from(snapshot, objectMapper));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapDetailResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapDetailResponse.java
@@ -1,0 +1,76 @@
+package com.back.coach.domain.roadmap.dto;
+
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record RoadmapDetailResponse(
+        String roadmapId,
+        Integer version,
+        Integer totalWeeks,
+        String summary,
+        Instant createdAt,
+        List<WeekResponse> weeks
+) {
+
+    private static final TypeReference<List<Map<String, Object>>> JSON_ARRAY_TYPE = new TypeReference<>() {
+    };
+
+    public static RoadmapDetailResponse from(RoadmapDetailSnapshot snapshot, ObjectMapper objectMapper) {
+        return new RoadmapDetailResponse(
+                String.valueOf(snapshot.roadmapId()),
+                snapshot.version(),
+                snapshot.totalWeeks(),
+                snapshot.summary(),
+                snapshot.createdAt(),
+                snapshot.weeks().stream()
+                        .map(week -> WeekResponse.from(week, objectMapper))
+                        .toList()
+        );
+    }
+
+    public record WeekResponse(
+            String roadmapWeekId,
+            Integer weekNumber,
+            String topic,
+            String reason,
+            List<Map<String, Object>> tasks,
+            List<Map<String, Object>> materials,
+            BigDecimal estimatedHours,
+            ProgressStatus progressStatus,
+            String progressNote,
+            Instant progressUpdatedAt
+    ) {
+
+        private static WeekResponse from(RoadmapDetailSnapshot.WeekSnapshot week, ObjectMapper objectMapper) {
+            return new WeekResponse(
+                    String.valueOf(week.roadmapWeekId()),
+                    week.weekNumber(),
+                    week.topic(),
+                    week.reasonText(),
+                    parseJsonArray(week.tasksJson(), objectMapper),
+                    parseJsonArray(week.materialsJson(), objectMapper),
+                    week.estimatedHours(),
+                    week.progressStatus(),
+                    week.progressNote(),
+                    week.progressUpdatedAt()
+            );
+        }
+    }
+
+    private static List<Map<String, Object>> parseJsonArray(String json, ObjectMapper objectMapper) {
+        try {
+            return objectMapper.readValue(json, JSON_ARRAY_TYPE);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapDetailControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapDetailControllerTest.java
@@ -1,0 +1,154 @@
+package com.back.coach.domain.roadmap.controller;
+
+import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
+import com.back.coach.domain.roadmap.service.RoadmapDetailSnapshotService;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapDetailControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private RoadmapDetailSnapshotService roadmapDetailSnapshotService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new RoadmapDetailController(roadmapDetailSnapshotService, objectMapper))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void findRoadmap_whenRoadmapExists_returnsRoadmapDetailWithLatestProgress() throws Exception {
+        Instant roadmapCreatedAt = Instant.parse("2026-04-28T01:00:00Z");
+        Instant progressUpdatedAt = Instant.parse("2026-04-28T02:00:00Z");
+        given(roadmapDetailSnapshotService.findSnapshot(1L, 10L))
+                .willReturn(new RoadmapDetailSnapshot(
+                        10L,
+                        2,
+                        2,
+                        "Redis 중심 로드맵",
+                        roadmapCreatedAt,
+                        List.of(new RoadmapDetailSnapshot.WeekSnapshot(
+                                100L,
+                                1,
+                                "Redis 기초",
+                                "캐시 설계 경험 보완",
+                                "[{\"type\":\"READ_DOCS\",\"title\":\"Redis 공식 문서 읽기\"}]",
+                                "[{\"type\":\"DOCS\",\"title\":\"Redis Documentation\",\"url\":\"https://redis.io/docs\"}]",
+                                new BigDecimal("8.0"),
+                                ProgressStatus.DONE,
+                                "TTL 정리 완료",
+                                progressUpdatedAt
+                        ))
+                ));
+
+        mockMvc.perform(get("/api/roadmaps/{roadmapId}", 10L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roadmapId").value("10"))
+                .andExpect(jsonPath("$.data.version").value(2))
+                .andExpect(jsonPath("$.data.totalWeeks").value(2))
+                .andExpect(jsonPath("$.data.summary").value("Redis 중심 로드맵"))
+                .andExpect(jsonPath("$.data.createdAt").value("2026-04-28T01:00:00Z"))
+                .andExpect(jsonPath("$.data.weeks[0].roadmapWeekId").value("100"))
+                .andExpect(jsonPath("$.data.weeks[0].weekNumber").value(1))
+                .andExpect(jsonPath("$.data.weeks[0].topic").value("Redis 기초"))
+                .andExpect(jsonPath("$.data.weeks[0].reason").value("캐시 설계 경험 보완"))
+                .andExpect(jsonPath("$.data.weeks[0].tasks[0].type").value("READ_DOCS"))
+                .andExpect(jsonPath("$.data.weeks[0].tasks[0].title").value("Redis 공식 문서 읽기"))
+                .andExpect(jsonPath("$.data.weeks[0].materials[0].type").value("DOCS"))
+                .andExpect(jsonPath("$.data.weeks[0].materials[0].title").value("Redis Documentation"))
+                .andExpect(jsonPath("$.data.weeks[0].materials[0].url").value("https://redis.io/docs"))
+                .andExpect(jsonPath("$.data.weeks[0].estimatedHours").value(8.0))
+                .andExpect(jsonPath("$.data.weeks[0].progressStatus").value("DONE"))
+                .andExpect(jsonPath("$.data.weeks[0].progressNote").value("TTL 정리 완료"))
+                .andExpect(jsonPath("$.data.weeks[0].progressUpdatedAt").value("2026-04-28T02:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(roadmapDetailSnapshotService).findSnapshot(1L, 10L);
+    }
+
+    @Test
+    void findRoadmap_whenRoadmapDoesNotBelongToUser_returnsNotFound() throws Exception {
+        given(roadmapDetailSnapshotService.findSnapshot(1L, 10L))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/roadmaps/{roadmapId}", 10L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void findRoadmap_whenStoredWeekJsonIsInvalid_returnsInternalServerError() throws Exception {
+        given(roadmapDetailSnapshotService.findSnapshot(1L, 10L))
+                .willReturn(new RoadmapDetailSnapshot(
+                        10L,
+                        1,
+                        1,
+                        "잘못된 주차 JSON",
+                        Instant.parse("2026-04-28T01:00:00Z"),
+                        List.of(new RoadmapDetailSnapshot.WeekSnapshot(
+                                100L,
+                                1,
+                                "Redis 기초",
+                                "캐시 설계 경험 보완",
+                                "not-json",
+                                "[]",
+                                new BigDecimal("8.0"),
+                                ProgressStatus.TODO,
+                                null,
+                                null
+                        ))
+                ));
+
+        mockMvc.perform(get("/api/roadmaps/{roadmapId}", 10L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -35,7 +35,7 @@ class OpenApiContractTest {
         assertThat(operation(paths, "/api/profiles", "post")
                 .get("x-implementation-status")).isEqualTo("planned");
         assertThat(operation(paths, "/api/roadmaps/{roadmapId}", "get")
-                .get("x-implementation-status")).isEqualTo("planned");
+                .get("x-implementation-status")).isEqualTo("implemented");
     }
 
     @Test

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -296,7 +296,7 @@ paths:
         - Roadmaps
       summary: Get learning roadmap
       operationId: getRoadmap
-      x-implementation-status: planned
+      x-implementation-status: implemented
       parameters:
         - $ref: '#/components/parameters/RoadmapId'
       responses:


### PR DESCRIPTION
﻿## 작업 내용
- `GET /api/roadmaps/{roadmapId}`를 추가했습니다.
- 로드맵 주차 원본과 최신 진도 snapshot을 함께 반환합니다.
- `tasksJson`, `materialsJson`는 응답에서 JSON 배열인 `tasks`, `materials`로 변환합니다.
- OpenAPI에서 로드맵 조회 API 구현 상태를 `implemented`로 갱신했습니다.

## 필요한 이유
진도 저장 후 프론트가 최신 로드맵 상태를 다시 불러올 API가 필요합니다. 이 API가 있어야 새로고침이나 화면 재진입 시 주차별 계획과 현재 진도 상태를 일관되게 표시할 수 있습니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #77
