### PR TITLE
feat(frontend-api): 공통 API 클라이언트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ npm run dev
 
 기본 주소는 `http://localhost:3000`입니다.
 
+프론트에서 백엔드 API를 호출하려면 `frontend/.env.local`에 API base URL을 설정합니다. 값이 없으면 같은 origin의 상대 경로로 요청합니다.
+
+```powershell
+Set-Content .env.local "NEXT_PUBLIC_API_BASE_URL=http://localhost:8080"
+```
+
 프론트 변경 검증은 다음 명령으로 확인합니다.
 
 ```powershell

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,181 @@
+import type {
+  ApiEnvelope,
+  ApiErrorBody,
+  ApiRequestOptions
+} from "@/lib/api/types";
+
+type HttpMethod = "GET" | "POST" | "PATCH";
+
+export type ApiTokenProvider = () =>
+  | Promise<string | null | undefined>
+  | string
+  | null
+  | undefined;
+
+type ApiErrorParams = {
+  status: number;
+  statusText: string;
+  body?: ApiErrorBody;
+};
+
+const JSON_CONTENT_TYPE = "application/json";
+
+let tokenProvider: ApiTokenProvider | null = null;
+
+export class ApiError extends Error {
+  readonly code?: string;
+  readonly details?: ApiErrorBody["details"];
+  readonly status: number;
+  readonly statusText: string;
+  readonly traceId?: string;
+
+  constructor({ status, statusText, body }: ApiErrorParams) {
+    super(body?.message ?? `API request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.statusText = statusText;
+    this.code = body?.code;
+    this.details = body?.details;
+    this.traceId = body?.details?.traceId;
+  }
+}
+
+export function setApiTokenProvider(provider: ApiTokenProvider | null) {
+  tokenProvider = provider;
+}
+
+export function getApiBaseUrl() {
+  return (process.env.NEXT_PUBLIC_API_BASE_URL ?? "").replace(/\/+$/, "");
+}
+
+export function resolveApiUrl(path: string) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const baseUrl = getApiBaseUrl();
+
+  return baseUrl ? `${baseUrl}${normalizedPath}` : normalizedPath;
+}
+
+async function request<TData>(
+  method: HttpMethod,
+  path: string,
+  options: ApiRequestOptions = {}
+) {
+  const { body, token, headers, ...requestInit } = options;
+  const resolvedToken = token ?? (await tokenProvider?.()) ?? undefined;
+  const response = await fetch(resolveApiUrl(path), {
+    ...requestInit,
+    body: serializeBody(body),
+    headers: buildHeaders(headers, body, resolvedToken),
+    method
+  });
+  const payload = await parseJson(response);
+
+  if (!response.ok) {
+    throw new ApiError({
+      body: toApiErrorBody(payload),
+      status: response.status,
+      statusText: response.statusText
+    });
+  }
+
+  return unwrapApiResponse<TData>(payload);
+}
+
+function buildHeaders(
+  initHeaders: HeadersInit | undefined,
+  body: unknown,
+  token: string | undefined
+) {
+  const headers = new Headers(initHeaders);
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", JSON_CONTENT_TYPE);
+  }
+
+  if (body !== undefined && !isNativeBody(body) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", JSON_CONTENT_TYPE);
+  }
+
+  if (token && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  return headers;
+}
+
+function serializeBody(body: unknown): BodyInit | undefined {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  if (isNativeBody(body)) {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
+function isNativeBody(body: unknown): body is BodyInit {
+  return (
+    typeof body === "string" ||
+    (typeof FormData !== "undefined" && body instanceof FormData) ||
+    (typeof Blob !== "undefined" && body instanceof Blob) ||
+    (typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams) ||
+    (typeof ArrayBuffer !== "undefined" && body instanceof ArrayBuffer)
+  );
+}
+
+async function parseJson(response: Response) {
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (!contentType.includes(JSON_CONTENT_TYPE)) {
+    return undefined;
+  }
+
+  return response.json();
+}
+
+function unwrapApiResponse<TData>(payload: unknown) {
+  if (isApiEnvelope<TData>(payload)) {
+    return payload.data;
+  }
+
+  return payload as TData;
+}
+
+function isApiEnvelope<TData>(payload: unknown): payload is ApiEnvelope<TData> {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "data" in payload &&
+    "meta" in payload
+  );
+}
+
+function toApiErrorBody(payload: unknown): ApiErrorBody | undefined {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  return payload as ApiErrorBody;
+}
+
+export const apiClient = {
+  get<TData>(path: string, options?: ApiRequestOptions) {
+    return request<TData>("GET", path, options);
+  },
+  patch<TData>(path: string, body?: unknown, options?: ApiRequestOptions) {
+    return request<TData>("PATCH", path, { ...options, body });
+  },
+  post<TData>(path: string, body?: unknown, options?: ApiRequestOptions) {
+    return request<TData>("POST", path, { ...options, body });
+  }
+};

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,0 +1,16 @@
+export {
+  ApiError,
+  apiClient,
+  getApiBaseUrl,
+  resolveApiUrl,
+  setApiTokenProvider
+} from "@/lib/api/client";
+export type {
+  ApiEnvelope,
+  ApiErrorBody,
+  ApiErrorDetails,
+  ApiErrorField,
+  ApiMeta,
+  ApiRequestOptions
+} from "@/lib/api/types";
+export type { ApiTokenProvider } from "@/lib/api/client";

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -1,0 +1,27 @@
+export type ApiMeta = Record<string, unknown>;
+
+export type ApiEnvelope<TData> = {
+  data: TData;
+  meta: ApiMeta;
+};
+
+export type ApiErrorField = {
+  field: string;
+  reason: string;
+};
+
+export type ApiErrorDetails = Record<string, unknown> & {
+  traceId?: string;
+  fieldErrors?: ApiErrorField[];
+};
+
+export type ApiErrorBody = {
+  code?: string;
+  message?: string;
+  details?: ApiErrorDetails | null;
+};
+
+export type ApiRequestOptions = Omit<RequestInit, "body" | "method"> & {
+  body?: unknown;
+  token?: string;
+};


### PR DESCRIPTION
## 변경 사항
- 프론트 공통 API 응답/에러 타입 추가
- `NEXT_PUBLIC_API_BASE_URL` 기반 API client 추가
- `{ data, meta }` 응답 unwrap과 공통 `ApiError` 처리 추가
- 추후 JWT Authorization 헤더 주입 지점 추가
- README에 프론트 API base URL 설정 안내 추가

## 왜 필요한가
로드맵, 대시보드, 프로필 등 이후 화면들이 같은 백엔드 응답 형식을 사용하므로, 화면마다 `fetch`/unwrap/error 처리를 반복하지 않도록 공통 진입점을 먼저 둡니다.

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #102