### PR TITLE
feat(github): GitHub 분석 보정값 저장 API 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
+++ b/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
@@ -1,13 +1,18 @@
 package com.back.coach.domain.github.controller;
 
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.service.GithubAnalysisDetailService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +36,21 @@ public class GithubAnalysisController {
         return ApiResponse.success(githubAnalysisDetailService.findAnalysis(
                 authenticatedUser.userId(),
                 githubAnalysisId
+        ));
+    }
+
+    @PatchMapping(path = "/{githubAnalysisId}/corrections", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<GithubAnalysisCorrectionResponse> saveCorrections(
+            Authentication authentication,
+            @PathVariable Long githubAnalysisId,
+            @Valid @RequestBody GithubAnalysisCorrectionRequest request
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(githubAnalysisDetailService.saveCorrections(
+                authenticatedUser.userId(),
+                githubAnalysisId,
+                request
         ));
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisCorrectionRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisCorrectionRequest.java
@@ -1,0 +1,14 @@
+package com.back.coach.domain.github.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record GithubAnalysisCorrectionRequest(
+        @NotNull
+        List<GithubAnalysisPayload.GithubUserCorrection> userCorrections,
+
+        @NotNull
+        GithubAnalysisPayload.FinalTechProfile finalTechProfile
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisCorrectionResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisCorrectionResponse.java
@@ -1,0 +1,22 @@
+package com.back.coach.domain.github.dto;
+
+import java.time.Instant;
+
+public record GithubAnalysisCorrectionResponse(
+        String githubAnalysisId,
+        Instant savedAt,
+        GithubAnalysisPayload.FinalTechProfile finalTechProfile
+) {
+
+    public static GithubAnalysisCorrectionResponse of(
+            Long githubAnalysisId,
+            Instant savedAt,
+            GithubAnalysisPayload.FinalTechProfile finalTechProfile
+    ) {
+        return new GithubAnalysisCorrectionResponse(
+                String.valueOf(githubAnalysisId),
+                savedAt,
+                finalTechProfile
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubAnalysis.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubAnalysis.java
@@ -41,4 +41,8 @@ public class GithubAnalysis extends BaseEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    public void updateAnalysisPayload(String analysisPayload) {
+        this.analysisPayload = analysisPayload;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -1,6 +1,8 @@
 package com.back.coach.domain.github.service;
 
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.entity.GithubAnalysis;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
@@ -11,18 +13,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.Instant;
+
 @Service
 public class GithubAnalysisDetailService {
 
     private final GithubAnalysisRepository githubAnalysisRepository;
     private final ObjectMapper objectMapper;
+    private final Clock clock;
 
     public GithubAnalysisDetailService(
             GithubAnalysisRepository githubAnalysisRepository,
             ObjectMapper objectMapper
     ) {
+        this(githubAnalysisRepository, objectMapper, Clock.systemUTC());
+    }
+
+    GithubAnalysisDetailService(
+            GithubAnalysisRepository githubAnalysisRepository,
+            ObjectMapper objectMapper,
+            Clock clock
+    ) {
         this.githubAnalysisRepository = githubAnalysisRepository;
         this.objectMapper = objectMapper;
+        this.clock = clock;
     }
 
     @Transactional(readOnly = true)
@@ -39,9 +54,46 @@ public class GithubAnalysisDetailService {
         );
     }
 
+    @Transactional
+    public GithubAnalysisCorrectionResponse saveCorrections(
+            Long userId,
+            Long githubAnalysisId,
+            GithubAnalysisCorrectionRequest request
+    ) {
+        GithubAnalysis githubAnalysis = githubAnalysisRepository.findByIdAndUserId(githubAnalysisId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        GithubAnalysisPayload payload = parsePayload(githubAnalysis.getAnalysisPayload());
+        GithubAnalysisPayload updatedPayload = new GithubAnalysisPayload(
+                payload.staticSignals(),
+                payload.repoSummaries(),
+                payload.techTags(),
+                payload.depthEstimates(),
+                payload.evidences(),
+                request.userCorrections(),
+                request.finalTechProfile()
+        );
+
+        githubAnalysis.updateAnalysisPayload(toJson(updatedPayload));
+        Instant savedAt = Instant.now(clock);
+
+        return GithubAnalysisCorrectionResponse.of(
+                githubAnalysis.getId(),
+                savedAt,
+                request.finalTechProfile()
+        );
+    }
+
     private GithubAnalysisPayload parsePayload(String analysisPayload) {
         try {
             return objectMapper.readValue(analysisPayload, GithubAnalysisPayload.class);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String toJson(GithubAnalysisPayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException ex) {
             throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
         }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -10,6 +10,7 @@ import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class GithubAnalysisDetailService {
     private final ObjectMapper objectMapper;
     private final Clock clock;
 
+    @Autowired
     public GithubAnalysisDetailService(
             GithubAnalysisRepository githubAnalysisRepository,
             ObjectMapper objectMapper

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
@@ -1,5 +1,7 @@
 package com.back.coach.domain.github.controller;
 
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.service.GithubAnalysisDetailService;
@@ -23,13 +25,18 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import java.time.Instant;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,9 +55,12 @@ class GithubAnalysisControllerTest {
 
     @BeforeEach
     void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new GithubAnalysisController(githubAnalysisDetailService))
                 .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
     }
@@ -134,6 +144,83 @@ class GithubAnalysisControllerTest {
         mockMvc.perform(get("/api/github-analyses/{githubAnalysisId}", 40L)
                         .principal(authentication(1L))
                         .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    @Test
+    void saveCorrections_whenValidRequest_returnsSavedCorrectionResponse() throws Exception {
+        given(githubAnalysisDetailService.saveCorrections(eq(1L), eq(40L), any(GithubAnalysisCorrectionRequest.class)))
+                .willReturn(new GithubAnalysisCorrectionResponse(
+                        "40",
+                        Instant.parse("2026-04-29T02:00:00Z"),
+                        new GithubAnalysisPayload.FinalTechProfile(
+                                List.of("Java", "Spring Boot", "Redis"),
+                                List.of("백엔드", "성능 최적화")
+                        )
+                ));
+
+        mockMvc.perform(patch("/api/github-analyses/{githubAnalysisId}/corrections", 40L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userCorrections": [
+                                    {
+                                      "skillName": "Redis",
+                                      "correction": "캐시에만 사용했고 Pub/Sub은 사용하지 않음"
+                                    }
+                                  ],
+                                  "finalTechProfile": {
+                                    "confirmedSkills": ["Java", "Spring Boot", "Redis"],
+                                    "focusAreas": ["백엔드", "성능 최적화"]
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.githubAnalysisId").value("40"))
+                .andExpect(jsonPath("$.data.savedAt").value("2026-04-29T02:00:00Z"))
+                .andExpect(jsonPath("$.data.finalTechProfile.confirmedSkills[0]").value("Java"))
+                .andExpect(jsonPath("$.data.finalTechProfile.confirmedSkills[2]").value("Redis"))
+                .andExpect(jsonPath("$.data.finalTechProfile.focusAreas[1]").value("성능 최적화"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(githubAnalysisDetailService).saveCorrections(eq(1L), eq(40L), any(GithubAnalysisCorrectionRequest.class));
+    }
+
+    @Test
+    void saveCorrections_whenFinalTechProfileMissing_returnsInvalidInput() throws Exception {
+        mockMvc.perform(patch("/api/github-analyses/{githubAnalysisId}/corrections", 40L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userCorrections": []
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(githubAnalysisDetailService);
+    }
+
+    @Test
+    void saveCorrections_whenAnalysisDoesNotBelongToUser_returnsNotFound() throws Exception {
+        given(githubAnalysisDetailService.saveCorrections(eq(1L), eq(40L), any(GithubAnalysisCorrectionRequest.class)))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/github-analyses/{githubAnalysisId}/corrections", 40L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userCorrections": [],
+                                  "finalTechProfile": {
+                                    "confirmedSkills": ["Java"],
+                                    "focusAreas": ["백엔드"]
+                                  }
+                                }
+                                """))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
     }

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
@@ -1,5 +1,7 @@
 package com.back.coach.domain.github.service;
 
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
+import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.entity.GithubAnalysis;
@@ -16,16 +18,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class GithubAnalysisDetailServiceTest {
+
+    private static final Instant FIXED_NOW = Instant.parse("2026-04-29T02:00:00Z");
 
     private final ObjectMapper objectMapper = JsonMapper.builder()
             .findAndAddModules()
@@ -38,7 +47,11 @@ class GithubAnalysisDetailServiceTest {
 
     @BeforeEach
     void setUp() {
-        githubAnalysisDetailService = new GithubAnalysisDetailService(githubAnalysisRepository, objectMapper);
+        githubAnalysisDetailService = new GithubAnalysisDetailService(
+                githubAnalysisRepository,
+                objectMapper,
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC)
+        );
     }
 
     @Test
@@ -104,6 +117,92 @@ class GithubAnalysisDetailServiceTest {
         given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.of(githubAnalysis));
 
         assertThatThrownBy(() -> githubAnalysisDetailService.findAnalysis(1L, 40L))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void saveCorrections_whenAnalysisExists_replacesCorrectionsAndFinalProfileOnly() throws Exception {
+        GithubAnalysis githubAnalysis = githubAnalysisWithPayload(validPayload());
+        given(githubAnalysis.getId()).willReturn(40L);
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.of(githubAnalysis));
+        GithubAnalysisCorrectionRequest request = new GithubAnalysisCorrectionRequest(
+                List.of(new GithubAnalysisPayload.GithubUserCorrection(
+                        "Redis",
+                        "캐시에만 사용했고 Pub/Sub은 사용하지 않음"
+                )),
+                new GithubAnalysisPayload.FinalTechProfile(
+                        List.of("Java", "Spring Boot", "Redis", "PostgreSQL"),
+                        List.of("백엔드", "성능 최적화")
+                )
+        );
+
+        GithubAnalysisCorrectionResponse result = githubAnalysisDetailService.saveCorrections(1L, 40L, request);
+
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(githubAnalysis).updateAnalysisPayload(payloadCaptor.capture());
+        GithubAnalysisPayload updatedPayload = objectMapper.readValue(payloadCaptor.getValue(), GithubAnalysisPayload.class);
+        assertThat(updatedPayload.staticSignals().primaryLanguages())
+                .containsExactly(new GithubAnalysisPayload.PrimaryLanguage("Java", 0.6));
+        assertThat(updatedPayload.repoSummaries()).containsExactly(new GithubAnalysisPayload.RepoSummary(
+                "9001",
+                "team06/ai-growth-coach",
+                "Spring Boot backend service",
+                List.of("Redis cache", "Batch processing")
+        ));
+        assertThat(updatedPayload.techTags()).containsExactly(new GithubAnalysisPayload.TechTag(
+                "Redis",
+                "Cache configuration and TTL usage were found"
+        ));
+        assertThat(updatedPayload.depthEstimates()).containsExactly(new GithubAnalysisPayload.DepthEstimate(
+                "Redis",
+                GithubDepthLevel.APPLIED,
+                "Cache keys and TTL are used beyond dependency setup"
+        ));
+        assertThat(updatedPayload.evidences()).containsExactly(new GithubAnalysisPayload.GithubEvidence(
+                "team06/ai-growth-coach",
+                GithubEvidenceType.CODE,
+                "src/main/java/com/back/coach/config/CacheConfig.java",
+                "RedisTemplate and TTL configuration"
+        ));
+        assertThat(updatedPayload.userCorrections()).containsExactly(new GithubAnalysisPayload.GithubUserCorrection(
+                "Redis",
+                "캐시에만 사용했고 Pub/Sub은 사용하지 않음"
+        ));
+        assertThat(updatedPayload.finalTechProfile().confirmedSkills())
+                .containsExactly("Java", "Spring Boot", "Redis", "PostgreSQL");
+        assertThat(updatedPayload.finalTechProfile().focusAreas())
+                .containsExactly("백엔드", "성능 최적화");
+        assertThat(result.githubAnalysisId()).isEqualTo("40");
+        assertThat(result.savedAt()).isEqualTo(FIXED_NOW);
+        assertThat(result.finalTechProfile()).isEqualTo(request.finalTechProfile());
+    }
+
+    @Test
+    void saveCorrections_whenAnalysisDoesNotBelongToUser_throwsResourceNotFound() {
+        GithubAnalysisCorrectionRequest request = new GithubAnalysisCorrectionRequest(
+                List.of(),
+                new GithubAnalysisPayload.FinalTechProfile(List.of("Java"), List.of("백엔드"))
+        );
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> githubAnalysisDetailService.saveCorrections(1L, 40L, request))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    void saveCorrections_whenPayloadJsonIsInvalid_throwsInternalServerError() {
+        GithubAnalysis githubAnalysis = githubAnalysisWithPayload("not-json");
+        GithubAnalysisCorrectionRequest request = new GithubAnalysisCorrectionRequest(
+                List.of(),
+                new GithubAnalysisPayload.FinalTechProfile(List.of("Java"), List.of("백엔드"))
+        );
+        given(githubAnalysisRepository.findByIdAndUserId(40L, 1L)).willReturn(Optional.of(githubAnalysis));
+
+        assertThatThrownBy(() -> githubAnalysisDetailService.saveCorrections(1L, 40L, request))
                 .isInstanceOf(ServiceException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -44,6 +44,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}/corrections", "patch")
+                .get("x-implementation-status")).isEqualTo("implemented");
     }
 
     @Test

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -161,7 +161,7 @@ paths:
         - GitHub Analyses
       summary: Save GitHub analysis corrections
       operationId: saveGithubAnalysisCorrections
-      x-implementation-status: planned
+      x-implementation-status: implemented
       parameters:
         - $ref: '#/components/parameters/GithubAnalysisId'
       requestBody:


### PR DESCRIPTION
﻿## 작업 내용
- `PATCH /api/github-analyses/{githubAnalysisId}/corrections`를 추가했습니다.
- 저장된 GitHub 분석 payload에서 `userCorrections`, `finalTechProfile`만 교체 저장합니다.
- AI 추정 필드와 사용자 확정 필드를 분리해 유지합니다.
- OpenAPI에서 GitHub 분석 보정 저장 API 구현 상태를 `implemented`로 갱신했습니다.

## 필요한 이유
AI가 추정한 기술 사용 결과를 사용자가 바로잡고, 이후 진단이 보정된 기술 프로필을 기준으로 동작해야 합니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #87
