### PR TITLE
test(result): 결과 version 최신 조회 기준 검증

### DIFF
--- a/backend/src/main/resources/db/migration/V3__result_latest_version_indexes.sql
+++ b/backend/src/main/resources/db/migration/V3__result_latest_version_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX idx_github_analyses_user_version_created_at
+    ON github_analyses (user_id, version DESC, created_at DESC);
+
+CREATE INDEX idx_capability_diagnoses_user_version_created_at
+    ON capability_diagnoses (user_id, version DESC, created_at DESC);
+
+CREATE INDEX idx_learning_roadmaps_user_version_created_at
+    ON learning_roadmaps (user_id, version DESC, created_at DESC);

--- a/backend/src/test/java/com/back/coach/domain/result/repository/ResultLatestVersionRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/result/repository/ResultLatestVersionRepositoryIntegrationTest.java
@@ -1,0 +1,170 @@
+package com.back.coach.domain.result.repository;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class ResultLatestVersionRepositoryIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Autowired
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Autowired
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Test
+    @DisplayName("결과 latest 조회는 created_at보다 version을 우선한다")
+    void latestResultQueriesPreferVersionBeforeCreatedAt() {
+        Long userId = insertUser();
+        Long githubConnectionId = insertGithubConnection(userId);
+        Long jobRoleId = findBackendDeveloperRoleId();
+
+        Long githubAnalysisV1 = insertGithubAnalysis(userId, githubConnectionId, 1, "2026-01-03T00:00:00Z");
+        Long githubAnalysisV2 = insertGithubAnalysis(userId, githubConnectionId, 2, "2026-01-01T00:00:00Z");
+        Long profileId = insertUserProfile(userId, jobRoleId);
+
+        Long diagnosisV1 = insertCapabilityDiagnosis(
+                userId, profileId, githubAnalysisV2, jobRoleId, 1, "2026-01-03T00:10:00Z");
+        Long diagnosisV2 = insertCapabilityDiagnosis(
+                userId, profileId, githubAnalysisV2, jobRoleId, 2, "2026-01-01T00:10:00Z");
+
+        Long roadmapV1 = insertLearningRoadmap(userId, diagnosisV2, 1, "2026-01-03T00:20:00Z");
+        Long roadmapV2 = insertLearningRoadmap(userId, diagnosisV2, 2, "2026-01-01T00:20:00Z");
+
+        GithubAnalysis latestGithubAnalysis = githubAnalysisRepository
+                .findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                .orElseThrow();
+        CapabilityDiagnosis latestDiagnosis = capabilityDiagnosisRepository
+                .findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                .orElseThrow();
+        LearningRoadmap latestRoadmap = learningRoadmapRepository
+                .findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                .orElseThrow();
+
+        assertThat(latestGithubAnalysis.getId()).isEqualTo(githubAnalysisV2);
+        assertThat(latestDiagnosis.getId()).isEqualTo(diagnosisV2);
+        assertThat(latestRoadmap.getId()).isEqualTo(roadmapV2);
+        assertThat(List.of(githubAnalysisV1, diagnosisV1, roadmapV1)).doesNotContainNull();
+
+        assertThat(githubAnalysisRepository.findMaxVersionByUserId(userId)).isEqualTo(2);
+        assertThat(capabilityDiagnosisRepository.findMaxVersionByUserId(userId)).isEqualTo(2);
+        assertThat(learningRoadmapRepository.findMaxVersionByUserId(userId)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("결과 latest 조회용 version 인덱스가 생성된다")
+    void latestVersionIndexesExist() {
+        List<String> indexNames = jdbcTemplate.queryForList("""
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                """, String.class);
+
+        assertThat(indexNames)
+                .contains(
+                        "idx_github_analyses_user_version_created_at",
+                        "idx_capability_diagnoses_user_version_created_at",
+                        "idx_learning_roadmaps_user_version_created_at"
+                );
+    }
+
+    private Long insertUser() {
+        String email = "latest-version-" + UUID.randomUUID() + "@example.com";
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO users (email, password_hash, auth_provider, is_active)
+                VALUES (?, 'hash', 'LOCAL', true)
+                RETURNING id
+                """, Long.class, email);
+    }
+
+    private Long insertGithubConnection(Long userId) {
+        String githubUserId = "github-" + UUID.randomUUID();
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO github_connections (user_id, github_user_id, github_login, access_type)
+                VALUES (?, ?, 'latest-version-user', 'OAUTH')
+                RETURNING id
+                """, Long.class, userId, githubUserId);
+    }
+
+    private Long findBackendDeveloperRoleId() {
+        return jdbcTemplate.queryForObject("""
+                SELECT id
+                FROM job_roles
+                WHERE role_code = 'BACKEND_DEVELOPER'
+                """, Long.class);
+    }
+
+    private Long insertUserProfile(Long userId, Long jobRoleId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO user_profiles (user_id, job_role_id, current_level, interest_areas_json)
+                VALUES (?, ?, 'JUNIOR', '[]'::jsonb)
+                RETURNING id
+                """, Long.class, userId, jobRoleId);
+    }
+
+    private Long insertGithubAnalysis(Long userId, Long githubConnectionId, int version, String createdAt) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO github_analyses (
+                    user_id, github_connection_id, version, summary, analysis_payload, created_at
+                )
+                VALUES (?, ?, ?, ?, '{}'::jsonb, ?::timestamptz)
+                RETURNING id
+                """, Long.class, userId, githubConnectionId, version, "GitHub analysis v" + version, createdAt);
+    }
+
+    private Long insertCapabilityDiagnosis(
+            Long userId,
+            Long profileId,
+            Long githubAnalysisId,
+            Long jobRoleId,
+            int version,
+            String createdAt
+    ) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO capability_diagnoses (
+                    user_id,
+                    profile_id,
+                    github_analysis_id,
+                    job_role_id,
+                    version,
+                    current_level,
+                    summary,
+                    diagnosis_payload,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, ?, 'JUNIOR', ?, '{}'::jsonb, ?::timestamptz)
+                RETURNING id
+                """, Long.class, userId, profileId, githubAnalysisId, jobRoleId, version,
+                "Capability diagnosis v" + version, createdAt);
+    }
+
+    private Long insertLearningRoadmap(Long userId, Long diagnosisId, int version, String createdAt) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO learning_roadmaps (
+                    user_id, diagnosis_id, version, total_weeks, summary, roadmap_payload, created_at
+                )
+                VALUES (?, ?, ?, 4, ?, '{}'::jsonb, ?::timestamptz)
+                RETURNING id
+                """, Long.class, userId, diagnosisId, version, "Learning roadmap v" + version, createdAt);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/result/service/ResultVersionServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/result/service/ResultVersionServiceTest.java
@@ -37,12 +37,39 @@ class ResultVersionServiceTest {
     }
 
     @Test
