### PR TITLE
feat(dashboard): 대시보드 조회 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/dashboard/controller/DashboardController.java
+++ b/backend/src/main/java/com/back/coach/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,31 @@
+package com.back.coach.domain.dashboard.controller;
+
+import com.back.coach.domain.dashboard.dto.DashboardResponse;
+import com.back.coach.domain.dashboard.dto.DashboardSnapshot;
+import com.back.coach.domain.dashboard.service.DashboardSnapshotService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/dashboard", produces = MediaType.APPLICATION_JSON_VALUE)
+public class DashboardController {
+
+    private final DashboardSnapshotService dashboardSnapshotService;
+
+    public DashboardController(DashboardSnapshotService dashboardSnapshotService) {
+        this.dashboardSnapshotService = dashboardSnapshotService;
+    }
+
+    @GetMapping
+    public ApiResponse<DashboardResponse> findDashboard(Authentication authentication) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        DashboardSnapshot snapshot = dashboardSnapshotService.findSnapshot(authenticatedUser.userId());
+
+        return ApiResponse.success(DashboardResponse.from(snapshot));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/dashboard/dto/DashboardResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/dashboard/dto/DashboardResponse.java
@@ -1,0 +1,135 @@
+package com.back.coach.domain.dashboard.dto;
+
+import com.back.coach.global.code.CurrentLevel;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+public record DashboardResponse(
+        String userId,
+        ProfileSummaryResponse profile,
+        GithubAnalysisSummaryResponse githubAnalysis,
+        DiagnosisSummaryResponse diagnosis,
+        RoadmapSummaryResponse roadmap
+) {
+
+    public static DashboardResponse from(DashboardSnapshot snapshot) {
+        return new DashboardResponse(
+                String.valueOf(snapshot.userId()),
+                ProfileSummaryResponse.from(snapshot.profile()),
+                GithubAnalysisSummaryResponse.from(snapshot.githubAnalysis()),
+                DiagnosisSummaryResponse.from(snapshot.diagnosis()),
+                RoadmapSummaryResponse.from(snapshot.roadmap())
+        );
+    }
+
+    public record ProfileSummaryResponse(
+            String profileId,
+            String jobRoleId,
+            CurrentLevel currentLevel,
+            Integer weeklyStudyHours,
+            LocalDate targetDate,
+            Instant updatedAt
+    ) {
+
+        private static ProfileSummaryResponse from(DashboardSnapshot.ProfileSummary summary) {
+            if (summary == null) {
+                return null;
+            }
+            return new ProfileSummaryResponse(
+                    String.valueOf(summary.profileId()),
+                    String.valueOf(summary.jobRoleId()),
+                    summary.currentLevel(),
+                    summary.weeklyStudyHours(),
+                    summary.targetDate(),
+                    summary.updatedAt()
+            );
+        }
+    }
+
+    public record GithubAnalysisSummaryResponse(
+            String githubAnalysisId,
+            Integer version,
+            String summary,
+            Instant createdAt
+    ) {
+
+        private static GithubAnalysisSummaryResponse from(DashboardSnapshot.GithubAnalysisSummary summary) {
+            if (summary == null) {
+                return null;
+            }
+            return new GithubAnalysisSummaryResponse(
+                    String.valueOf(summary.githubAnalysisId()),
+                    summary.version(),
+                    summary.summary(),
+                    summary.createdAt()
+            );
+        }
+    }
+
+    public record DiagnosisSummaryResponse(
+            String diagnosisId,
+            Integer version,
+            String summary,
+            Instant createdAt
+    ) {
+
+        private static DiagnosisSummaryResponse from(DashboardSnapshot.DiagnosisSummary summary) {
+            if (summary == null) {
+                return null;
+            }
+            return new DiagnosisSummaryResponse(
+                    String.valueOf(summary.diagnosisId()),
+                    summary.version(),
+                    summary.summary(),
+                    summary.createdAt()
+            );
+        }
+    }
+
+    public record RoadmapSummaryResponse(
+            String roadmapId,
+            Integer version,
+            Integer totalWeeks,
+            String summary,
+            Instant createdAt,
+            ProgressSummaryResponse progress
+    ) {
+
+        private static RoadmapSummaryResponse from(DashboardSnapshot.RoadmapSummary summary) {
+            if (summary == null) {
+                return null;
+            }
+            return new RoadmapSummaryResponse(
+                    String.valueOf(summary.roadmapId()),
+                    summary.version(),
+                    summary.totalWeeks(),
+                    summary.summary(),
+                    summary.createdAt(),
+                    ProgressSummaryResponse.from(summary.progress())
+            );
+        }
+    }
+
+    public record ProgressSummaryResponse(
+            int totalWeeks,
+            int todoWeeks,
+            int inProgressWeeks,
+            int doneWeeks,
+            int skippedWeeks
+    ) {
+
+        private static ProgressSummaryResponse from(DashboardSnapshot.ProgressSummary summary) {
+            if (summary == null) {
+                return null;
+            }
+            return new ProgressSummaryResponse(
+                    summary.totalWeeks(),
+                    summary.todoWeeks(),
+                    summary.inProgressWeeks(),
+                    summary.doneWeeks(),
+                    summary.skippedWeeks()
+            );
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/dashboard/controller/DashboardControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/dashboard/controller/DashboardControllerTest.java
@@ -1,0 +1,150 @@
+package com.back.coach.domain.dashboard.controller;
+
+import com.back.coach.domain.dashboard.dto.DashboardSnapshot;
+import com.back.coach.domain.dashboard.service.DashboardSnapshotService;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private DashboardSnapshotService dashboardSnapshotService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new DashboardController(dashboardSnapshotService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void findDashboard_whenLatestResultsExist_returnsDashboardSnapshot() throws Exception {
+        Instant profileUpdatedAt = Instant.parse("2026-04-28T01:00:00Z");
+        Instant githubAnalysisCreatedAt = Instant.parse("2026-04-28T02:00:00Z");
+        Instant diagnosisCreatedAt = Instant.parse("2026-04-28T03:00:00Z");
+        Instant roadmapCreatedAt = Instant.parse("2026-04-28T04:00:00Z");
+        given(dashboardSnapshotService.findSnapshot(1L))
+                .willReturn(new DashboardSnapshot(
+                        1L,
+                        new DashboardSnapshot.ProfileSummary(
+                                10L,
+                                100L,
+                                CurrentLevel.JUNIOR,
+                                12,
+                                LocalDate.of(2026, 12, 31),
+                                profileUpdatedAt
+                        ),
+                        new DashboardSnapshot.GithubAnalysisSummary(
+                                20L,
+                                3,
+                                "latest analysis",
+                                githubAnalysisCreatedAt
+                        ),
+                        new DashboardSnapshot.DiagnosisSummary(
+                                30L,
+                                4,
+                                "latest diagnosis",
+                                diagnosisCreatedAt
+                        ),
+                        new DashboardSnapshot.RoadmapSummary(
+                                40L,
+                                2,
+                                8,
+                                "latest roadmap",
+                                roadmapCreatedAt,
+                                new DashboardSnapshot.ProgressSummary(4, 1, 1, 1, 1)
+                        )
+                ));
+
+        mockMvc.perform(get("/api/dashboard")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value("1"))
+                .andExpect(jsonPath("$.data.profile.profileId").value("10"))
+                .andExpect(jsonPath("$.data.profile.jobRoleId").value("100"))
+                .andExpect(jsonPath("$.data.profile.currentLevel").value("JUNIOR"))
+                .andExpect(jsonPath("$.data.profile.weeklyStudyHours").value(12))
+                .andExpect(jsonPath("$.data.profile.targetDate").value("2026-12-31"))
+                .andExpect(jsonPath("$.data.profile.updatedAt").value("2026-04-28T01:00:00Z"))
+                .andExpect(jsonPath("$.data.githubAnalysis.githubAnalysisId").value("20"))
+                .andExpect(jsonPath("$.data.githubAnalysis.version").value(3))
+                .andExpect(jsonPath("$.data.githubAnalysis.summary").value("latest analysis"))
+                .andExpect(jsonPath("$.data.githubAnalysis.createdAt").value("2026-04-28T02:00:00Z"))
+                .andExpect(jsonPath("$.data.diagnosis.diagnosisId").value("30"))
+                .andExpect(jsonPath("$.data.diagnosis.version").value(4))
+                .andExpect(jsonPath("$.data.diagnosis.summary").value("latest diagnosis"))
+                .andExpect(jsonPath("$.data.diagnosis.createdAt").value("2026-04-28T03:00:00Z"))
+                .andExpect(jsonPath("$.data.roadmap.roadmapId").value("40"))
+                .andExpect(jsonPath("$.data.roadmap.version").value(2))
+                .andExpect(jsonPath("$.data.roadmap.totalWeeks").value(8))
+                .andExpect(jsonPath("$.data.roadmap.summary").value("latest roadmap"))
+                .andExpect(jsonPath("$.data.roadmap.createdAt").value("2026-04-28T04:00:00Z"))
+                .andExpect(jsonPath("$.data.roadmap.progress.totalWeeks").value(4))
+                .andExpect(jsonPath("$.data.roadmap.progress.todoWeeks").value(1))
+                .andExpect(jsonPath("$.data.roadmap.progress.inProgressWeeks").value(1))
+                .andExpect(jsonPath("$.data.roadmap.progress.doneWeeks").value(1))
+                .andExpect(jsonPath("$.data.roadmap.progress.skippedWeeks").value(1))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(dashboardSnapshotService).findSnapshot(1L);
+    }
+
+    @Test
+    void findDashboard_whenLatestResultsDoNotExist_returnsNullSummaries() throws Exception {
+        given(dashboardSnapshotService.findSnapshot(1L))
+                .willReturn(new DashboardSnapshot(1L, null, null, null, null));
+
+        mockMvc.perform(get("/api/dashboard")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value("1"))
+                .andExpect(jsonPath("$.data.profile").value(nullValue()))
+                .andExpect(jsonPath("$.data.githubAnalysis").value(nullValue()))
+                .andExpect(jsonPath("$.data.diagnosis").value(nullValue()))
+                .andExpect(jsonPath("$.data.roadmap").value(nullValue()))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(dashboardSnapshotService).findSnapshot(1L);
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -36,6 +36,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("planned");
         assertThat(operation(paths, "/api/roadmaps/{roadmapId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/dashboard", "get")
+                .get("x-implementation-status")).isEqualTo("implemented");
     }
 
     @Test
@@ -43,7 +45,7 @@ class OpenApiContractTest {
         Map<String, Object> components = mapValue(loadOpenApiDocument(), "components");
         Map<String, Object> schemas = mapValue(components, "schemas");
 
-        assertThat(schemas).containsKeys("ErrorResponse", "ProgressStatus", "CurrentLevel");
+        assertThat(schemas).containsKeys("ErrorResponse", "ProgressStatus", "CurrentLevel", "DashboardApiResponse");
         assertThat(mapValue(schemas, "ProgressStatus").get("enum"))
                 .isEqualTo(List.of("TODO", "IN_PROGRESS", "DONE", "SKIPPED"));
         Map<String, Object> errorResponseProperties = mapValue(mapValue(schemas, "ErrorResponse"), "properties");

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -547,6 +547,64 @@ v1 처리 기준
 
 ---
 
+## 3.6 대시보드 API (v1 확장)
+
+### 3.6.1 대시보드 최신 결과 조회
+
+- Method: `GET`
+- Path: `/api/dashboard`
+
+응답 body
+```json
+{
+  "data": {
+    "userId": "1",
+    "profile": {
+      "profileId": "101",
+      "jobRoleId": "1",
+      "currentLevel": "JUNIOR",
+      "weeklyStudyHours": 10,
+      "targetDate": "2026-08-31",
+      "updatedAt": "2026-04-24T14:10:00Z"
+    },
+    "githubAnalysis": {
+      "githubAnalysisId": "401",
+      "version": 1,
+      "summary": "Spring Boot 기반 백엔드 프로젝트 경험이 확인되었습니다.",
+      "createdAt": "2026-04-24T14:25:00Z"
+    },
+    "diagnosis": {
+      "diagnosisId": "301",
+      "version": 1,
+      "summary": "Redis와 캐시 설계 경험을 보완할 필요가 있습니다.",
+      "createdAt": "2026-04-24T14:30:00Z"
+    },
+    "roadmap": {
+      "roadmapId": "601",
+      "version": 1,
+      "totalWeeks": 12,
+      "summary": "Redis 중심의 백엔드 실무 역량 보완 로드맵입니다.",
+      "createdAt": "2026-04-24T14:40:00Z",
+      "progress": {
+        "totalWeeks": 12,
+        "todoWeeks": 7,
+        "inProgressWeeks": 1,
+        "doneWeeks": 3,
+        "skippedWeeks": 1
+      }
+    }
+  }
+}
+```
+
+조회 규칙
+- 현재 로그인 사용자의 최신 프로필, 최신 GitHub 분석, 최신 진단, 최신 로드맵을 조립한다
+- 아직 생성되지 않은 결과 영역은 `null`로 반환한다
+- 로드맵 진행률은 `progress_logs` 최신 row 기준으로 계산한다
+- 대시보드는 화면 편의용 snapshot이며, 각 결과의 원본 상세 조회를 대체하지 않는다
+
+---
+
 ## 4. v2 확장 API
 
 ## 4.1 코치 세션 생성

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -27,6 +27,8 @@ tags:
     description: Capability diagnosis APIs
   - name: Roadmaps
     description: Learning roadmap and progress APIs
+  - name: Dashboard
+    description: Current user dashboard summary APIs
 
 paths:
   /api/profiles:
@@ -345,6 +347,23 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+
+  /api/dashboard:
+    get:
+      tags:
+        - Dashboard
+      summary: Get current user dashboard
+      operationId: getDashboard
+      x-implementation-status: implemented
+      responses:
+        '200':
+          description: Current user's latest result dashboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardApiResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
 components:
   securitySchemes:
@@ -1321,5 +1340,175 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/RoadmapProgressResponseData'
+        meta:
+          $ref: '#/components/schemas/ApiMeta'
+
+    DashboardProfileSummary:
+      type: object
+      required:
+        - profileId
+        - jobRoleId
+        - currentLevel
+        - updatedAt
+      properties:
+        profileId:
+          type: string
+          example: '101'
+        jobRoleId:
+          type: string
+          example: '1'
+        currentLevel:
+          $ref: '#/components/schemas/CurrentLevel'
+        weeklyStudyHours:
+          type: integer
+          nullable: true
+          example: 10
+        targetDate:
+          type: string
+          format: date
+          nullable: true
+          example: '2026-08-31'
+        updatedAt:
+          type: string
+          format: date-time
+
+    DashboardGithubAnalysisSummary:
+      type: object
+      required:
+        - githubAnalysisId
+        - version
+        - summary
+        - createdAt
+      properties:
+        githubAnalysisId:
+          type: string
+          example: '401'
+        version:
+          type: integer
+          minimum: 1
+          example: 1
+        summary:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    DashboardDiagnosisSummary:
+      type: object
+      required:
+        - diagnosisId
+        - version
+        - summary
+        - createdAt
+      properties:
+        diagnosisId:
+          type: string
+          example: '301'
+        version:
+          type: integer
+          minimum: 1
+          example: 1
+        summary:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    DashboardProgressSummary:
+      type: object
+      required:
+        - totalWeeks
+        - todoWeeks
+        - inProgressWeeks
+        - doneWeeks
+        - skippedWeeks
+      properties:
+        totalWeeks:
+          type: integer
+          minimum: 0
+          example: 12
+        todoWeeks:
+          type: integer
+          minimum: 0
+          example: 7
+        inProgressWeeks:
+          type: integer
+          minimum: 0
+          example: 1
+        doneWeeks:
+          type: integer
+          minimum: 0
+          example: 3
+        skippedWeeks:
+          type: integer
+          minimum: 0
+          example: 1
+
+    DashboardRoadmapSummary:
+      type: object
+      required:
+        - roadmapId
+        - version
+        - totalWeeks
+        - summary
+        - createdAt
+        - progress
+      properties:
+        roadmapId:
+          type: string
+          example: '601'
+        version:
+          type: integer
+          minimum: 1
+          example: 1
+        totalWeeks:
+          type: integer
+          minimum: 1
+          example: 12
+        summary:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        progress:
+          $ref: '#/components/schemas/DashboardProgressSummary'
+
+    Dashboard:
+      type: object
+      required:
+        - userId
+        - profile
+        - githubAnalysis
+        - diagnosis
+        - roadmap
+      properties:
+        userId:
+          type: string
+          example: '1'
+        profile:
+          allOf:
+            - $ref: '#/components/schemas/DashboardProfileSummary'
+          nullable: true
+        githubAnalysis:
+          allOf:
+            - $ref: '#/components/schemas/DashboardGithubAnalysisSummary'
+          nullable: true
+        diagnosis:
+          allOf:
+            - $ref: '#/components/schemas/DashboardDiagnosisSummary'
+          nullable: true
+        roadmap:
+          allOf:
+            - $ref: '#/components/schemas/DashboardRoadmapSummary'
+          nullable: true
+
+    DashboardApiResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/Dashboard'
         meta:
           $ref: '#/components/schemas/ApiMeta'


### PR DESCRIPTION
﻿## 작업 내용
- `GET /api/dashboard`를 추가했습니다.
- 최신 프로필, GitHub 분석, 진단, 로드맵, 진도 요약을 한 번에 반환합니다.
- 대시보드 조회 API의 컨트롤러 테스트를 추가했습니다.
- `docs/03_api_spec_aligned.md`와 `docs/openapi.yml`에 대시보드 조회 계약을 추가했습니다.

## 필요한 이유
프론트가 여러 API와 repository 조회 규칙을 직접 조합하면 화면마다 최신 결과 기준이 달라질 수 있습니다. 서버 기준 최신 snapshot을 한 번에 제공해 대시보드 상태를 일관되게 보여주기 위해 필요합니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #79
