### PR TITLE
feat(github): GitHub 분석 결과 조회 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
+++ b/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
@@ -1,0 +1,36 @@
+package com.back.coach.domain.github.controller;
+
+import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
+import com.back.coach.domain.github.service.GithubAnalysisDetailService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/github-analyses", produces = MediaType.APPLICATION_JSON_VALUE)
+public class GithubAnalysisController {
+
+    private final GithubAnalysisDetailService githubAnalysisDetailService;
+
+    public GithubAnalysisController(GithubAnalysisDetailService githubAnalysisDetailService) {
+        this.githubAnalysisDetailService = githubAnalysisDetailService;
+    }
+
+    @GetMapping("/{githubAnalysisId}")
+    public ApiResponse<GithubAnalysisDetailResponse> findAnalysis(
+            Authentication authentication,
+            @PathVariable Long githubAnalysisId
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(githubAnalysisDetailService.findAnalysis(
+                authenticatedUser.userId(),
+                githubAnalysisId
+        ));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisDetailResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisDetailResponse.java
@@ -1,0 +1,38 @@
+package com.back.coach.domain.github.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record GithubAnalysisDetailResponse(
+        String githubAnalysisId,
+        Integer version,
+        GithubAnalysisPayload.StaticSignals staticSignals,
+        List<GithubAnalysisPayload.RepoSummary> repoSummaries,
+        List<GithubAnalysisPayload.TechTag> techTags,
+        List<GithubAnalysisPayload.DepthEstimate> depthEstimates,
+        List<GithubAnalysisPayload.GithubEvidence> evidences,
+        List<GithubAnalysisPayload.GithubUserCorrection> userCorrections,
+        GithubAnalysisPayload.FinalTechProfile finalTechProfile,
+        Instant createdAt
+) {
+
+    public static GithubAnalysisDetailResponse from(
+            Long githubAnalysisId,
+            Integer version,
+            GithubAnalysisPayload payload,
+            Instant createdAt
+    ) {
+        return new GithubAnalysisDetailResponse(
+                String.valueOf(githubAnalysisId),
+                version,
+                payload.staticSignals(),
+                payload.repoSummaries(),
+                payload.techTags(),
+                payload.depthEstimates(),
+                payload.evidences(),
+                payload.userCorrections(),
+                payload.finalTechProfile(),
+                createdAt
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
@@ -1,0 +1,72 @@
+package com.back.coach.domain.github.dto;
+
+import com.back.coach.global.code.GithubDepthLevel;
+import com.back.coach.global.code.GithubEvidenceType;
+
+import java.util.List;
+
+public record GithubAnalysisPayload(
+        StaticSignals staticSignals,
+        List<RepoSummary> repoSummaries,
+        List<TechTag> techTags,
+        List<DepthEstimate> depthEstimates,
+        List<GithubEvidence> evidences,
+        List<GithubUserCorrection> userCorrections,
+        FinalTechProfile finalTechProfile
+) {
+
+    public record StaticSignals(
+            List<PrimaryLanguage> primaryLanguages,
+            Integer activeRepos,
+            String commitFrequency,
+            String contributionPattern
+    ) {
+    }
+
+    public record PrimaryLanguage(
+            String lang,
+            Double ratio
+    ) {
+    }
+
+    public record RepoSummary(
+            String repoId,
+            String repoName,
+            String summary,
+            List<String> highlights
+    ) {
+    }
+
+    public record TechTag(
+            String skillName,
+            String tagReason
+    ) {
+    }
+
+    public record DepthEstimate(
+            String skillName,
+            GithubDepthLevel level,
+            String reason
+    ) {
+    }
+
+    public record GithubEvidence(
+            String repoName,
+            GithubEvidenceType type,
+            String source,
+            String summary
+    ) {
+    }
+
+    public record GithubUserCorrection(
+            String skillName,
+            String correction
+    ) {
+    }
+
+    public record FinalTechProfile(
+            List<String> confirmedSkills,
+            List<String> focusAreas
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -1,0 +1,49 @@
+package com.back.coach.domain.github.service;
+
+import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GithubAnalysisDetailService {
+
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final ObjectMapper objectMapper;
+
+    public GithubAnalysisDetailService(
+            GithubAnalysisRepository githubAnalysisRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.githubAnalysisRepository = githubAnalysisRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public GithubAnalysisDetailResponse findAnalysis(Long userId, Long githubAnalysisId) {
+        GithubAnalysis githubAnalysis = githubAnalysisRepository.findByIdAndUserId(githubAnalysisId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        GithubAnalysisPayload payload = parsePayload(githubAnalysis.getAnalysisPayload());
+
+        return GithubAnalysisDetailResponse.from(
+                githubAnalysis.getId(),
+                githubAnalysis.getVersion(),
+                payload,
+                githubAnalysis.getCreatedAt()
+        );
+    }
+
+    private GithubAnalysisPayload parsePayload(String analysisPayload) {
+        try {
+            return objectMapper.readValue(analysisPayload, GithubAnalysisPayload.class);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
@@ -1,0 +1,144 @@
+package com.back.coach.domain.github.controller;
+
+import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.service.GithubAnalysisDetailService;
+import com.back.coach.global.code.GithubDepthLevel;
+import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class GithubAnalysisControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private GithubAnalysisDetailService githubAnalysisDetailService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new GithubAnalysisController(githubAnalysisDetailService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void findAnalysis_whenAnalysisExists_returnsGithubAnalysisDetail() throws Exception {
+        given(githubAnalysisDetailService.findAnalysis(1L, 40L))
+                .willReturn(new GithubAnalysisDetailResponse(
+                        "40",
+                        2,
+                        new GithubAnalysisPayload.StaticSignals(
+                                List.of(new GithubAnalysisPayload.PrimaryLanguage("Java", 0.6)),
+                                12,
+                                "WEEKLY",
+                                "CONSISTENT"
+                        ),
+                        List.of(new GithubAnalysisPayload.RepoSummary(
+                                "9001",
+                                "team06/ai-growth-coach",
+                                "Spring Boot backend service",
+                                List.of("Redis cache", "Batch processing")
+                        )),
+                        List.of(new GithubAnalysisPayload.TechTag(
+                                "Redis",
+                                "Cache configuration and TTL usage were found"
+                        )),
+                        List.of(new GithubAnalysisPayload.DepthEstimate(
+                                "Redis",
+                                GithubDepthLevel.APPLIED,
+                                "Cache keys and TTL are used beyond dependency setup"
+                        )),
+                        List.of(new GithubAnalysisPayload.GithubEvidence(
+                                "team06/ai-growth-coach",
+                                GithubEvidenceType.CODE,
+                                "src/main/java/com/back/coach/config/CacheConfig.java",
+                                "RedisTemplate and TTL configuration"
+                        )),
+                        List.of(new GithubAnalysisPayload.GithubUserCorrection(
+                                "Redis",
+                                "Used for cache only, not Pub/Sub"
+                        )),
+                        new GithubAnalysisPayload.FinalTechProfile(
+                                List.of("Java", "Spring Boot", "Redis"),
+                                List.of("Backend", "Performance")
+                        ),
+                        Instant.parse("2026-04-29T01:00:00Z")
+                ));
+
+        mockMvc.perform(get("/api/github-analyses/{githubAnalysisId}", 40L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.githubAnalysisId").value("40"))
+                .andExpect(jsonPath("$.data.version").value(2))
+                .andExpect(jsonPath("$.data.staticSignals.primaryLanguages[0].lang").value("Java"))
+                .andExpect(jsonPath("$.data.staticSignals.primaryLanguages[0].ratio").value(0.6))
+                .andExpect(jsonPath("$.data.staticSignals.activeRepos").value(12))
+                .andExpect(jsonPath("$.data.staticSignals.commitFrequency").value("WEEKLY"))
+                .andExpect(jsonPath("$.data.staticSignals.contributionPattern").value("CONSISTENT"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].repoId").value("9001"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].repoName").value("team06/ai-growth-coach"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].summary").value("Spring Boot backend service"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0]").value("Redis cache"))
+                .andExpect(jsonPath("$.data.techTags[0].skillName").value("Redis"))
+                .andExpect(jsonPath("$.data.depthEstimates[0].level").value("APPLIED"))
+                .andExpect(jsonPath("$.data.evidences[0].type").value("CODE"))
+                .andExpect(jsonPath("$.data.userCorrections[0].correction").value("Used for cache only, not Pub/Sub"))
+                .andExpect(jsonPath("$.data.finalTechProfile.confirmedSkills[0]").value("Java"))
+                .andExpect(jsonPath("$.data.finalTechProfile.focusAreas[1]").value("Performance"))
+                .andExpect(jsonPath("$.data.createdAt").value("2026-04-29T01:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(githubAnalysisDetailService).findAnalysis(1L, 40L);
+    }
+
+    @Test
+    void findAnalysis_whenAnalysisDoesNotBelongToUser_returnsNotFound() throws Exception {
+        given(githubAnalysisDetailService.findAnalysis(1L, 40L))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/github-analyses/{githubAnalysisId}", 40L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
@@ -1,0 +1,192 @@
+package com.back.coach.domain.github.service;
+
+import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.global.code.GithubDepthLevel;
+import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class GithubAnalysisDetailServiceTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Mock
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    private GithubAnalysisDetailService githubAnalysisDetailService;
+
+    @BeforeEach
+    void setUp() {
+        githubAnalysisDetailService = new GithubAnalysisDetailService(githubAnalysisRepository, objectMapper);
+    }
+
+    @Test
+    void findAnalysis_whenAnalysisExists_returnsParsedAnalysisDetail() {
+        Instant createdAt = Instant.parse("2026-04-29T01:00:00Z");
+        GithubAnalysis githubAnalysis = githubAnalysis(validPayload(), createdAt);
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.of(githubAnalysis));
+
+        GithubAnalysisDetailResponse result = githubAnalysisDetailService.findAnalysis(1L, 40L);
+
+        assertThat(result.githubAnalysisId()).isEqualTo("40");
+        assertThat(result.version()).isEqualTo(2);
+        assertThat(result.staticSignals().primaryLanguages())
+                .containsExactly(new GithubAnalysisPayload.PrimaryLanguage("Java", 0.6));
+        assertThat(result.staticSignals().activeRepos()).isEqualTo(12);
+        assertThat(result.staticSignals().commitFrequency()).isEqualTo("WEEKLY");
+        assertThat(result.staticSignals().contributionPattern()).isEqualTo("CONSISTENT");
+        assertThat(result.repoSummaries()).containsExactly(new GithubAnalysisPayload.RepoSummary(
+                "9001",
+                "team06/ai-growth-coach",
+                "Spring Boot backend service",
+                java.util.List.of("Redis cache", "Batch processing")
+        ));
+        assertThat(result.techTags()).containsExactly(new GithubAnalysisPayload.TechTag(
+                "Redis",
+                "Cache configuration and TTL usage were found"
+        ));
+        assertThat(result.depthEstimates()).containsExactly(new GithubAnalysisPayload.DepthEstimate(
+                "Redis",
+                GithubDepthLevel.APPLIED,
+                "Cache keys and TTL are used beyond dependency setup"
+        ));
+        assertThat(result.evidences()).containsExactly(new GithubAnalysisPayload.GithubEvidence(
+                "team06/ai-growth-coach",
+                GithubEvidenceType.CODE,
+                "src/main/java/com/back/coach/config/CacheConfig.java",
+                "RedisTemplate and TTL configuration"
+        ));
+        assertThat(result.userCorrections()).containsExactly(new GithubAnalysisPayload.GithubUserCorrection(
+                "Redis",
+                "Used for cache only, not Pub/Sub"
+        ));
+        assertThat(result.finalTechProfile().confirmedSkills())
+                .containsExactly("Java", "Spring Boot", "Redis");
+        assertThat(result.finalTechProfile().focusAreas())
+                .containsExactly("Backend", "Performance");
+        assertThat(result.createdAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    void findAnalysis_whenAnalysisDoesNotBelongToUser_throwsResourceNotFound() {
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> githubAnalysisDetailService.findAnalysis(1L, 40L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    void findAnalysis_whenPayloadJsonIsInvalid_throwsInternalServerError() {
+        GithubAnalysis githubAnalysis = githubAnalysisWithPayload("not-json");
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.of(githubAnalysis));
+
+        assertThatThrownBy(() -> githubAnalysisDetailService.findAnalysis(1L, 40L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private GithubAnalysis githubAnalysis(String payload, Instant createdAt) {
+        GithubAnalysis githubAnalysis = githubAnalysisWithPayload(payload);
+        given(githubAnalysis.getId()).willReturn(40L);
+        given(githubAnalysis.getVersion()).willReturn(2);
+        given(githubAnalysis.getCreatedAt()).willReturn(createdAt);
+        return githubAnalysis;
+    }
+
+    private GithubAnalysis githubAnalysisWithPayload(String payload) {
+        GithubAnalysis githubAnalysis = mock(GithubAnalysis.class);
+        given(githubAnalysis.getAnalysisPayload()).willReturn(payload);
+        return githubAnalysis;
+    }
+
+    private String validPayload() {
+        return """
+                {
+                  "staticSignals": {
+                    "primaryLanguages": [
+                      {
+                        "lang": "Java",
+                        "ratio": 0.6
+                      }
+                    ],
+                    "activeRepos": 12,
+                    "commitFrequency": "WEEKLY",
+                    "contributionPattern": "CONSISTENT"
+                  },
+                  "repoSummaries": [
+                    {
+                      "repoId": "9001",
+                      "repoName": "team06/ai-growth-coach",
+                      "summary": "Spring Boot backend service",
+                      "highlights": [
+                        "Redis cache",
+                        "Batch processing"
+                      ]
+                    }
+                  ],
+                  "techTags": [
+                    {
+                      "skillName": "Redis",
+                      "tagReason": "Cache configuration and TTL usage were found"
+                    }
+                  ],
+                  "depthEstimates": [
+                    {
+                      "skillName": "Redis",
+                      "level": "APPLIED",
+                      "reason": "Cache keys and TTL are used beyond dependency setup"
+                    }
+                  ],
+                  "evidences": [
+                    {
+                      "repoName": "team06/ai-growth-coach",
+                      "type": "CODE",
+                      "source": "src/main/java/com/back/coach/config/CacheConfig.java",
+                      "summary": "RedisTemplate and TTL configuration"
+                    }
+                  ],
+                  "userCorrections": [
+                    {
+                      "skillName": "Redis",
+                      "correction": "Used for cache only, not Pub/Sub"
+                    }
+                  ],
+                  "finalTechProfile": {
+                    "confirmedSkills": [
+                      "Java",
+                      "Spring Boot",
+                      "Redis"
+                    ],
+                    "focusAreas": [
+                      "Backend",
+                      "Performance"
+                    ]
+                  }
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -42,6 +42,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}", "get")
+                .get("x-implementation-status")).isEqualTo("implemented");
     }
 
     @Test

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -192,7 +192,7 @@ paths:
         - GitHub Analyses
       summary: Get GitHub analysis result
       operationId: getGithubAnalysis
-      x-implementation-status: planned
+      x-implementation-status: implemented
       parameters:
         - $ref: '#/components/parameters/GithubAnalysisId'
       responses:


### PR DESCRIPTION
﻿## 작업 내용
- `GET /api/github-analyses/{githubAnalysisId}`를 추가했습니다.
- 저장된 `github_analyses.analysis_payload`를 소유권 기준으로 조회하고 API 응답 형태로 파싱합니다.
- OpenAPI에서 GitHub 분석 결과 조회 API 구현 상태를 `implemented`로 갱신했습니다.

## 필요한 이유
GitHub 분석 생성/보정 이후 프론트가 저장된 분석 결과와 근거를 다시 표시하려면 `githubAnalysisId` 기준 재조회 API가 필요합니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #85