+    void nextGithubAnalysisVersion_whenPreviousResultExists_returnsNextVersion() {
+        given(githubAnalysisRepository.findMaxVersionByUserId(1L)).willReturn(5);
+
+        int nextVersion = resultVersionService.nextGithubAnalysisVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(6);
+    }
+
+    @Test
+    void nextCapabilityDiagnosisVersion_whenNoPreviousResult_returnsOne() {
+        given(capabilityDiagnosisRepository.findMaxVersionByUserId(1L)).willReturn(null);
+
+        int nextVersion = resultVersionService.nextCapabilityDiagnosisVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(1);
+    }
+
+    @Test
     void nextCapabilityDiagnosisVersion_whenPreviousResultExists_returnsNextVersion() {
         given(capabilityDiagnosisRepository.findMaxVersionByUserId(1L)).willReturn(3);
 
         int nextVersion = resultVersionService.nextCapabilityDiagnosisVersion(1L);
 
         assertThat(nextVersion).isEqualTo(4);
+    }
+
+    @Test
+    void nextLearningRoadmapVersion_whenNoPreviousResult_returnsOne() {
+        given(learningRoadmapRepository.findMaxVersionByUserId(1L)).willReturn(null);
+
+        int nextVersion = resultVersionService.nextLearningRoadmapVersion(1L);
+
+        assertThat(nextVersion).isEqualTo(1);
     }
 
     @Test

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -340,6 +340,7 @@ v1 처리 기준
 - 보정 저장은 새 분석 실행이 아니므로 새 `github_analyses` row 또는 새 `version`을 만들지 않는다.
 - 기존 `analysis_payload`에서 `userCorrections`, `finalTechProfile`만 요청값으로 교체한다.
 - `staticSignals`, `repoSummaries`, `techTags`, `depthEstimates`, `evidences`는 분석 실행 당시의 AI/정적 분석 결과로 유지한다.
