### PR TITLE
feat(roadmap): 로드맵 상세 진도 연결

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -195,6 +195,189 @@ a {
   line-height: 1.5;
 }
 
+.roadmap-detail {
+  display: grid;
+  gap: 24px;
+}
+
+.roadmap-summary-list,
+.roadmap-week-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+}
+
+.roadmap-summary-list div,
+.roadmap-week-meta div {
+  min-width: 140px;
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--surface);
+}
+
+.roadmap-summary-list dt,
+.roadmap-week-meta dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.roadmap-summary-list dd,
+.roadmap-week-meta dd {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.roadmap-week-list {
+  display: grid;
+  gap: 16px;
+}
+
+.roadmap-week-card {
+  display: grid;
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 20px;
+}
+
+.roadmap-week-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.roadmap-week-kicker {
+  margin: 0 0 4px;
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.roadmap-week-header h2 {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.35;
+}
+
+.progress-badge {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.progress-badge[data-status="todo"] {
+  background: #eef2f7;
+  color: #475467;
+}
+
+.progress-badge[data-status="in-progress"] {
+  background: #e8f0ff;
+  color: #2563eb;
+}
+
+.progress-badge[data-status="done"] {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.progress-badge[data-status="skipped"] {
+  background: #fff4e5;
+  color: #a15c00;
+}
+
+.roadmap-week-reason {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.roadmap-progress-note {
+  display: grid;
+  gap: 6px;
+  border-left: 3px solid var(--accent);
+  padding-left: 12px;
+}
+
+.roadmap-progress-note strong {
+  font-size: 13px;
+}
+
+.roadmap-progress-note p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.roadmap-week-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.roadmap-week-columns h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+}
+
+.roadmap-detail-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.roadmap-detail-list li {
+  display: grid;
+  gap: 4px;
+  color: var(--foreground);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.roadmap-detail-list span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.roadmap-detail-list a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.roadmap-state-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.roadmap-state-panel[data-tone="danger"] {
+  border-color: #f3b4b4;
+  background: #fff5f5;
+}
+
+.roadmap-state-panel[data-tone="danger"] p {
+  color: #a32020;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -214,5 +397,9 @@ a {
 
   .screen-heading h1 {
     font-size: 26px;
+  }
+
+  .roadmap-week-header {
+    flex-direction: column;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -324,6 +324,81 @@ a {
   line-height: 1.5;
 }
 
+.roadmap-progress-form {
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: #fbfcfe;
+}
+
+.roadmap-progress-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.roadmap-progress-form label span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.roadmap-progress-form select,
+.roadmap-progress-form textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--foreground);
+  font: inherit;
+}
+
+.roadmap-progress-form select {
+  min-height: 38px;
+  padding: 0 10px;
+}
+
+.roadmap-progress-form textarea {
+  min-height: 84px;
+  resize: vertical;
+  padding: 10px;
+  line-height: 1.5;
+}
+
+.roadmap-progress-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.roadmap-progress-actions p {
+  margin: 0;
+  color: #a32020;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.roadmap-progress-actions button {
+  min-height: 38px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 0 14px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.roadmap-progress-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .roadmap-week-columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -400,6 +475,11 @@ a {
   }
 
   .roadmap-week-header {
+    flex-direction: column;
+  }
+
+  .roadmap-progress-actions {
+    align-items: stretch;
     flex-direction: column;
   }
 }

--- a/frontend/src/app/roadmaps/[roadmapId]/page.tsx
+++ b/frontend/src/app/roadmaps/[roadmapId]/page.tsx
@@ -1,6 +1,15 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { RoadmapDetailView } from "@/features/roadmap/roadmap-detail-view";
 
-export default function RoadmapDetailPage() {
-  return <ScreenShell screen={screens.roadmapDetail} />;
+type RoadmapDetailPageProps = {
+  params: Promise<{
+    roadmapId: string;
+  }>;
+};
+
+export default async function RoadmapDetailPage({
+  params
+}: RoadmapDetailPageProps) {
+  const { roadmapId } = await params;
+
+  return <RoadmapDetailView roadmapId={roadmapId} />;
 }

--- a/frontend/src/features/roadmap/api.ts
+++ b/frontend/src/features/roadmap/api.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/lib/api";
+import type { Roadmap } from "@/features/roadmap/types";
+
+export function getRoadmap(roadmapId: string) {
+  return apiClient.get<Roadmap>(`/api/roadmaps/${roadmapId}`);
+}

--- a/frontend/src/features/roadmap/api.ts
+++ b/frontend/src/features/roadmap/api.ts
@@ -1,6 +1,20 @@
 import { apiClient } from "@/lib/api";
-import type { Roadmap } from "@/features/roadmap/types";
+import type {
+  Roadmap,
+  RoadmapProgressRequest,
+  RoadmapProgressResponse
+} from "@/features/roadmap/types";
 
 export function getRoadmap(roadmapId: string) {
   return apiClient.get<Roadmap>(`/api/roadmaps/${roadmapId}`);
+}
+
+export function saveRoadmapProgress(
+  roadmapId: string,
+  payload: RoadmapProgressRequest
+) {
+  return apiClient.post<RoadmapProgressResponse>(
+    `/api/roadmaps/${roadmapId}/progress`,
+    payload
+  );
 }

--- a/frontend/src/features/roadmap/labels.ts
+++ b/frontend/src/features/roadmap/labels.ts
@@ -1,0 +1,38 @@
+import type { MaterialType, ProgressStatus, RoadmapTaskType } from "@/features/roadmap/types";
+
+export const progressStatusOptions: ProgressStatus[] = [
+  "TODO",
+  "IN_PROGRESS",
+  "DONE",
+  "SKIPPED"
+];
+
+export const progressStatusLabels: Record<ProgressStatus, string> = {
+  DONE: "완료",
+  IN_PROGRESS: "진행 중",
+  SKIPPED: "건너뜀",
+  TODO: "예정"
+};
+
+export const progressStatusClassNames: Record<ProgressStatus, string> = {
+  DONE: "done",
+  IN_PROGRESS: "in-progress",
+  SKIPPED: "skipped",
+  TODO: "todo"
+};
+
+export const taskTypeLabels: Record<RoadmapTaskType, string> = {
+  APPLY_PROJECT: "프로젝트 적용",
+  BUILD_EXAMPLE: "예제 구현",
+  READ_DOCS: "문서 읽기",
+  REVIEW: "복습",
+  WRITE_NOTE: "노트 작성"
+};
+
+export const materialTypeLabels: Record<MaterialType, string> = {
+  ARTICLE: "아티클",
+  DOCS: "문서",
+  REPOSITORY: "저장소",
+  TEMPLATE: "템플릿",
+  VIDEO: "영상"
+};

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getRoadmap } from "@/features/roadmap/api";
+import {
+  materialTypeLabels,
+  progressStatusClassNames,
+  progressStatusLabels,
+  taskTypeLabels
+} from "@/features/roadmap/labels";
+import type { Roadmap } from "@/features/roadmap/types";
+import { ApiError } from "@/lib/api";
+
+type RoadmapDetailViewProps = {
+  roadmapId: string;
+};
+
+type RoadmapState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; roadmap: Roadmap };
+
+export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
+  const [state, setState] = useState<RoadmapState>({ status: "loading" });
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadRoadmap() {
+      setState({ status: "loading" });
+
+      try {
+        const roadmap = await getRoadmap(roadmapId);
+
+        if (!ignore) {
+          setState({ roadmap, status: "success" });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({ message: getErrorMessage(error), status: "error" });
+        }
+      }
+    }
+
+    loadRoadmap();
+
+    return () => {
+      ignore = true;
+    };
+  }, [roadmapId]);
+
+  if (state.status === "loading") {
+    return <RoadmapStatePanel message="로드맵을 불러오는 중입니다." />;
+  }
+
+  if (state.status === "error") {
+    return <RoadmapStatePanel message={state.message} tone="danger" />;
+  }
+
+  const { roadmap } = state;
+
+  return (
+    <section className="roadmap-detail" aria-labelledby="roadmap-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v{roadmap.version} 로드맵</p>
+        <div className="screen-heading">
+          <h1 id="roadmap-title">학습 로드맵 / 진도 관리</h1>
+          <p>{roadmap.summary}</p>
+        </div>
+        <dl className="roadmap-summary-list" aria-label="로드맵 요약">
+          <div>
+            <dt>로드맵 ID</dt>
+            <dd>{roadmap.roadmapId}</dd>
+          </div>
+          <div>
+            <dt>전체 기간</dt>
+            <dd>{roadmap.totalWeeks}주</dd>
+          </div>
+          <div>
+            <dt>생성일</dt>
+            <dd>{formatDateTime(roadmap.createdAt)}</dd>
+          </div>
+        </dl>
+      </div>
+
+      {roadmap.weeks.length === 0 ? (
+        <RoadmapStatePanel message="표시할 주차 계획이 없습니다." />
+      ) : (
+        <div className="roadmap-week-list">
+          {roadmap.weeks.map((week) => {
+            const progressStatus = week.progressStatus ?? "TODO";
+
+            return (
+              <article className="roadmap-week-card" key={week.roadmapWeekId}>
+                <div className="roadmap-week-header">
+                  <div>
+                    <p className="roadmap-week-kicker">{week.weekNumber}주차</p>
+                    <h2>{week.topic}</h2>
+                  </div>
+                  <span
+                    className="progress-badge"
+                    data-status={progressStatusClassNames[progressStatus]}
+                  >
+                    {progressStatusLabels[progressStatus]}
+                  </span>
+                </div>
+
+                <p className="roadmap-week-reason">{week.reason}</p>
+
+                <dl className="roadmap-week-meta">
+                  <div>
+                    <dt>예상 시간</dt>
+                    <dd>{formatHours(week.estimatedHours)}</dd>
+                  </div>
+                  <div>
+                    <dt>저장 ID</dt>
+                    <dd>{week.roadmapWeekId}</dd>
+                  </div>
+                  <div>
+                    <dt>최근 변경</dt>
+                    <dd>
+                      {week.progressUpdatedAt
+                        ? formatDateTime(week.progressUpdatedAt)
+                        : "아직 없음"}
+                    </dd>
+                  </div>
+                </dl>
+
+                {week.progressNote ? (
+                  <div className="roadmap-progress-note">
+                    <strong>진도 메모</strong>
+                    <p>{week.progressNote}</p>
+                  </div>
+                ) : null}
+
+                <div className="roadmap-week-columns">
+                  <section aria-label={`${week.weekNumber}주차 작업`}>
+                    <h3>작업</h3>
+                    <ul className="roadmap-detail-list">
+                      {week.tasks.map((task) => (
+                        <li key={`${task.type}-${task.title}`}>
+                          <span>{taskTypeLabels[task.type]}</span>
+                          {task.title}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+
+                  <section aria-label={`${week.weekNumber}주차 자료`}>
+                    <h3>자료</h3>
+                    <ul className="roadmap-detail-list">
+                      {week.materials.map((material) => (
+                        <li key={`${material.type}-${material.title}`}>
+                          <span>{materialTypeLabels[material.type]}</span>
+                          {material.url ? (
+                            <a href={material.url} rel="noreferrer" target="_blank">
+                              {material.title}
+                            </a>
+                          ) : (
+                            material.title
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RoadmapStatePanel({
+  message,
+  tone = "neutral"
+}: {
+  message: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
+    <section className="panel roadmap-state-panel" data-tone={tone}>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "로드맵을 불러오지 못했습니다.";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}
+
+function formatHours(value: number) {
+  return `${value.toLocaleString("ko-KR", {
+    maximumFractionDigits: 1
+  })}시간`;
+}

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
-import { getRoadmap } from "@/features/roadmap/api";
+import { getRoadmap, saveRoadmapProgress } from "@/features/roadmap/api";
 import {
   materialTypeLabels,
   progressStatusClassNames,
   progressStatusLabels,
+  progressStatusOptions,
   taskTypeLabels
 } from "@/features/roadmap/labels";
-import type { Roadmap } from "@/features/roadmap/types";
+import type { ProgressStatus, Roadmap } from "@/features/roadmap/types";
 import { ApiError } from "@/lib/api";
 
 type RoadmapDetailViewProps = {
@@ -23,6 +24,8 @@ type RoadmapState =
 
 export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
   const [state, setState] = useState<RoadmapState>({ status: "loading" });
+  const [savingWeekId, setSavingWeekId] = useState<string | null>(null);
+  const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let ignore = false;
@@ -38,7 +41,10 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
         }
       } catch (error) {
         if (!ignore) {
-          setState({ message: getErrorMessage(error), status: "error" });
+          setState({
+            message: getErrorMessage(error, "로드맵을 불러오지 못했습니다."),
+            status: "error"
+          });
         }
       }
     }
@@ -49,6 +55,73 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
       ignore = true;
     };
   }, [roadmapId]);
+
+  async function handleProgressSubmit(
+    event: FormEvent<HTMLFormElement>,
+    roadmapWeekId: string
+  ) {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const status = formData.get("status");
+    const note = formData.get("note");
+
+    if (!isProgressStatus(status)) {
+      setSaveErrors((current) => ({
+        ...current,
+        [roadmapWeekId]: "진도 상태를 선택해 주세요."
+      }));
+      return;
+    }
+
+    const normalizedNote =
+      typeof note === "string" && note.trim().length > 0 ? note.trim() : null;
+
+    setSavingWeekId(roadmapWeekId);
+    setSaveErrors((current) => {
+      const next = { ...current };
+      delete next[roadmapWeekId];
+      return next;
+    });
+
+    try {
+      const saved = await saveRoadmapProgress(roadmapId, {
+        note: normalizedNote,
+        roadmapWeekId,
+        status
+      });
+
+      setState((current) => {
+        if (current.status !== "success") {
+          return current;
+        }
+
+        return {
+          roadmap: {
+            ...current.roadmap,
+            weeks: current.roadmap.weeks.map((week) =>
+              week.roadmapWeekId === saved.roadmapWeekId
+                ? {
+                    ...week,
+                    progressNote: normalizedNote,
+                    progressStatus: saved.status,
+                    progressUpdatedAt: saved.savedAt
+                  }
+                : week
+            )
+          },
+          status: "success"
+        };
+      });
+    } catch (error) {
+      setSaveErrors((current) => ({
+        ...current,
+        [roadmapWeekId]: getErrorMessage(error, "진도를 저장하지 못했습니다.")
+      }));
+    } finally {
+      setSavingWeekId(null);
+    }
+  }
 
   if (state.status === "loading") {
     return <RoadmapStatePanel message="로드맵을 불러오는 중입니다." />;
@@ -134,6 +207,50 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
                   </div>
                 ) : null}
 
+                <form
+                  className="roadmap-progress-form"
+                  key={`${week.roadmapWeekId}-${progressStatus}-${week.progressUpdatedAt ?? ""}`}
+                  onSubmit={(event) =>
+                    handleProgressSubmit(event, week.roadmapWeekId)
+                  }
+                >
+                  <label>
+                    <span>진도 상태</span>
+                    <select defaultValue={progressStatus} name="status">
+                      {progressStatusOptions.map((status) => (
+                        <option key={status} value={status}>
+                          {progressStatusLabels[status]}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label>
+                    <span>메모</span>
+                    <textarea
+                      defaultValue={week.progressNote ?? ""}
+                      maxLength={1000}
+                      name="note"
+                      placeholder="학습 결과나 다음에 볼 내용을 적어두세요."
+                      rows={3}
+                    />
+                  </label>
+
+                  <div className="roadmap-progress-actions">
+                    {saveErrors[week.roadmapWeekId] ? (
+                      <p role="alert">{saveErrors[week.roadmapWeekId]}</p>
+                    ) : null}
+                    <button
+                      disabled={savingWeekId === week.roadmapWeekId}
+                      type="submit"
+                    >
+                      {savingWeekId === week.roadmapWeekId
+                        ? "저장 중"
+                        : "진도 저장"}
+                    </button>
+                  </div>
+                </form>
+
                 <div className="roadmap-week-columns">
                   <section aria-label={`${week.weekNumber}주차 작업`}>
                     <h3>작업</h3>
@@ -188,12 +305,21 @@ function RoadmapStatePanel({
   );
 }
 
-function getErrorMessage(error: unknown) {
+function getErrorMessage(error: unknown, fallbackMessage: string) {
   if (error instanceof ApiError) {
     return error.message;
   }
 
-  return "로드맵을 불러오지 못했습니다.";
+  return fallbackMessage;
+}
+
+function isProgressStatus(
+  value: FormDataEntryValue | null
+): value is ProgressStatus {
+  return (
+    typeof value === "string" &&
+    progressStatusOptions.includes(value as ProgressStatus)
+  );
 }
 
 function formatDateTime(value: string) {

--- a/frontend/src/features/roadmap/types.ts
+++ b/frontend/src/features/roadmap/types.ts
@@ -1,0 +1,62 @@
+export type ProgressStatus = "TODO" | "IN_PROGRESS" | "DONE" | "SKIPPED";
+
+export type RoadmapTaskType =
+  | "READ_DOCS"
+  | "BUILD_EXAMPLE"
+  | "WRITE_NOTE"
+  | "APPLY_PROJECT"
+  | "REVIEW";
+
+export type MaterialType =
+  | "DOCS"
+  | "ARTICLE"
+  | "REPOSITORY"
+  | "VIDEO"
+  | "TEMPLATE";
+
+export type RoadmapTask = {
+  type: RoadmapTaskType;
+  title: string;
+};
+
+export type RoadmapMaterial = {
+  type: MaterialType;
+  title: string;
+  url?: string | null;
+};
+
+export type RoadmapWeek = {
+  estimatedHours: number;
+  materials: RoadmapMaterial[];
+  progressNote?: string | null;
+  progressStatus?: ProgressStatus | null;
+  progressUpdatedAt?: string | null;
+  reason: string;
+  roadmapWeekId: string;
+  tasks: RoadmapTask[];
+  topic: string;
+  weekNumber: number;
+};
+
+export type Roadmap = {
+  createdAt: string;
+  diagnosisId?: string | null;
+  roadmapId: string;
+  summary: string;
+  totalWeeks: number;
+  version: number;
+  weeks: RoadmapWeek[];
+};
+
+export type RoadmapProgressRequest = {
+  note?: string | null;
+  roadmapWeekId: string;
+  status: ProgressStatus;
+};
+
+export type RoadmapProgressResponse = {
+  progressLogId: string;
+  roadmapWeekId: string;
+  savedAt: string;
+  status: ProgressStatus;
+};


### PR DESCRIPTION
## 변경 사항
- 로드맵 상세/주차/진도 저장 API 타입 추가
- `GET /api/roadmaps/{roadmapId}` 상세 조회 연결
- `POST /api/roadmaps/{roadmapId}/progress` 주차별 진도 저장 연결
- 진행 상태 한글 라벨, loading/error/empty 상태 추가

## 왜 필요한가
로드맵 화면이 저장된 학습 계획과 최신 진도를 보여주고, 사용자가 주차별 상태와 메모를 저장할 수 있어야 실제 진도 관리 화면으로 동작합니다.

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #104