### PR TITLE
feat(frontend): v1 라우팅 shell 추가

### DIFF
--- a/frontend/src/app/diagnoses/[diagnosisId]/page.tsx
+++ b/frontend/src/app/diagnoses/[diagnosisId]/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function DiagnosisDetailPage() {
+  return <ScreenShell screen={screens.diagnosisDetail} />;
+}

--- a/frontend/src/app/github/analysis/page.tsx
+++ b/frontend/src/app/github/analysis/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function GithubAnalysisPage() {
+  return <ScreenShell screen={screens.githubAnalysis} />;
+}

--- a/frontend/src/app/github/page.tsx
+++ b/frontend/src/app/github/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function GithubConnectionPage() {
+  return <ScreenShell screen={screens.githubConnection} />;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6,6 +6,8 @@
   --line: #d8dde6;
   --accent: #2563eb;
   --accent-soft: #e8f0ff;
+  --success: #16803c;
+  --success-soft: #e9f8ef;
 }
 
 * {
@@ -30,14 +32,14 @@ a {
   text-decoration: none;
 }
 
-.app-frame {
+.app-shell {
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
 }
 
 .topbar {
-  height: 56px;
+  min-height: 56px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -47,13 +49,35 @@ a {
 }
 
 .brand {
+  color: var(--foreground);
   font-size: 16px;
   font-weight: 700;
+  white-space: nowrap;
 }
 
-.status {
+.topnav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow-x: auto;
+  padding-left: 24px;
+}
+
+.nav-link {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 6px;
+  padding: 0 10px;
   color: var(--muted);
   font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.nav-link[data-active="true"] {
+  color: var(--accent);
+  background: var(--accent-soft);
 }
 
 .page {
@@ -62,48 +86,133 @@ a {
   padding: 32px 24px;
 }
 
-.page-title {
-  margin: 0 0 20px;
-  font-size: 28px;
-  line-height: 1.25;
-}
-
-.summary-grid {
+.screen-shell {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
+  gap: 24px;
 }
 
-.summary-item {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
-  padding: 16px;
+.screen-hero {
+  display: grid;
+  gap: 18px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
 }
 
-.summary-label {
-  margin: 0 0 8px;
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.summary-value {
+.eyebrow {
   margin: 0;
-  font-size: 18px;
+  color: var(--accent);
+  font-size: 13px;
   font-weight: 700;
 }
 
-.summary-item[data-state="active"] {
+.screen-heading {
+  max-width: 760px;
+}
+
+.screen-heading h1 {
+  margin: 0;
+  font-size: 30px;
+  line-height: 1.25;
+}
+
+.screen-heading p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.action-link {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0 14px;
+  background: var(--surface);
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.action-link.primary {
   border-color: var(--accent);
-  background: var(--accent-soft);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px;
+}
+
+.panel h2 {
+  margin: 0 0 14px;
+  font-size: 16px;
+  line-height: 1.35;
+}
+
+.state-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.state-chip {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  background: var(--success-soft);
+  color: var(--success);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.item-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 @media (max-width: 640px) {
   .topbar {
-    padding: 0 16px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 16px;
+  }
+
+  .topnav {
+    width: 100%;
+    padding-left: 0;
   }
 
   .page {
     padding: 24px 16px;
+  }
+
+  .screen-heading h1 {
+    font-size: 26px;
   }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+
+import { AppShell } from "@/components/app-shell";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,7 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <AppShell>{children}</AppShell>
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,32 +1,6 @@
-const dashboardItems = [
-  { label: "프로필", value: "준비 중", state: "active" },
-  { label: "GitHub 분석", value: "대기" },
-  { label: "진단", value: "대기" },
-  { label: "로드맵", value: "대기" }
-];
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
 
 export default function Home() {
-  return (
-    <div className="app-frame">
-      <header className="topbar">
-        <span className="brand">AI Growth Coach</span>
-        <span className="status">v1</span>
-      </header>
-      <main className="page">
-        <h1 className="page-title">대시보드</h1>
-        <section className="summary-grid" aria-label="현재 상태 요약">
-          {dashboardItems.map((item) => (
-            <article
-              className="summary-item"
-              data-state={item.state}
-              key={item.label}
-            >
-              <p className="summary-label">{item.label}</p>
-              <p className="summary-value">{item.value}</p>
-            </article>
-          ))}
-        </section>
-      </main>
-    </div>
-  );
+  return <ScreenShell screen={screens.dashboard} />;
 }

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function ProfilePage() {
+  return <ScreenShell screen={screens.profile} />;
+}

--- a/frontend/src/app/roadmaps/[roadmapId]/page.tsx
+++ b/frontend/src/app/roadmaps/[roadmapId]/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function RoadmapDetailPage() {
+  return <ScreenShell screen={screens.roadmapDetail} />;
+}

--- a/frontend/src/app/roadmaps/new/page.tsx
+++ b/frontend/src/app/roadmaps/new/page.tsx
@@ -1,0 +1,6 @@
+import { ScreenShell } from "@/components/screen-shell";
+import { screens } from "@/config/routes";
+
+export default function RoadmapCreatePage() {
+  return <ScreenShell screen={screens.roadmapCreate} />;
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { isNavigationItemActive, navigationItems } from "@/config/routes";
+
+type AppShellProps = {
+  children: ReactNode;
+};
+
+export function AppShell({ children }: AppShellProps) {
+  const pathname = usePathname();
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <Link className="brand" href="/">
+          AI Growth Coach
+        </Link>
+        <nav className="topnav" aria-label="v1 화면 이동">
+          {navigationItems.map((item) => {
+            const isActive = isNavigationItemActive(item, pathname);
+
+            return (
+              <Link
+                aria-current={isActive ? "page" : undefined}
+                className="nav-link"
+                data-active={isActive}
+                href={item.href}
+                key={item.href}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </header>
+      <main className="page">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/screen-shell.tsx
+++ b/frontend/src/components/screen-shell.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+
+import type { ScreenDefinition } from "@/config/routes";
+
+type ScreenShellProps = {
+  screen: ScreenDefinition;
+};
+
+export function ScreenShell({ screen }: ScreenShellProps) {
+  return (
+    <section className="screen-shell">
+      <div className="screen-hero">
+        <p className="eyebrow">{screen.eyebrow}</p>
+        <div className="screen-heading">
+          <h1>{screen.title}</h1>
+          <p>{screen.description}</p>
+        </div>
+        <div className="action-row" aria-label="다음 행동">
+          <Link className="action-link primary" href={screen.primaryAction.href}>
+            {screen.primaryAction.label}
+          </Link>
+          {screen.secondaryAction ? (
+            <Link className="action-link" href={screen.secondaryAction.href}>
+              {screen.secondaryAction.label}
+            </Link>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="content-grid">
+        <section className="panel" aria-labelledby="screen-states-title">
+          <h2 id="screen-states-title">화면 상태</h2>
+          <div className="state-list">
+            {screen.states.map((state) => (
+              <span className="state-chip" key={state}>
+                {state}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {screen.sections.map((section) => (
+          <section className="panel" key={section.title}>
+            <h2>{section.title}</h2>
+            <ul className="item-list">
+              {section.items.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -1,0 +1,189 @@
+export type NavigationItem = {
+  href: string;
+  label: string;
+  activePrefix?: string;
+  exact?: boolean;
+};
+
+export type ActionLink = {
+  label: string;
+  href: string;
+};
+
+export type ScreenDefinition = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  states: string[];
+  primaryAction: ActionLink;
+  secondaryAction?: ActionLink;
+  sections: {
+    title: string;
+    items: string[];
+  }[];
+};
+
+export const navigationItems: NavigationItem[] = [
+  { href: "/", label: "대시보드", exact: true },
+  { href: "/profile", label: "프로필", activePrefix: "/profile" },
+  { href: "/github", label: "GitHub", exact: true },
+  {
+    href: "/github/analysis",
+    label: "분석 보정",
+    activePrefix: "/github/analysis"
+  },
+  {
+    href: "/diagnoses/demo",
+    label: "진단",
+    activePrefix: "/diagnoses"
+  },
+  { href: "/roadmaps/new", label: "로드맵 생성", exact: true },
+  {
+    href: "/roadmaps/demo",
+    label: "로드맵",
+    activePrefix: "/roadmaps"
+  }
+];
+
+export const screens = {
+  dashboard: {
+    eyebrow: "v1 확장",
+    title: "대시보드",
+    description:
+      "프로필, GitHub 분석, 진단, 로드맵의 최신 상태를 한 화면에서 확인하는 진입점입니다.",
+    states: ["최신 결과 조회", "상세 화면 이동", "진도 요약 확인"],
+    primaryAction: { label: "프로필 입력", href: "/profile" },
+    secondaryAction: { label: "로드맵 보기", href: "/roadmaps/demo" },
+    sections: [
+      {
+        title: "표시 예정 데이터",
+        items: [
+          "최근 프로필 요약",
+          "최종 기술 프로필과 보정 개수",
+          "최근 진단 결과와 로드맵 진행률"
+        ]
+      }
+    ]
+  },
+  profile: {
+    eyebrow: "v1 필수",
+    title: "프로필 입력 / 수정",
+    description:
+      "목표 직무, 현재 수준, 기술 스택, 관심 분야와 학습 가능 시간을 저장하는 시작 화면입니다.",
+    states: ["입력 전", "저장 중", "저장 완료"],
+    primaryAction: { label: "GitHub 연동으로 이동", href: "/github" },
+    secondaryAction: { label: "대시보드로 이동", href: "/" },
+    sections: [
+      {
+        title: "입력 예정 항목",
+        items: [
+          "목표 직무와 현재 수준",
+          "사용자 입력 기술 스택",
+          "관심 분야, 주당 학습 시간, 목표 날짜"
+        ]
+      }
+    ]
+  },
+  githubConnection: {
+    eyebrow: "v1 필수",
+    title: "GitHub 연동 / 저장소 선택",
+    description:
+      "GitHub 계정을 연결하고 분석 대상 저장소와 핵심 repo를 선택하는 화면입니다.",
+    states: ["연결 전", "저장소 불러오는 중", "분석 시작 가능"],
+    primaryAction: { label: "분석 결과 확인", href: "/github/analysis" },
+    secondaryAction: { label: "프로필로 돌아가기", href: "/profile" },
+    sections: [
+      {
+        title: "선택 예정 항목",
+        items: [
+          "GitHub OAuth 연결 상태",
+          "전체 정적 분석 대상 저장소",
+          "LLM 요약 대상 핵심 repo"
+        ]
+      }
+    ]
+  },
+  githubAnalysis: {
+    eyebrow: "v1 필수",
+    title: "GitHub 분석 결과 / 사용자 보정",
+    description:
+      "정적 분석 결과와 근거를 확인하고 사용자 보정값을 저장하는 화면입니다.",
+    states: ["분석 완료", "보정 전", "보정 저장 완료"],
+    primaryAction: { label: "진단 결과 확인", href: "/diagnoses/demo" },
+    secondaryAction: { label: "저장소 선택으로 이동", href: "/github" },
+    sections: [
+      {
+        title: "표시 예정 데이터",
+        items: [
+          "정적 분석 요약과 repo 요약",
+          "기술 태그, 사용 깊이 후보, 근거",
+          "사용자 보정과 최종 기술 프로필"
+        ]
+      }
+    ]
+  },
+  diagnosisDetail: {
+    eyebrow: "v1 필수",
+    title: "역량 진단 결과",
+    description:
+      "GitHub 최종 분석이 반영된 부족 기술, 강점, 추천 우선순위를 확인하는 화면입니다.",
+    states: ["진단 결과 조회", "부족 기술 확인", "로드맵 생성 가능"],
+    primaryAction: { label: "로드맵 생성", href: "/roadmaps/new" },
+    secondaryAction: { label: "분석 보정으로 이동", href: "/github/analysis" },
+    sections: [
+      {
+        title: "표시 예정 데이터",
+        items: ["역량 요약", "부족 기술 목록", "강점과 추천 우선순위"]
+      }
+    ]
+  },
+  roadmapCreate: {
+    eyebrow: "v1 필수",
+    title: "학습 로드맵 생성",
+    description:
+      "진단 결과를 기준으로 학습 가능 시간과 목표 날짜를 확인한 뒤 로드맵을 생성하는 화면입니다.",
+    states: ["진단 선택", "생성 요청", "생성 완료"],
+    primaryAction: { label: "로드맵 보기", href: "/roadmaps/demo" },
+    secondaryAction: { label: "진단 결과로 이동", href: "/diagnoses/demo" },
+    sections: [
+      {
+        title: "입력 예정 항목",
+        items: ["진단 결과 ID", "주당 학습 시간 override", "목표 날짜 override"]
+      }
+    ]
+  },
+  roadmapDetail: {
+    eyebrow: "v1 필수",
+    title: "학습 로드맵 / 진도 관리",
+    description:
+      "주차별 학습 계획과 추천 자료를 확인하고 최신 진도 상태를 저장하는 화면입니다.",
+    states: ["로드맵 조회", "주차별 상태 확인", "진도 저장"],
+    primaryAction: { label: "대시보드로 이동", href: "/" },
+    secondaryAction: { label: "로드맵 생성으로 이동", href: "/roadmaps/new" },
+    sections: [
+      {
+        title: "표시 예정 데이터",
+        items: [
+          "주차별 학습 주제와 추천 자료",
+          "표시용 weekNumber와 저장용 roadmapWeekId",
+          "최신 progressStatus, progressNote, progressUpdatedAt"
+        ]
+      }
+    ]
+  }
+} satisfies Record<string, ScreenDefinition>;
+
+export function isNavigationItemActive(
+  item: NavigationItem,
+  pathname: string
+) {
+  if (item.exact) {
+    return pathname === item.href;
+  }
+
+  if (item.href === "/roadmaps/demo") {
+    return pathname.startsWith("/roadmaps/") && pathname !== "/roadmaps/new";
+  }
+
+  return pathname.startsWith(item.activePrefix ?? item.href);
+}


### PR DESCRIPTION
## 핵심 변경
- v1 화면 흐름에 맞는 Next.js route 추가
- 공통 app shell과 활성 navigation 추가
- API 연결/폼 검증/상태 관리는 다음 작업으로 분리

## 필요한 이유
- 이후 진도 저장 API 연결과 화면 구현을 안정적인 route 구조 위에서 나눠 진행하기 위해 필요합니다.

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm audit --audit-level=moderate`
- `npm run dev` 후 `/`, `/profile`, `/github`, `/github/analysis`, `/diagnoses/demo`, `/roadmaps/new`, `/roadmaps/demo` 렌더링 확인
- 브라우저에서 `/roadmaps/demo` 활성 navigation이 `로드맵`으로 표시되는지 확인
- 백엔드 변경 없음: 백엔드 테스트는 실행하지 않았습니다.

Closes #100