+- 이 저장은 기존 결과 row의 사용자 확정값 갱신이므로 latest 조회 기준의 `version` 값에는 영향을 주지 않는다.
 - 응답의 `savedAt`은 보정 저장 처리 시각이다.
 
 ### 3.3.3 GitHub 분석 결과 조회
@@ -618,6 +619,7 @@ v1 처리 기준
 
 조회 규칙
 - 현재 로그인 사용자의 최신 프로필, 최신 GitHub 분석, 최신 진단, 최신 로드맵을 조립한다
+- GitHub 분석, 진단, 로드맵의 최신 결과는 `version desc, created_at desc` 순서로 선택한다
 - 아직 생성되지 않은 결과 영역은 `null`로 반환한다
 - 로드맵 진행률은 `progress_logs` 최신 row 기준으로 계산한다
 - 대시보드는 화면 편의용 snapshot이며, 각 결과의 원본 상세 조회를 대체하지 않는다
@@ -707,7 +709,9 @@ data: {"sessionId":"10001"}
 규칙
 - 새 실행은 기존 row update가 아니라 새 row insert
 - 같은 사용자, 같은 결과 종류 내에서 `version` 1씩 증가
-- 기본 조회는 최신 결과 반환 정책을 따르되, 상세 조회는 ID 기준으로 고정한다
+- 기본 snapshot/latest 조회는 `version desc, created_at desc` 순서의 최신 결과 반환 정책을 따른다
+- 상세 조회는 `id` 기준으로 고정하며, `created_at` 또는 latest 기준으로 다른 row를 대체 조회하지 않는다
+- `PATCH /api/github-analyses/{githubAnalysisId}/corrections`는 새 분석 실행이 아니므로 `version`을 올리지 않고 기존 row의 보정 필드만 갱신한다
 
 ### 5.2 진도 상태 규칙
 

--- a/docs/08_db_physical_schema.md
+++ b/docs/08_db_physical_schema.md
@@ -201,6 +201,7 @@
 
 인덱스/제약
 - `uq_github_analyses_user_version` on (`user_id`, `version`)
+- `idx_github_analyses_user_version_created_at` on (`user_id`, `version desc`, `created_at desc`)
 - `idx_github_analyses_user_created_at` on (`user_id`, `created_at desc`)
 
 ### 4.9 capability_diagnoses
@@ -220,6 +221,7 @@
 
 인덱스/제약
 - `uq_capability_diagnoses_user_version` on (`user_id`, `version`)
+- `idx_capability_diagnoses_user_version_created_at` on (`user_id`, `version desc`, `created_at desc`)
 - `idx_capability_diagnoses_user_created_at` on (`user_id`, `created_at desc`)
 
 ### 4.10 learning_roadmaps
@@ -237,6 +239,7 @@
 
 인덱스/제약
 - `uq_learning_roadmaps_user_version` on (`user_id`, `version`)
