### PR TITLE
feat(dashboard): 대시보드 최신 결과 요약 연결

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -453,6 +453,150 @@ a {
   color: #a32020;
 }
 
+.dashboard-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 14px;
+}
+
+.dashboard-summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dashboard-summary-card h2 {
+  margin-bottom: 0;
+}
+
+.dashboard-card-summary,
+.dashboard-card-note,
+.dashboard-empty-summary p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.dashboard-card-link {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0 12px;
+  background: var(--surface);
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.dashboard-metric-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.dashboard-metric-list div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px;
+  background: #fbfcfe;
+}
+
+.dashboard-metric-list dt,
+.dashboard-progress-summary dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dashboard-metric-list dd,
+.dashboard-progress-summary dd {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.dashboard-tag-group {
+  display: grid;
+  gap: 8px;
+}
+
+.dashboard-tag-group p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dashboard-tag-group div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dashboard-tag-group span {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dashboard-progress-summary {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-progress-summary > div {
+  display: grid;
+  gap: 4px;
+}
+
+.dashboard-progress-summary strong {
+  color: var(--success);
+  font-size: 30px;
+  line-height: 1;
+}
+
+.dashboard-progress-summary span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.dashboard-progress-summary dl {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.dashboard-progress-summary dl div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px;
+  background: #fbfcfe;
+}
+
+.dashboard-empty-summary {
+  display: grid;
+  gap: 12px;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -481,5 +625,9 @@ a {
   .roadmap-progress-actions {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .dashboard-progress-summary dl {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 
@@ -10,9 +10,12 @@ export default function MePage() {
   const [me, setMe] = useState<Me | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const didInitialLoad = useRef(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  const load = useCallback(async (showLoading = true) => {
+    if (showLoading) {
+      setLoading(true);
+    }
     setError(null);
     const res = await api<Me>("/api/v1/auth/me");
     if (res.ok && res.data) {
@@ -26,7 +29,12 @@ export default function MePage() {
   }, []);
 
   useEffect(() => {
-    load();
+    if (didInitialLoad.current) {
+      return;
+    }
+
+    didInitialLoad.current = true;
+    void load(false);
   }, [load]);
 
   const refresh = async () => {
@@ -48,7 +56,7 @@ export default function MePage() {
       {me && <pre>{JSON.stringify(me, null, 2)}</pre>}
 
       <p>
-        <button onClick={load}>다시 조회</button>{" "}
+        <button onClick={() => void load()}>다시 조회</button>{" "}
         <button onClick={refresh}>토큰 갱신 (/refresh)</button>{" "}
         <button onClick={logout}>로그아웃</button>
       </p>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,5 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { DashboardView } from "@/features/dashboard/dashboard-view";
 
 export default function Home() {
-  return <ScreenShell screen={screens.dashboard} />;
+  return <DashboardView />;
 }

--- a/frontend/src/features/dashboard/api.ts
+++ b/frontend/src/features/dashboard/api.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/lib/api";
+import type { Dashboard } from "@/features/dashboard/types";
+
+export function getDashboard() {
+  return apiClient.get<Dashboard>("/api/dashboard");
+}

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { getDashboard } from "@/features/dashboard/api";
 import { currentLevelLabels } from "@/features/dashboard/labels";
-import type { Dashboard } from "@/features/dashboard/types";
+import type {
+  Dashboard,
+  DashboardProgressSummary
+} from "@/features/dashboard/types";
 import { ApiError } from "@/lib/api";
 
 type DashboardState =
@@ -62,76 +66,142 @@ export function DashboardView() {
           <h1>대시보드</h1>
           <p>프로필, GitHub 분석, 진단, 로드맵의 최신 상태를 확인합니다.</p>
         </div>
+        <div className="action-row" aria-label="주요 화면 이동">
+          <Link className="action-link primary" href="/profile">
+            프로필 입력
+          </Link>
+          {dashboard.roadmap ? (
+            <Link
+              className="action-link"
+              href={`/roadmaps/${dashboard.roadmap.roadmapId}`}
+            >
+              최근 로드맵
+            </Link>
+          ) : null}
+        </div>
       </div>
 
-      <div className="content-grid">
-        <section className="panel">
+      <div className="dashboard-summary-grid">
+        <section className="panel dashboard-summary-card">
           <h2>프로필</h2>
           {dashboard.profile ? (
-            <ul className="item-list">
-              <li>직무 ID: {dashboard.profile.jobRoleId}</li>
-              <li>현재 수준: {currentLevelLabels[dashboard.profile.currentLevel]}</li>
-              <li>
-                주당 학습 시간:{" "}
-                {dashboard.profile.weeklyStudyHours
-                  ? `${dashboard.profile.weeklyStudyHours}시간`
-                  : "미설정"}
-              </li>
-              <li>수정일: {formatDateTime(dashboard.profile.updatedAt)}</li>
-            </ul>
+            <>
+              <dl className="dashboard-metric-list">
+                <div>
+                  <dt>현재 수준</dt>
+                  <dd>{currentLevelLabels[dashboard.profile.currentLevel]}</dd>
+                </div>
+                <div>
+                  <dt>주당 학습</dt>
+                  <dd>
+                    {dashboard.profile.weeklyStudyHours
+                      ? `${dashboard.profile.weeklyStudyHours}시간`
+                      : "미설정"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>목표일</dt>
+                  <dd>{dashboard.profile.targetDate ?? "미설정"}</dd>
+                </div>
+              </dl>
+              <p className="dashboard-card-note">
+                최근 수정 {formatDateTime(dashboard.profile.updatedAt)}
+              </p>
+              <Link className="dashboard-card-link" href="/profile">
+                프로필 보기
+              </Link>
+            </>
           ) : (
-            <EmptySummary message="저장된 프로필이 없습니다." />
+            <EmptySummary
+              actionHref="/profile"
+              actionLabel="프로필 입력"
+              message="저장된 프로필이 없습니다."
+            />
           )}
         </section>
 
-        <section className="panel">
+        <section className="panel dashboard-summary-card">
           <h2>GitHub 분석</h2>
           {dashboard.githubAnalysis ? (
-            <ul className="item-list">
-              <li>{dashboard.githubAnalysis.summary}</li>
-              <li>
-                확정 기술:{" "}
-                {formatList(
-                  dashboard.githubAnalysis.finalTechProfile.confirmedSkills
-                )}
-              </li>
-              <li>
-                보정 개수: {dashboard.githubAnalysis.userCorrectionCount}개
-              </li>
-              <li>생성일: {formatDateTime(dashboard.githubAnalysis.createdAt)}</li>
-            </ul>
+            <>
+              <p className="dashboard-card-summary">
+                {dashboard.githubAnalysis.summary}
+              </p>
+              <TagList
+                items={dashboard.githubAnalysis.finalTechProfile.confirmedSkills}
+                label="확정 기술"
+              />
+              <TagList
+                items={dashboard.githubAnalysis.finalTechProfile.focusAreas}
+                label="관심 영역"
+              />
+              <p className="dashboard-card-note">
+                사용자 보정 {dashboard.githubAnalysis.userCorrectionCount}개 ·{" "}
+                {formatDateTime(dashboard.githubAnalysis.createdAt)}
+              </p>
+              <Link className="dashboard-card-link" href="/github/analysis">
+                분석 보정 보기
+              </Link>
+            </>
           ) : (
-            <EmptySummary message="저장된 GitHub 분석이 없습니다." />
+            <EmptySummary
+              actionHref="/github"
+              actionLabel="GitHub 연동"
+              message="저장된 GitHub 분석이 없습니다."
+            />
           )}
         </section>
 
-        <section className="panel">
+        <section className="panel dashboard-summary-card">
           <h2>진단</h2>
           {dashboard.diagnosis ? (
-            <ul className="item-list">
-              <li>{dashboard.diagnosis.summary}</li>
-              <li>버전: v{dashboard.diagnosis.version}</li>
-              <li>생성일: {formatDateTime(dashboard.diagnosis.createdAt)}</li>
-            </ul>
+            <>
+              <p className="dashboard-card-summary">
+                {dashboard.diagnosis.summary}
+              </p>
+              <p className="dashboard-card-note">
+                v{dashboard.diagnosis.version} ·{" "}
+                {formatDateTime(dashboard.diagnosis.createdAt)}
+              </p>
+              <Link
+                className="dashboard-card-link"
+                href={`/diagnoses/${dashboard.diagnosis.diagnosisId}`}
+              >
+                진단 결과 보기
+              </Link>
+            </>
           ) : (
-            <EmptySummary message="저장된 진단 결과가 없습니다." />
+            <EmptySummary
+              actionHref="/github/analysis"
+              actionLabel="분석 보정"
+              message="저장된 진단 결과가 없습니다."
+            />
           )}
         </section>
 
-        <section className="panel">
+        <section className="panel dashboard-summary-card">
           <h2>로드맵</h2>
           {dashboard.roadmap ? (
-            <ul className="item-list">
-              <li>{dashboard.roadmap.summary}</li>
-              <li>전체 기간: {dashboard.roadmap.totalWeeks}주</li>
-              <li>
-                진행: 완료 {dashboard.roadmap.progress.doneWeeks}주 / 전체{" "}
-                {dashboard.roadmap.progress.totalWeeks}주
-              </li>
-              <li>생성일: {formatDateTime(dashboard.roadmap.createdAt)}</li>
-            </ul>
+            <>
+              <p className="dashboard-card-summary">{dashboard.roadmap.summary}</p>
+              <ProgressSummary progress={dashboard.roadmap.progress} />
+              <p className="dashboard-card-note">
+                v{dashboard.roadmap.version} · {dashboard.roadmap.totalWeeks}주 ·{" "}
+                {formatDateTime(dashboard.roadmap.createdAt)}
+              </p>
+              <Link
+                className="dashboard-card-link"
+                href={`/roadmaps/${dashboard.roadmap.roadmapId}`}
+              >
+                로드맵 보기
+              </Link>
+            </>
           ) : (
-            <EmptySummary message="저장된 로드맵이 없습니다." />
+            <EmptySummary
+              actionHref="/roadmaps/new"
+              actionLabel="로드맵 생성"
+              message="저장된 로드맵이 없습니다."
+            />
           )}
         </section>
       </div>
@@ -153,8 +223,76 @@ function DashboardStatePanel({
   );
 }
 
-function EmptySummary({ message }: { message: string }) {
-  return <p className="dashboard-empty-summary">{message}</p>;
+function EmptySummary({
+  actionHref,
+  actionLabel,
+  message
+}: {
+  actionHref: string;
+  actionLabel: string;
+  message: string;
+}) {
+  return (
+    <div className="dashboard-empty-summary">
+      <p>{message}</p>
+      <Link className="dashboard-card-link" href={actionHref}>
+        {actionLabel}
+      </Link>
+    </div>
+  );
+}
+
+function TagList({ items, label }: { items: string[]; label: string }) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="dashboard-tag-group">
+      <p>{label}</p>
+      <div>
+        {items.map((item) => (
+          <span key={item}>{item}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProgressSummary({ progress }: { progress: DashboardProgressSummary }) {
+  const doneRate =
+    progress.totalWeeks > 0
+      ? Math.round((progress.doneWeeks / progress.totalWeeks) * 100)
+      : 0;
+
+  return (
+    <div className="dashboard-progress-summary">
+      <div>
+        <strong>{doneRate}%</strong>
+        <span>
+          완료 {progress.doneWeeks}주 / 전체 {progress.totalWeeks}주
+        </span>
+      </div>
+      <dl>
+        <div>
+          <dt>예정</dt>
+          <dd>{progress.todoWeeks}</dd>
+        </div>
+        <div>
+          <dt>진행</dt>
+          <dd>{progress.inProgressWeeks}</dd>
+        </div>
+        <div>
+          <dt>완료</dt>
+          <dd>{progress.doneWeeks}</dd>
+        </div>
+        <div>
+          <dt>건너뜀</dt>
+          <dd>{progress.skippedWeeks}</dd>
+        </div>
+      </dl>
+    </div>
+  );
 }
 
 function getErrorMessage(error: unknown) {
@@ -170,8 +308,4 @@ function formatDateTime(value: string) {
     dateStyle: "medium",
     timeStyle: "short"
   }).format(new Date(value));
-}
-
-function formatList(values: string[]) {
-  return values.length > 0 ? values.join(", ") : "없음";
 }

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getDashboard } from "@/features/dashboard/api";
+import { currentLevelLabels } from "@/features/dashboard/labels";
+import type { Dashboard } from "@/features/dashboard/types";
+import { ApiError } from "@/lib/api";
+
+type DashboardState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; dashboard: Dashboard };
+
+export function DashboardView() {
+  const [state, setState] = useState<DashboardState>({ status: "loading" });
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadDashboard() {
+      setState({ status: "loading" });
+
+      try {
+        const dashboard = await getDashboard();
+
+        if (!ignore) {
+          setState({ dashboard, status: "success" });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({
+            message: getErrorMessage(error),
+            status: "error"
+          });
+        }
+      }
+    }
+
+    loadDashboard();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  if (state.status === "loading") {
+    return <DashboardStatePanel message="대시보드를 불러오는 중입니다." />;
+  }
+
+  if (state.status === "error") {
+    return <DashboardStatePanel message={state.message} tone="danger" />;
+  }
+
+  const { dashboard } = state;
+
+  return (
+    <section className="screen-shell">
+      <div className="screen-hero">
+        <p className="eyebrow">사용자 {dashboard.userId}</p>
+        <div className="screen-heading">
+          <h1>대시보드</h1>
+          <p>프로필, GitHub 분석, 진단, 로드맵의 최신 상태를 확인합니다.</p>
+        </div>
+      </div>
+
+      <div className="content-grid">
+        <section className="panel">
+          <h2>프로필</h2>
+          {dashboard.profile ? (
+            <ul className="item-list">
+              <li>직무 ID: {dashboard.profile.jobRoleId}</li>
+              <li>현재 수준: {currentLevelLabels[dashboard.profile.currentLevel]}</li>
+              <li>
+                주당 학습 시간:{" "}
+                {dashboard.profile.weeklyStudyHours
+                  ? `${dashboard.profile.weeklyStudyHours}시간`
+                  : "미설정"}
+              </li>
+              <li>수정일: {formatDateTime(dashboard.profile.updatedAt)}</li>
+            </ul>
+          ) : (
+            <EmptySummary message="저장된 프로필이 없습니다." />
+          )}
+        </section>
+
+        <section className="panel">
+          <h2>GitHub 분석</h2>
+          {dashboard.githubAnalysis ? (
+            <ul className="item-list">
+              <li>{dashboard.githubAnalysis.summary}</li>
+              <li>
+                확정 기술:{" "}
+                {formatList(
+                  dashboard.githubAnalysis.finalTechProfile.confirmedSkills
+                )}
+              </li>
+              <li>
+                보정 개수: {dashboard.githubAnalysis.userCorrectionCount}개
+              </li>
+              <li>생성일: {formatDateTime(dashboard.githubAnalysis.createdAt)}</li>
+            </ul>
+          ) : (
+            <EmptySummary message="저장된 GitHub 분석이 없습니다." />
+          )}
+        </section>
+
+        <section className="panel">
+          <h2>진단</h2>
+          {dashboard.diagnosis ? (
+            <ul className="item-list">
+              <li>{dashboard.diagnosis.summary}</li>
+              <li>버전: v{dashboard.diagnosis.version}</li>
+              <li>생성일: {formatDateTime(dashboard.diagnosis.createdAt)}</li>
+            </ul>
+          ) : (
+            <EmptySummary message="저장된 진단 결과가 없습니다." />
+          )}
+        </section>
+
+        <section className="panel">
+          <h2>로드맵</h2>
+          {dashboard.roadmap ? (
+            <ul className="item-list">
+              <li>{dashboard.roadmap.summary}</li>
+              <li>전체 기간: {dashboard.roadmap.totalWeeks}주</li>
+              <li>
+                진행: 완료 {dashboard.roadmap.progress.doneWeeks}주 / 전체{" "}
+                {dashboard.roadmap.progress.totalWeeks}주
+              </li>
+              <li>생성일: {formatDateTime(dashboard.roadmap.createdAt)}</li>
+            </ul>
+          ) : (
+            <EmptySummary message="저장된 로드맵이 없습니다." />
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function DashboardStatePanel({
+  message,
+  tone = "neutral"
+}: {
+  message: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
+    <section className="panel roadmap-state-panel" data-tone={tone}>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function EmptySummary({ message }: { message: string }) {
+  return <p className="dashboard-empty-summary">{message}</p>;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "대시보드를 불러오지 못했습니다.";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}
+
+function formatList(values: string[]) {
+  return values.length > 0 ? values.join(", ") : "없음";
+}

--- a/frontend/src/features/dashboard/labels.ts
+++ b/frontend/src/features/dashboard/labels.ts
@@ -1,0 +1,9 @@
+import type { CurrentLevel } from "@/features/dashboard/types";
+
+export const currentLevelLabels: Record<CurrentLevel, string> = {
+  ADVANCED: "고급",
+  BASIC: "기초",
+  BEGINNER: "입문",
+  INTERMEDIATE: "중급",
+  JUNIOR: "주니어"
+};

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -1,0 +1,61 @@
+export type CurrentLevel =
+  | "BEGINNER"
+  | "BASIC"
+  | "JUNIOR"
+  | "INTERMEDIATE"
+  | "ADVANCED";
+
+export type FinalTechProfile = {
+  confirmedSkills: string[];
+  focusAreas: string[];
+};
+
+export type DashboardProfileSummary = {
+  currentLevel: CurrentLevel;
+  jobRoleId: string;
+  profileId: string;
+  targetDate?: string | null;
+  updatedAt: string;
+  weeklyStudyHours?: number | null;
+};
+
+export type DashboardGithubAnalysisSummary = {
+  createdAt: string;
+  finalTechProfile: FinalTechProfile;
+  githubAnalysisId: string;
+  summary: string;
+  userCorrectionCount: number;
+  version: number;
+};
+
+export type DashboardDiagnosisSummary = {
+  createdAt: string;
+  diagnosisId: string;
+  summary: string;
+  version: number;
+};
+
+export type DashboardProgressSummary = {
+  doneWeeks: number;
+  inProgressWeeks: number;
+  skippedWeeks: number;
+  todoWeeks: number;
+  totalWeeks: number;
+};
+
+export type DashboardRoadmapSummary = {
+  createdAt: string;
+  progress: DashboardProgressSummary;
+  roadmapId: string;
+  summary: string;
+  totalWeeks: number;
+  version: number;
+};
+
+export type Dashboard = {
+  diagnosis: DashboardDiagnosisSummary | null;
+  githubAnalysis: DashboardGithubAnalysisSummary | null;
+  profile: DashboardProfileSummary | null;
+  roadmap: DashboardRoadmapSummary | null;
+  userId: string;
+};

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,3 +29,20 @@ export function githubLoginUrl(redirectUrl?: string): string {
   const qs = target ? `?redirectUrl=${encodeURIComponent(target)}` : "";
   return `${API_BASE}/oauth2/authorization/github${qs}`;
 }
+
+export {
+  ApiError,
+  apiClient,
+  getApiBaseUrl,
+  resolveApiUrl,
+  setApiTokenProvider
+} from "@/lib/api/client";
+export type {
+  ApiEnvelope,
+  ApiErrorBody,
+  ApiErrorDetails,
+  ApiErrorField,
+  ApiMeta,
+  ApiRequestOptions
+} from "@/lib/api/types";
+export type { ApiTokenProvider } from "@/lib/api/client";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## 변경 사항
- 대시보드 API 타입과 `GET /api/dashboard` 호출 추가
- 최신 프로필, GitHub 분석, 진단, 로드맵 요약 표시
- 로드맵 진행률과 상세 화면 이동 링크 추가
- 데이터 없음, 로딩, 에러 상태 추가
- dev 통합 중 생긴 `@/lib/api` export 충돌과 `/me` lint/build 오류 정리

## 왜 필요한가
대시보드는 사용자가 가장 먼저 보는 진입점이므로 최신 결과와 다음 이동 경로를 한 화면에서 확인할 수 있어야 합니다. 이후 프로필/진단/로드맵 상세 흐름으로 자연스럽게 이어지게 합니다.

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #106