### PR TITLE
docs(github): GitHub 분석 payload 보정 규칙 정리

### DIFF
--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -42,6 +42,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/github-analyses", "post")
+                .get("x-implementation-status")).isEqualTo("planned");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}/corrections", "patch")

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -242,6 +242,8 @@
 v1 처리 기준
 - 현재 명세의 기본 외부 계약은 동기 응답이다
 - 추후 장시간 작업으로 확장할 경우 `job_status` 상태 모델을 따른다
+- GitHub 분석 실행은 새 결과 생성이므로 기존 row를 덮어쓰지 않고 사용자별 다음 `version` row를 생성한다
+- 최초 분석 결과의 `userCorrections`는 빈 배열일 수 있고, `finalTechProfile`은 AI 추정 결과 기반 초기값이다
 
 응답 body
 ```json
@@ -334,6 +336,12 @@ v1 처리 기준
 }
 ```
 
+처리 규칙
+- 보정 저장은 새 분석 실행이 아니므로 새 `github_analyses` row 또는 새 `version`을 만들지 않는다.
+- 기존 `analysis_payload`에서 `userCorrections`, `finalTechProfile`만 요청값으로 교체한다.
+- `staticSignals`, `repoSummaries`, `techTags`, `depthEstimates`, `evidences`는 분석 실행 당시의 AI/정적 분석 결과로 유지한다.
+- 응답의 `savedAt`은 보정 저장 처리 시각이다.
+
 ### 3.3.3 GitHub 분석 결과 조회
 
 - Method: `GET`
@@ -341,6 +349,12 @@ v1 처리 기준
 
 응답 body
 - `POST /api/github-analyses`의 `data`와 동일 구조
+
+조회 규칙
+- 현재 로그인 사용자가 소유한 `github_analyses` row만 조회할 수 있다.
+- 응답의 `githubAnalysisId`, `version`, `createdAt`은 row 헤더 컬럼 기준이다.
+- 나머지 분석 상세는 저장된 `analysis_payload` 기준으로 반환한다.
+- 보정 저장 후 조회하면 갱신된 `userCorrections`, `finalTechProfile`이 반환된다.
 
 ---
 

--- a/docs/09_contract_appendix.md
+++ b/docs/09_contract_appendix.md
@@ -195,6 +195,10 @@ shape
 - `evidences.type`은 `github_evidence_type` enum 사용
 - `depthEstimates.level`은 `github_depth_level` enum 사용
 - AI가 만든 후보와 사용자가 확정한 값은 같은 key 아래에 섞어 저장하지 않는다
+- `staticSignals`, `repoSummaries`, `techTags`, `depthEstimates`, `evidences`는 분석 실행 시 생성된 AI/정적 분석 결과다
+- `userCorrections`는 사용자가 AI 추정 결과를 보정한 설명이며, 보정 저장 시 이 배열 전체를 요청값으로 교체한다
+- `finalTechProfile`은 진단/로드맵에서 사용할 사용자 확정 기술 프로필이며, 보정 저장 시 요청값으로 교체한다
+- GitHub 분석 실행은 새 `version` row를 생성하지만, 보정 저장은 기존 row의 `analysis_payload.userCorrections`와 `analysis_payload.finalTechProfile`만 갱신한다
 
 ## 4.4 learning_roadmaps.roadmap_payload
 


### PR DESCRIPTION
﻿## 작업 내용
- GitHub 분석 payload 필드 책임을 문서에 정리했습니다.
- 보정 저장 시 갱신 대상이 `userCorrections`, `finalTechProfile`임을 명시했습니다.
- 분석 실행은 새 version row, 보정 저장은 기존 payload 갱신이라는 기준을 분리했습니다.
- GitHub 분석 생성/조회/보정 API 구현 상태 계약 테스트를 보강했습니다.

## 필요한 이유
분석 생성 담당과 조회/보정 담당이 같은 JSONB shape와 version 규칙을 기준으로 작업해야 합니다.

## 검증
- `cd backend && .\gradlew.bat test --tests com.back.coach.global.config.OpenApiContractTest`
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`

Closes #89