+- `idx_learning_roadmaps_user_version_created_at` on (`user_id`, `version desc`, `created_at desc`)
 - `idx_learning_roadmaps_user_created_at` on (`user_id`, `created_at desc`)
 
 ### 4.11 roadmap_weeks
@@ -379,9 +382,9 @@
 ## 7. 조회 성능용 핵심 인덱스
 
 반드시 필요한 인덱스
-- 최신 GitHub 분석 조회: `github_analyses(user_id, created_at desc)`
-- 최신 진단 조회: `capability_diagnoses(user_id, created_at desc)`
-- 최신 로드맵 조회: `learning_roadmaps(user_id, created_at desc)`
+- 최신 GitHub 분석 조회: `github_analyses(user_id, version desc, created_at desc)`
+- 최신 진단 조회: `capability_diagnoses(user_id, version desc, created_at desc)`
+- 최신 로드맵 조회: `learning_roadmaps(user_id, version desc, created_at desc)`
 - 로드맵 주차 조회: `roadmap_weeks(roadmap_id, week_number)`
 - 진도 최신 상태 조회: `progress_logs(user_id, roadmap_week_id, created_at desc)`
 - 활성 snapshot 조회: `user_context_snapshots(user_id, context_type)` where `valid_to is null`

--- a/docs/09_contract_appendix.md
+++ b/docs/09_contract_appendix.md
@@ -199,6 +199,7 @@ shape
 - `userCorrections`는 사용자가 AI 추정 결과를 보정한 설명이며, 보정 저장 시 이 배열 전체를 요청값으로 교체한다
 - `finalTechProfile`은 진단/로드맵에서 사용할 사용자 확정 기술 프로필이며, 보정 저장 시 요청값으로 교체한다
 - GitHub 분석 실행은 새 `version` row를 생성하지만, 보정 저장은 기존 row의 `analysis_payload.userCorrections`와 `analysis_payload.finalTechProfile`만 갱신한다
+- 보정 저장은 사용자 확정값을 같은 분석 결과에 반영하는 작업이므로 latest 조회 기준의 `version`을 변경하지 않는다
 
 ## 4.4 learning_roadmaps.roadmap_payload
 
@@ -409,8 +410,10 @@ shape
 규칙
 - 같은 사용자, 같은 결과 종류 내에서 `version`을 1씩 증가
 - 새 실행 결과는 기존 row update가 아니라 새 row insert
-- 기본 조회는 최신 version 반환
+- 기본 snapshot/latest 조회는 `version desc, created_at desc` 순서의 최신 결과를 반환
+- 상세 조회는 `id` 기준으로 고정하며 latest 기준으로 다른 결과를 대신 반환하지 않는다
 - 과거 조회가 필요하면 version 지정 조회 허용
+- GitHub 분석 보정 저장은 새 실행 결과가 아니므로 기존 row의 `analysis_payload.userCorrections`, `analysis_payload.finalTechProfile`만 갱신하고 `version`을 올리지 않는다
 - v2 `chat_sessions.profile_version`, `roadmap_version`은 세션 시작 시 snapshot version을 고정한다
 
 ## 7. 구현 체크포인트


### PR DESCRIPTION
## 핵심 변경
- GitHub 분석/진단/로드맵 latest 기준을 `version desc, created_at desc`로 문서화했습니다.
- 결과 테이블에 latest 조회용 `(user_id, version desc, created_at desc)` 인덱스를 추가했습니다.
- version 증가 규칙과 repository latest 조회 규칙을 테스트로 고정했습니다.

## 필요한 이유
대시보드와 상세 재조회가 서로 다른 결과 version을 보여주면 사용자 상태가 흔들릴 수 있어, 최신 결과 기준을 version 중심으로 통일해야 합니다.

## 검증
- `cd backend && .\gradlew.bat test`
- `cd backend && .\gradlew.bat prVerification`
- `cd backend && .\gradlew.bat integrationTest --tests *ResultLatestVersionRepositoryIntegrationTest`

Closes #91