### PR TITLE
feat(profile): 프로필 저장 조회 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
@@ -3,5 +3,9 @@ package com.back.coach.domain.jobrole.repository;
 import com.back.coach.domain.jobrole.entity.JobRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface JobRoleRepository extends JpaRepository<JobRole, Long> {
+
+    Optional<JobRole> findByRoleCodeAndActiveTrue(String roleCode);
 }

--- a/backend/src/main/java/com/back/coach/domain/user/controller/ProfileController.java
+++ b/backend/src/main/java/com/back/coach/domain/user/controller/ProfileController.java
@@ -1,0 +1,46 @@
+package com.back.coach.domain.user.controller;
+
+import com.back.coach.domain.user.dto.ProfileDetailResponse;
+import com.back.coach.domain.user.dto.ProfileSaveRequest;
+import com.back.coach.domain.user.dto.ProfileSaveResponse;
+import com.back.coach.domain.user.dto.ProfileSaveResult;
+import com.back.coach.domain.user.service.ProfileService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/profiles", produces = MediaType.APPLICATION_JSON_VALUE)
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<ProfileSaveResponse> saveProfile(
+            Authentication authentication,
+            @Valid @RequestBody ProfileSaveRequest request
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        ProfileSaveResult result = profileService.saveProfile(authenticatedUser.userId(), request);
+
+        return ApiResponse.success(ProfileSaveResponse.from(result));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<ProfileDetailResponse> findMyProfile(Authentication authentication) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(profileService.findMyProfile(authenticatedUser.userId()));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileDetailResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileDetailResponse.java
@@ -1,0 +1,19 @@
+package com.back.coach.domain.user.dto;
+
+import com.back.coach.global.code.CurrentLevel;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProfileDetailResponse(
+        String profileId,
+        String targetRole,
+        CurrentLevel currentLevel,
+        List<ProfileSkillResponse> skills,
+        List<String> interestAreas,
+        Integer weeklyStudyHours,
+        LocalDate targetDate,
+        String resumeAssetId,
+        String portfolioAssetId
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveRequest.java
@@ -1,0 +1,41 @@
+package com.back.coach.domain.user.dto;
+
+import com.back.coach.global.code.CurrentLevel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProfileSaveRequest(
+        @NotBlank
+        String targetRole,
+
+        @NotNull
+        CurrentLevel currentLevel,
+
+        @NotEmpty
+        @Size(max = 20)
+        List<@Valid ProfileSkillRequest> skills,
+
+        @Size(max = 10)
+        List<@Size(max = 50) String> interestAreas,
+
+        @Min(1)
+        @Max(40)
+        Integer weeklyStudyHours,
+
+        @Future
+        LocalDate targetDate,
+
+        Long resumeAssetId,
+
+        Long portfolioAssetId
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveResponse.java
@@ -1,0 +1,18 @@
+package com.back.coach.domain.user.dto;
+
+import java.time.Instant;
+
+public record ProfileSaveResponse(
+        String profileId,
+        Instant savedAt,
+        String message
+) {
+
+    public static ProfileSaveResponse from(ProfileSaveResult result) {
+        return new ProfileSaveResponse(
+                String.valueOf(result.profileId()),
+                result.savedAt(),
+                "프로필이 저장되었습니다."
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveResult.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSaveResult.java
@@ -1,0 +1,9 @@
+package com.back.coach.domain.user.dto;
+
+import java.time.Instant;
+
+public record ProfileSaveResult(
+        Long profileId,
+        Instant savedAt
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSkillRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSkillRequest.java
@@ -1,0 +1,14 @@
+package com.back.coach.domain.user.dto;
+
+import com.back.coach.global.code.ProficiencyLevel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileSkillRequest(
+        @NotBlank
+        @Size(max = 100)
+        String skillName,
+
+        ProficiencyLevel proficiencyLevel
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSkillResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/user/dto/ProfileSkillResponse.java
@@ -1,0 +1,11 @@
+package com.back.coach.domain.user.dto;
+
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+
+public record ProfileSkillResponse(
+        String skillName,
+        ProficiencyLevel proficiencyLevel,
+        SkillSourceType sourceType
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/user/entity/UserProfile.java
+++ b/backend/src/main/java/com/back/coach/domain/user/entity/UserProfile.java
@@ -46,4 +46,38 @@ public class UserProfile extends BaseTimeEntity {
 
     @Column(name = "portfolio_asset_id")
     private Long portfolioAssetId;
+
+    public static UserProfile create(
+            Long userId,
+            Long jobRoleId,
+            CurrentLevel currentLevel,
+            Integer weeklyStudyHours,
+            LocalDate targetDate,
+            String interestAreasJson,
+            Long resumeAssetId,
+            Long portfolioAssetId
+    ) {
+        UserProfile profile = new UserProfile();
+        profile.userId = userId;
+        profile.update(jobRoleId, currentLevel, weeklyStudyHours, targetDate, interestAreasJson, resumeAssetId, portfolioAssetId);
+        return profile;
+    }
+
+    public void update(
+            Long jobRoleId,
+            CurrentLevel currentLevel,
+            Integer weeklyStudyHours,
+            LocalDate targetDate,
+            String interestAreasJson,
+            Long resumeAssetId,
+            Long portfolioAssetId
+    ) {
+        this.jobRoleId = jobRoleId;
+        this.currentLevel = currentLevel;
+        this.weeklyStudyHours = weeklyStudyHours;
+        this.targetDate = targetDate;
+        this.interestAreasJson = interestAreasJson;
+        this.resumeAssetId = resumeAssetId;
+        this.portfolioAssetId = portfolioAssetId;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/user/entity/UserSkill.java
+++ b/backend/src/main/java/com/back/coach/domain/user/entity/UserSkill.java
@@ -41,4 +41,18 @@ public class UserSkill extends BaseEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    public static UserSkill create(
+            Long userId,
+            String skillName,
+            ProficiencyLevel proficiencyLevel,
+            SkillSourceType sourceType
+    ) {
+        UserSkill skill = new UserSkill();
+        skill.userId = userId;
+        skill.skillName = skillName;
+        skill.proficiencyLevel = proficiencyLevel;
+        skill.sourceType = sourceType;
+        return skill;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserSkillRepository.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.user.repository;
 
 import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.global.code.SkillSourceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public interface UserSkillRepository extends JpaRepository<UserSkill, Long> {
 
     List<UserSkill> findByUserIdOrderBySkillNameAsc(Long userId);
+
+    List<UserSkill> findByUserIdAndSourceTypeOrderBySkillNameAsc(Long userId, SkillSourceType sourceType);
 
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/user/service/ProfileService.java
+++ b/backend/src/main/java/com/back/coach/domain/user/service/ProfileService.java
@@ -1,0 +1,178 @@
+package com.back.coach.domain.user.service;
+
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.user.dto.ProfileDetailResponse;
+import com.back.coach.domain.user.dto.ProfileSaveRequest;
+import com.back.coach.domain.user.dto.ProfileSaveResult;
+import com.back.coach.domain.user.dto.ProfileSkillRequest;
+import com.back.coach.domain.user.dto.ProfileSkillResponse;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Service
+public class ProfileService {
+
+    private static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<>() {
+    };
+
+    private final UserProfileRepository userProfileRepository;
+    private final UserSkillRepository userSkillRepository;
+    private final JobRoleRepository jobRoleRepository;
+    private final ObjectMapper objectMapper;
+
+    public ProfileService(
+            UserProfileRepository userProfileRepository,
+            UserSkillRepository userSkillRepository,
+            JobRoleRepository jobRoleRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.userProfileRepository = userProfileRepository;
+        this.userSkillRepository = userSkillRepository;
+        this.jobRoleRepository = jobRoleRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public ProfileSaveResult saveProfile(Long userId, ProfileSaveRequest request) {
+        JobRole jobRole = findActiveJobRole(request.targetRole());
+        List<ProfileSkillRequest> normalizedSkills = normalizeSkills(request.skills());
+        String interestAreasJson = toJson(normalizeInterestAreas(request.interestAreas()));
+
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+                .map(existingProfile -> {
+                    existingProfile.update(
+                            jobRole.getId(),
+                            request.currentLevel(),
+                            request.weeklyStudyHours(),
+                            request.targetDate(),
+                            interestAreasJson,
+                            request.resumeAssetId(),
+                            request.portfolioAssetId()
+                    );
+                    return existingProfile;
+                })
+                .orElseGet(() -> UserProfile.create(
+                        userId,
+                        jobRole.getId(),
+                        request.currentLevel(),
+                        request.weeklyStudyHours(),
+                        request.targetDate(),
+                        interestAreasJson,
+                        request.resumeAssetId(),
+                        request.portfolioAssetId()
+                ));
+
+        UserProfile savedProfile = userProfileRepository.saveAndFlush(profile);
+        replaceUserInputSkills(userId, normalizedSkills);
+
+        return new ProfileSaveResult(savedProfile.getId(), savedProfile.getUpdatedAt());
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileDetailResponse findMyProfile(Long userId) {
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        JobRole jobRole = jobRoleRepository.findById(profile.getJobRoleId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+        List<ProfileSkillResponse> skills = userSkillRepository
+                .findByUserIdAndSourceTypeOrderBySkillNameAsc(userId, SkillSourceType.USER_INPUT)
+                .stream()
+                .map(skill -> new ProfileSkillResponse(
+                        skill.getSkillName(),
+                        skill.getProficiencyLevel(),
+                        skill.getSourceType()
+                ))
+                .toList();
+
+        return new ProfileDetailResponse(
+                String.valueOf(profile.getId()),
+                jobRole.getRoleCode(),
+                profile.getCurrentLevel(),
+                skills,
+                parseInterestAreas(profile.getInterestAreasJson()),
+                profile.getWeeklyStudyHours(),
+                profile.getTargetDate(),
+                toNullableString(profile.getResumeAssetId()),
+                toNullableString(profile.getPortfolioAssetId())
+        );
+    }
+
+    private JobRole findActiveJobRole(String targetRole) {
+        return jobRoleRepository.findByRoleCodeAndActiveTrue(targetRole.trim())
+                .orElseThrow(() -> new ServiceException(ErrorCode.INVALID_INPUT));
+    }
+
+    private List<ProfileSkillRequest> normalizeSkills(List<ProfileSkillRequest> skills) {
+        Set<String> normalizedSkillNames = new HashSet<>();
+        return skills.stream()
+                .map(skill -> {
+                    String skillName = skill.skillName().trim();
+                    String normalizedName = skillName.toLowerCase(Locale.ROOT);
+                    if (!normalizedSkillNames.add(normalizedName)) {
+                        throw new ServiceException(ErrorCode.INVALID_INPUT);
+                    }
+                    return new ProfileSkillRequest(skillName, skill.proficiencyLevel());
+                })
+                .toList();
+    }
+
+    private List<String> normalizeInterestAreas(List<String> interestAreas) {
+        if (interestAreas == null) {
+            return List.of();
+        }
+        return interestAreas.stream()
+                .map(String::trim)
+                .toList();
+    }
+
+    private void replaceUserInputSkills(Long userId, List<ProfileSkillRequest> skills) {
+        List<UserSkill> existingUserInputSkills = userSkillRepository
+                .findByUserIdAndSourceTypeOrderBySkillNameAsc(userId, SkillSourceType.USER_INPUT);
+        userSkillRepository.deleteAll(existingUserInputSkills);
+        userSkillRepository.flush();
+        userSkillRepository.saveAll(skills.stream()
+                .map(skill -> UserSkill.create(
+                        userId,
+                        skill.skillName(),
+                        skill.proficiencyLevel(),
+                        SkillSourceType.USER_INPUT
+                ))
+                .toList());
+    }
+
+    private String toJson(List<String> interestAreas) {
+        try {
+            return objectMapper.writeValueAsString(interestAreas);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private List<String> parseInterestAreas(String interestAreasJson) {
+        try {
+            return objectMapper.readValue(interestAreasJson, STRING_LIST_TYPE);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String toNullableString(Long value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/user/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/user/controller/ProfileControllerTest.java
@@ -1,0 +1,207 @@
+package com.back.coach.domain.user.controller;
+
+import com.back.coach.domain.user.dto.ProfileDetailResponse;
+import com.back.coach.domain.user.dto.ProfileSaveRequest;
+import com.back.coach.domain.user.dto.ProfileSaveResult;
+import com.back.coach.domain.user.dto.ProfileSkillResponse;
+import com.back.coach.domain.user.service.ProfileService;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private ProfileService profileService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ProfileController(profileService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void saveProfile_whenValidRequest_returnsSaveResponse() throws Exception {
+        Instant savedAt = Instant.parse("2026-04-29T01:00:00Z");
+        given(profileService.saveProfile(eq(1L), any(ProfileSaveRequest.class)))
+                .willReturn(new ProfileSaveResult(10L, savedAt));
+
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetRole": "BACKEND_ENGINEER",
+                                  "currentLevel": "JUNIOR",
+                                  "skills": [
+                                    {
+                                      "skillName": "Spring Boot",
+                                      "proficiencyLevel": "WORKING"
+                                    }
+                                  ],
+                                  "interestAreas": ["백엔드", "성능 최적화"],
+                                  "weeklyStudyHours": 10,
+                                  "targetDate": "2099-12-31",
+                                  "resumeAssetId": "1001",
+                                  "portfolioAssetId": "2001"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profileId").value("10"))
+                .andExpect(jsonPath("$.data.savedAt").value("2026-04-29T01:00:00Z"))
+                .andExpect(jsonPath("$.data.message").value("프로필이 저장되었습니다."))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(profileService).saveProfile(eq(1L), any(ProfileSaveRequest.class));
+    }
+
+    @Test
+    void findMyProfile_whenProfileExists_returnsProfileDetail() throws Exception {
+        given(profileService.findMyProfile(1L))
+                .willReturn(new ProfileDetailResponse(
+                        "10",
+                        "BACKEND_ENGINEER",
+                        CurrentLevel.JUNIOR,
+                        List.of(new ProfileSkillResponse(
+                                "Spring Boot",
+                                ProficiencyLevel.WORKING,
+                                SkillSourceType.USER_INPUT
+                        )),
+                        List.of("백엔드", "성능 최적화"),
+                        10,
+                        LocalDate.of(2099, 12, 31),
+                        "1001",
+                        "2001"
+                ));
+
+        mockMvc.perform(get("/api/profiles/me")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.profileId").value("10"))
+                .andExpect(jsonPath("$.data.targetRole").value("BACKEND_ENGINEER"))
+                .andExpect(jsonPath("$.data.currentLevel").value("JUNIOR"))
+                .andExpect(jsonPath("$.data.skills[0].skillName").value("Spring Boot"))
+                .andExpect(jsonPath("$.data.skills[0].proficiencyLevel").value("WORKING"))
+                .andExpect(jsonPath("$.data.skills[0].sourceType").value("USER_INPUT"))
+                .andExpect(jsonPath("$.data.interestAreas[0]").value("백엔드"))
+                .andExpect(jsonPath("$.data.weeklyStudyHours").value(10))
+                .andExpect(jsonPath("$.data.targetDate").value("2099-12-31"))
+                .andExpect(jsonPath("$.data.resumeAssetId").value("1001"))
+                .andExpect(jsonPath("$.data.portfolioAssetId").value("2001"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(profileService).findMyProfile(1L);
+    }
+
+    @Test
+    void saveProfile_whenTargetRoleMissing_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "currentLevel": "JUNIOR",
+                                  "skills": [
+                                    {
+                                      "skillName": "Spring Boot"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(profileService);
+    }
+
+    @Test
+    void saveProfile_whenSkillsEmpty_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetRole": "BACKEND_ENGINEER",
+                                  "currentLevel": "JUNIOR",
+                                  "skills": []
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(profileService);
+    }
+
+    @Test
+    void saveProfile_whenWeeklyStudyHoursOutOfRange_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetRole": "BACKEND_ENGINEER",
+                                  "currentLevel": "JUNIOR",
+                                  "skills": [
+                                    {
+                                      "skillName": "Spring Boot"
+                                    }
+                                  ],
+                                  "weeklyStudyHours": 41
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(profileService);
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/user/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/user/service/ProfileServiceTest.java
@@ -1,0 +1,267 @@
+package com.back.coach.domain.user.service;
+
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.user.dto.ProfileDetailResponse;
+import com.back.coach.domain.user.dto.ProfileSaveRequest;
+import com.back.coach.domain.user.dto.ProfileSaveResult;
+import com.back.coach.domain.user.dto.ProfileSkillRequest;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private UserSkillRepository userSkillRepository;
+
+    @Mock
+    private JobRoleRepository jobRoleRepository;
+
+    private ProfileService profileService;
+
+    @BeforeEach
+    void setUp() {
+        profileService = new ProfileService(
+                userProfileRepository,
+                userSkillRepository,
+                jobRoleRepository,
+                objectMapper
+        );
+    }
+
+    @Test
+    void saveProfile_whenProfileDoesNotExist_createsProfileAndUserInputSkills() {
+        Instant savedAt = Instant.parse("2026-04-29T01:00:00Z");
+        JobRole jobRole = jobRoleWithId(100L);
+        given(jobRoleRepository.findByRoleCodeAndActiveTrue("BACKEND_ENGINEER")).willReturn(Optional.of(jobRole));
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.empty());
+        given(userProfileRepository.saveAndFlush(any(UserProfile.class)))
+                .willAnswer(invocation -> {
+                    UserProfile profile = invocation.getArgument(0);
+                    setEntityId(profile, 10L);
+                    setUpdatedAt(profile, savedAt);
+                    return profile;
+                });
+        given(userSkillRepository.findByUserIdAndSourceTypeOrderBySkillNameAsc(1L, SkillSourceType.USER_INPUT))
+                .willReturn(List.of());
+
+        ProfileSaveResult result = profileService.saveProfile(1L, profileRequest("Spring Boot", "PostgreSQL"));
+
+        assertThat(result).isEqualTo(new ProfileSaveResult(10L, savedAt));
+        ArgumentCaptor<UserProfile> profileCaptor = ArgumentCaptor.forClass(UserProfile.class);
+        verify(userProfileRepository).saveAndFlush(profileCaptor.capture());
+        UserProfile savedProfile = profileCaptor.getValue();
+        assertThat(savedProfile.getUserId()).isEqualTo(1L);
+        assertThat(savedProfile.getJobRoleId()).isEqualTo(100L);
+        assertThat(savedProfile.getCurrentLevel()).isEqualTo(CurrentLevel.JUNIOR);
+        assertThat(savedProfile.getWeeklyStudyHours()).isEqualTo(10);
+        assertThat(savedProfile.getTargetDate()).isEqualTo(LocalDate.of(2099, 12, 31));
+        assertThat(savedProfile.getInterestAreasJson()).isEqualTo("[\"백엔드\",\"성능 최적화\"]");
+        assertThat(savedProfile.getResumeAssetId()).isEqualTo(1001L);
+        assertThat(savedProfile.getPortfolioAssetId()).isEqualTo(2001L);
+
+        ArgumentCaptor<List<UserSkill>> skillCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userSkillRepository).saveAll(skillCaptor.capture());
+        assertThat(skillCaptor.getValue())
+                .extracting(UserSkill::getSkillName)
+                .containsExactly("Spring Boot", "PostgreSQL");
+        assertThat(skillCaptor.getValue())
+                .extracting(UserSkill::getSourceType)
+                .containsOnly(SkillSourceType.USER_INPUT);
+    }
+
+    @Test
+    void saveProfile_whenProfileExists_updatesProfileAndReplacesOnlyUserInputSkills() {
+        Instant savedAt = Instant.parse("2026-04-29T01:00:00Z");
+        JobRole jobRole = jobRoleWithId(100L);
+        UserProfile existingProfile = UserProfile.create(
+                1L,
+                90L,
+                CurrentLevel.BASIC,
+                5,
+                LocalDate.of(2099, 1, 1),
+                "[]",
+                null,
+                null
+        );
+        setEntityId(existingProfile, 10L);
+        List<UserSkill> existingUserInputSkills = List.of(UserSkill.create(
+                1L,
+                "Old Skill",
+                ProficiencyLevel.BASIC,
+                SkillSourceType.USER_INPUT
+        ));
+        given(jobRoleRepository.findByRoleCodeAndActiveTrue("BACKEND_ENGINEER")).willReturn(Optional.of(jobRole));
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.of(existingProfile));
+        given(userProfileRepository.saveAndFlush(existingProfile)).willAnswer(invocation -> {
+            setUpdatedAt(existingProfile, savedAt);
+            return existingProfile;
+        });
+        given(userSkillRepository.findByUserIdAndSourceTypeOrderBySkillNameAsc(1L, SkillSourceType.USER_INPUT))
+                .willReturn(existingUserInputSkills);
+
+        ProfileSaveResult result = profileService.saveProfile(1L, profileRequest("Redis"));
+
+        assertThat(result).isEqualTo(new ProfileSaveResult(10L, savedAt));
+        assertThat(existingProfile.getJobRoleId()).isEqualTo(100L);
+        assertThat(existingProfile.getCurrentLevel()).isEqualTo(CurrentLevel.JUNIOR);
+        verify(userSkillRepository).deleteAll(existingUserInputSkills);
+        verify(userSkillRepository).flush();
+        ArgumentCaptor<List<UserSkill>> skillCaptor = ArgumentCaptor.forClass(List.class);
+        verify(userSkillRepository).saveAll(skillCaptor.capture());
+        assertThat(skillCaptor.getValue())
+                .extracting(UserSkill::getSkillName)
+                .containsExactly("Redis");
+    }
+
+    @Test
+    void saveProfile_whenTargetRoleDoesNotExist_throwsInvalidInput() {
+        given(jobRoleRepository.findByRoleCodeAndActiveTrue("UNKNOWN")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> profileService.saveProfile(1L, profileRequestWithTargetRole("UNKNOWN", "Redis")))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        verifyNoInteractions(userProfileRepository, userSkillRepository);
+    }
+
+    @Test
+    void saveProfile_whenSkillNamesAreDuplicatedAfterNormalization_throwsInvalidInput() {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRoleRepository.findByRoleCodeAndActiveTrue("BACKEND_ENGINEER")).willReturn(Optional.of(jobRole));
+
+        assertThatThrownBy(() -> profileService.saveProfile(1L, profileRequest(" Redis ", "redis")))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        verifyNoInteractions(userProfileRepository, userSkillRepository);
+    }
+
+    @Test
+    void findMyProfile_whenProfileExists_returnsUserInputProfileDetail() {
+        UserProfile profile = UserProfile.create(
+                1L,
+                100L,
+                CurrentLevel.JUNIOR,
+                10,
+                LocalDate.of(2099, 12, 31),
+                "[\"백엔드\",\"성능 최적화\"]",
+                1001L,
+                2001L
+        );
+        setEntityId(profile, 10L);
+        JobRole jobRole = jobRoleWithRoleCode("BACKEND_ENGINEER");
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.of(profile));
+        given(jobRoleRepository.findById(100L)).willReturn(Optional.of(jobRole));
+        given(userSkillRepository.findByUserIdAndSourceTypeOrderBySkillNameAsc(1L, SkillSourceType.USER_INPUT))
+                .willReturn(List.of(UserSkill.create(
+                        1L,
+                        "Spring Boot",
+                        ProficiencyLevel.WORKING,
+                        SkillSourceType.USER_INPUT
+                )));
+
+        ProfileDetailResponse result = profileService.findMyProfile(1L);
+
+        assertThat(result.profileId()).isEqualTo("10");
+        assertThat(result.targetRole()).isEqualTo("BACKEND_ENGINEER");
+        assertThat(result.currentLevel()).isEqualTo(CurrentLevel.JUNIOR);
+        assertThat(result.skills()).hasSize(1);
+        assertThat(result.skills().get(0).sourceType()).isEqualTo(SkillSourceType.USER_INPUT);
+        assertThat(result.interestAreas()).containsExactly("백엔드", "성능 최적화");
+        assertThat(result.resumeAssetId()).isEqualTo("1001");
+        assertThat(result.portfolioAssetId()).isEqualTo("2001");
+    }
+
+    @Test
+    void findMyProfile_whenProfileDoesNotExist_throwsResourceNotFound() {
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> profileService.findMyProfile(1L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verifyNoMoreInteractions(userProfileRepository);
+        verifyNoInteractions(jobRoleRepository, userSkillRepository);
+    }
+
+    private ProfileSaveRequest profileRequest(String... skillNames) {
+        return profileRequestWithTargetRole("BACKEND_ENGINEER", skillNames);
+    }
+
+    private ProfileSaveRequest profileRequestWithTargetRole(String targetRole, String... skillNames) {
+        return new ProfileSaveRequest(
+                targetRole,
+                CurrentLevel.JUNIOR,
+                List.of(skillNames).stream()
+                        .map(skillName -> new ProfileSkillRequest(skillName, ProficiencyLevel.WORKING))
+                        .toList(),
+                List.of("백엔드", "성능 최적화"),
+                10,
+                LocalDate.of(2099, 12, 31),
+                1001L,
+                2001L
+        );
+    }
+
+    private JobRole jobRoleWithId(Long id) {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRole.getId()).willReturn(id);
+        return jobRole;
+    }
+
+    private JobRole jobRoleWithRoleCode(String roleCode) {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn(roleCode);
+        return jobRole;
+    }
+
+    private void setEntityId(Object entity, Long id) {
+        ReflectionTestUtils.setField(entity, "id", id);
+    }
+
+    private void setUpdatedAt(Object entity, Instant updatedAt) {
+        ReflectionTestUtils.setField(entity, "updatedAt", updatedAt);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -33,7 +33,9 @@ class OpenApiContractTest {
         assertThat(operation(paths, "/api/roadmaps/{roadmapId}/progress", "post")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/profiles", "post")
-                .get("x-implementation-status")).isEqualTo("planned");
+                .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/profiles/me", "get")
+                .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/roadmaps/{roadmapId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/dashboard", "get")

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -118,6 +118,11 @@
 - `targetDate`: 선택, 오늘 이후 날짜
 - `resumeAssetId`, `portfolioAssetId`: 선택
 
+저장 규칙
+- 프로필은 사용자당 1개를 유지하며, 재저장 시 기존 프로필 row를 갱신한다
+- 프로필 저장 시 `skills`는 `USER_INPUT` 출처 기술만 교체하고, GitHub 분석 또는 시스템 파생 기술은 삭제하지 않는다
+- `skills[].skillName`은 trim 후 대소문자 구분 없이 중복될 수 없다
+
 응답 body
 ```json
 {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -37,7 +37,7 @@ paths:
         - Profiles
       summary: Create or update my profile
       operationId: saveProfile
-      x-implementation-status: planned
+      x-implementation-status: implemented
       requestBody:
         required: true
         content:
@@ -62,7 +62,7 @@ paths:
         - Profiles
       summary: Get my profile
       operationId: getMyProfile
-      x-implementation-status: planned
+      x-implementation-status: implemented
       responses:
         '200':
           description: Current user's profile


### PR DESCRIPTION
﻿## 작업 내용
- `POST /api/profiles`와 `GET /api/profiles/me`를 추가했습니다.
- `job_roles.role_code` 기준으로 목표 직무를 검증하고, 사용자당 프로필 1개를 upsert합니다.
- 프로필 저장 시 `USER_INPUT` 기술 스택만 교체하고 GitHub/시스템 파생 기술은 유지합니다.
- API 문서와 OpenAPI 구현 상태를 갱신했습니다.

## 필요한 이유
GitHub 분석, 역량 진단, 로드맵 생성은 사용자의 목표 직무와 현재 역량 입력값을 기준으로 동작합니다. 프로필 API가 있어야 v1 핵심 흐름의 시작 입력을 서버에 안정적으로 저장하고 재조회할 수 있습니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #81
