### PR TITLE
feat(diagnosis): 진단 결과 조회 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailController.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailController.java
@@ -1,0 +1,33 @@
+package com.back.coach.domain.diagnosis.controller;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.service.DiagnosisDetailService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/diagnoses", produces = MediaType.APPLICATION_JSON_VALUE)
+public class DiagnosisDetailController {
+
+    private final DiagnosisDetailService diagnosisDetailService;
+
+    public DiagnosisDetailController(DiagnosisDetailService diagnosisDetailService) {
+        this.diagnosisDetailService = diagnosisDetailService;
+    }
+
+    @GetMapping("/{diagnosisId}")
+    public ApiResponse<DiagnosisDetailResponse> findDiagnosis(
+            Authentication authentication,
+            @PathVariable Long diagnosisId
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(diagnosisDetailService.findDiagnosis(authenticatedUser.userId(), diagnosisId));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisDetailResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisDetailResponse.java
@@ -1,0 +1,39 @@
+package com.back.coach.domain.diagnosis.dto;
+
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DiagnosisDetailResponse(
+        String diagnosisId,
+        Integer version,
+        String profileId,
+        String githubAnalysisId,
+        String targetRole,
+        CurrentLevel currentLevel,
+        String summary,
+        List<MissingSkillResponse> missingSkills,
+        List<String> strengths,
+        List<String> recommendations,
+        Instant createdAt
+) {
+
+    public record MissingSkillResponse(
+            String skillName,
+            DiagnosisSeverity severity,
+            String reason,
+            Integer priorityOrder
+    ) {
+
+        public static MissingSkillResponse from(DiagnosisPayload.MissingSkill missingSkill) {
+            return new MissingSkillResponse(
+                    missingSkill.skillName(),
+                    missingSkill.severity(),
+                    missingSkill.reason(),
+                    missingSkill.priorityOrder()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisPayload.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisPayload.java
@@ -1,0 +1,20 @@
+package com.back.coach.domain.diagnosis.dto;
+
+import com.back.coach.global.code.DiagnosisSeverity;
+
+import java.util.List;
+
+public record DiagnosisPayload(
+        List<MissingSkill> missingSkills,
+        List<String> strengths,
+        List<String> recommendations
+) {
+
+    public record MissingSkill(
+            String skillName,
+            DiagnosisSeverity severity,
+            String reason,
+            Integer priorityOrder
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailService.java
@@ -1,0 +1,65 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DiagnosisDetailService {
+
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final JobRoleRepository jobRoleRepository;
+    private final ObjectMapper objectMapper;
+
+    public DiagnosisDetailService(
+            CapabilityDiagnosisRepository capabilityDiagnosisRepository,
+            JobRoleRepository jobRoleRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
+        this.jobRoleRepository = jobRoleRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public DiagnosisDetailResponse findDiagnosis(Long userId, Long diagnosisId) {
+        CapabilityDiagnosis diagnosis = capabilityDiagnosisRepository.findByIdAndUserId(diagnosisId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        JobRole jobRole = jobRoleRepository.findById(diagnosis.getJobRoleId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+        DiagnosisPayload payload = parsePayload(diagnosis.getDiagnosisPayload());
+
+        return new DiagnosisDetailResponse(
+                String.valueOf(diagnosis.getId()),
+                diagnosis.getVersion(),
+                String.valueOf(diagnosis.getProfileId()),
+                String.valueOf(diagnosis.getGithubAnalysisId()),
+                jobRole.getRoleCode(),
+                diagnosis.getCurrentLevel(),
+                diagnosis.getSummary(),
+                payload.missingSkills().stream()
+                        .map(DiagnosisDetailResponse.MissingSkillResponse::from)
+                        .toList(),
+                payload.strengths(),
+                payload.recommendations(),
+                diagnosis.getCreatedAt()
+        );
+    }
+
+    private DiagnosisPayload parsePayload(String diagnosisPayload) {
+        try {
+            return objectMapper.readValue(diagnosisPayload, DiagnosisPayload.class);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailControllerTest.java
@@ -1,0 +1,117 @@
+package com.back.coach.domain.diagnosis.controller;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.service.DiagnosisDetailService;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class DiagnosisDetailControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private DiagnosisDetailService diagnosisDetailService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new DiagnosisDetailController(diagnosisDetailService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void findDiagnosis_whenDiagnosisExists_returnsDiagnosisDetail() throws Exception {
+        given(diagnosisDetailService.findDiagnosis(1L, 30L))
+                .willReturn(new DiagnosisDetailResponse(
+                        "30",
+                        3,
+                        "10",
+                        "20",
+                        "BACKEND_ENGINEER",
+                        CurrentLevel.JUNIOR,
+                        "Redis 보완 필요",
+                        List.of(new DiagnosisDetailResponse.MissingSkillResponse(
+                                "Redis",
+                                DiagnosisSeverity.HIGH,
+                                "캐시 설계 경험이 부족함",
+                                1
+                        )),
+                        List.of("Spring Boot", "JPA"),
+                        List.of("Redis 캐시와 TTL 기반 설계를 먼저 학습"),
+                        Instant.parse("2026-04-29T01:00:00Z")
+                ));
+
+        mockMvc.perform(get("/api/diagnoses/{diagnosisId}", 30L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.diagnosisId").value("30"))
+                .andExpect(jsonPath("$.data.version").value(3))
+                .andExpect(jsonPath("$.data.profileId").value("10"))
+                .andExpect(jsonPath("$.data.githubAnalysisId").value("20"))
+                .andExpect(jsonPath("$.data.targetRole").value("BACKEND_ENGINEER"))
+                .andExpect(jsonPath("$.data.currentLevel").value("JUNIOR"))
+                .andExpect(jsonPath("$.data.summary").value("Redis 보완 필요"))
+                .andExpect(jsonPath("$.data.missingSkills[0].skillName").value("Redis"))
+                .andExpect(jsonPath("$.data.missingSkills[0].severity").value("HIGH"))
+                .andExpect(jsonPath("$.data.missingSkills[0].reason").value("캐시 설계 경험이 부족함"))
+                .andExpect(jsonPath("$.data.missingSkills[0].priorityOrder").value(1))
+                .andExpect(jsonPath("$.data.strengths[0]").value("Spring Boot"))
+                .andExpect(jsonPath("$.data.recommendations[0]").value("Redis 캐시와 TTL 기반 설계를 먼저 학습"))
+                .andExpect(jsonPath("$.data.createdAt").value("2026-04-29T01:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(diagnosisDetailService).findDiagnosis(1L, 30L);
+    }
+
+    @Test
+    void findDiagnosis_whenDiagnosisDoesNotBelongToUser_returnsNotFound() throws Exception {
+        given(diagnosisDetailService.findDiagnosis(1L, 30L))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/diagnoses/{diagnosisId}", 30L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailServiceTest.java
@@ -1,0 +1,165 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DiagnosisDetailServiceTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Mock
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Mock
+    private JobRoleRepository jobRoleRepository;
+
+    private DiagnosisDetailService diagnosisDetailService;
+
+    @BeforeEach
+    void setUp() {
+        diagnosisDetailService = new DiagnosisDetailService(
+                capabilityDiagnosisRepository,
+                jobRoleRepository,
+                objectMapper
+        );
+    }
+
+    @Test
+    void findDiagnosis_whenDiagnosisExists_returnsParsedDiagnosisDetail() {
+        Instant createdAt = Instant.parse("2026-04-29T01:00:00Z");
+        CapabilityDiagnosis diagnosis = diagnosis(validPayload(), createdAt);
+        JobRole jobRole = jobRole("BACKEND_ENGINEER");
+        given(capabilityDiagnosisRepository.findByIdAndUserId(30L, 1L)).willReturn(Optional.of(diagnosis));
+        given(jobRoleRepository.findById(100L)).willReturn(Optional.of(jobRole));
+
+        DiagnosisDetailResponse result = diagnosisDetailService.findDiagnosis(1L, 30L);
+
+        assertThat(result.diagnosisId()).isEqualTo("30");
+        assertThat(result.version()).isEqualTo(3);
+        assertThat(result.profileId()).isEqualTo("10");
+        assertThat(result.githubAnalysisId()).isEqualTo("20");
+        assertThat(result.targetRole()).isEqualTo("BACKEND_ENGINEER");
+        assertThat(result.currentLevel()).isEqualTo(CurrentLevel.JUNIOR);
+        assertThat(result.summary()).isEqualTo("Redis 보완 필요");
+        assertThat(result.missingSkills()).containsExactly(new DiagnosisDetailResponse.MissingSkillResponse(
+                "Redis",
+                DiagnosisSeverity.HIGH,
+                "캐시 설계 경험이 부족함",
+                1
+        ));
+        assertThat(result.strengths()).containsExactly("Spring Boot", "JPA");
+        assertThat(result.recommendations()).containsExactly("Redis 캐시와 TTL 기반 설계를 먼저 학습");
+        assertThat(result.createdAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    void findDiagnosis_whenDiagnosisDoesNotBelongToUser_throwsResourceNotFound() {
+        given(capabilityDiagnosisRepository.findByIdAndUserId(30L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> diagnosisDetailService.findDiagnosis(1L, 30L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        verifyNoInteractions(jobRoleRepository);
+    }
+
+    @Test
+    void findDiagnosis_whenPayloadJsonIsInvalid_throwsInternalServerError() {
+        CapabilityDiagnosis diagnosis = diagnosisWithPayload("not-json");
+        JobRole jobRole = mock(JobRole.class);
+        given(capabilityDiagnosisRepository.findByIdAndUserId(30L, 1L)).willReturn(Optional.of(diagnosis));
+        given(jobRoleRepository.findById(100L)).willReturn(Optional.of(jobRole));
+
+        assertThatThrownBy(() -> diagnosisDetailService.findDiagnosis(1L, 30L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void findDiagnosis_whenJobRoleDoesNotExist_throwsInternalServerError() {
+        CapabilityDiagnosis diagnosis = diagnosisWithJobRoleId(100L);
+        given(capabilityDiagnosisRepository.findByIdAndUserId(30L, 1L)).willReturn(Optional.of(diagnosis));
+        given(jobRoleRepository.findById(100L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> diagnosisDetailService.findDiagnosis(1L, 30L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private CapabilityDiagnosis diagnosis(String payload, Instant createdAt) {
+        CapabilityDiagnosis diagnosis = mock(CapabilityDiagnosis.class);
+        given(diagnosis.getId()).willReturn(30L);
+        given(diagnosis.getProfileId()).willReturn(10L);
+        given(diagnosis.getGithubAnalysisId()).willReturn(20L);
+        given(diagnosis.getJobRoleId()).willReturn(100L);
+        given(diagnosis.getVersion()).willReturn(3);
+        given(diagnosis.getCurrentLevel()).willReturn(CurrentLevel.JUNIOR);
+        given(diagnosis.getSummary()).willReturn("Redis 보완 필요");
+        given(diagnosis.getDiagnosisPayload()).willReturn(payload);
+        given(diagnosis.getCreatedAt()).willReturn(createdAt);
+        return diagnosis;
+    }
+
+    private CapabilityDiagnosis diagnosisWithPayload(String payload) {
+        CapabilityDiagnosis diagnosis = diagnosisWithJobRoleId(100L);
+        given(diagnosis.getDiagnosisPayload()).willReturn(payload);
+        return diagnosis;
+    }
+
+    private CapabilityDiagnosis diagnosisWithJobRoleId(Long jobRoleId) {
+        CapabilityDiagnosis diagnosis = mock(CapabilityDiagnosis.class);
+        given(diagnosis.getJobRoleId()).willReturn(jobRoleId);
+        return diagnosis;
+    }
+
+    private JobRole jobRole(String roleCode) {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn(roleCode);
+        return jobRole;
+    }
+
+    private String validPayload() {
+        return """
+                {
+                  "missingSkills": [
+                    {
+                      "skillName": "Redis",
+                      "severity": "HIGH",
+                      "reason": "캐시 설계 경험이 부족함",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["Spring Boot", "JPA"],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -40,6 +40,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/dashboard", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
+                .get("x-implementation-status")).isEqualTo("implemented");
     }
 
     @Test

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -244,7 +244,7 @@ paths:
         - Diagnoses
       summary: Get capability diagnosis result
       operationId: getDiagnosis
-      x-implementation-status: planned
+      x-implementation-status: implemented
       parameters:
         - $ref: '#/components/parameters/DiagnosisId'
       responses:


### PR DESCRIPTION
﻿## 작업 내용
- `GET /api/diagnoses/{diagnosisId}`를 추가했습니다.
- 저장된 진단 결과를 소유권 기준으로 조회하고 `diagnosis_payload`를 API 응답 형태로 파싱합니다.
- OpenAPI에서 진단 결과 조회 API 구현 상태를 `implemented`로 갱신했습니다.

## 필요한 이유
로드맵 생성 전후로 사용자가 기존 진단 결과를 다시 확인할 수 있어야 합니다. 조회 API가 있어야 프론트가 `diagnosisId`로 로드맵 추천의 근거를 다시 보여줄 수 있습니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #83
