### PR TITLE
feat(profile): 프로필 저장 조회 연결

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -707,6 +707,51 @@ a {
   color: #a32020;
 }
 
+.profile-form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-form-actions > div {
+  display: grid;
+  gap: 6px;
+}
+
+.profile-form-actions p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.profile-form-error {
+  color: #a32020;
+}
+
+.profile-form-success {
+  color: var(--success);
+}
+
+.profile-form-actions button {
+  min-height: 40px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 0 14px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.profile-form-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -739,5 +784,10 @@ a {
 
   .dashboard-progress-summary dl {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .profile-form-actions {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -597,6 +597,116 @@ a {
   gap: 12px;
 }
 
+.profile-page {
+  display: grid;
+  gap: 24px;
+}
+
+.profile-form {
+  display: grid;
+  gap: 16px;
+}
+
+.profile-form-section {
+  display: grid;
+  gap: 14px;
+}
+
+.profile-section-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.profile-section-heading h2 {
+  margin-bottom: 0;
+}
+
+.profile-section-heading p,
+.profile-form-note,
+.profile-state-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.profile-section-heading code {
+  border-radius: 4px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 1px 4px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.profile-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.profile-form label span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.profile-form input,
+.profile-form select,
+.profile-form textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--foreground);
+  font: inherit;
+}
+
+.profile-form input,
+.profile-form select {
+  min-height: 40px;
+  padding: 0 10px;
+}
+
+.profile-form textarea {
+  min-height: 110px;
+  resize: vertical;
+  padding: 10px;
+  line-height: 1.5;
+}
+
+.profile-helper-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.profile-helper-list span {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  background: #eef2f7;
+  color: #475467;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.profile-inline-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.profile-state-panel[data-tone="danger"] {
+  border-color: #f3b4b4;
+  background: #fff5f5;
+}
+
+.profile-state-panel[data-tone="danger"] p {
+  color: #a32020;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,6 +1,5 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { ProfileView } from "@/features/profile/profile-view";
 
 export default function ProfilePage() {
-  return <ScreenShell screen={screens.profile} />;
+  return <ProfileView />;
 }

--- a/frontend/src/features/profile/api.ts
+++ b/frontend/src/features/profile/api.ts
@@ -1,6 +1,14 @@
 import { apiClient } from "@/lib/api";
-import type { ProfileDetail } from "@/features/profile/types";
+import type {
+  ProfileDetail,
+  ProfileSaveRequest,
+  ProfileSaveResponse
+} from "@/features/profile/types";
 
 export function getMyProfile() {
   return apiClient.get<ProfileDetail>("/api/profiles/me");
+}
+
+export function saveProfile(payload: ProfileSaveRequest) {
+  return apiClient.post<ProfileSaveResponse>("/api/profiles", payload);
 }

--- a/frontend/src/features/profile/api.ts
+++ b/frontend/src/features/profile/api.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/lib/api";
+import type { ProfileDetail } from "@/features/profile/types";
+
+export function getMyProfile() {
+  return apiClient.get<ProfileDetail>("/api/profiles/me");
+}

--- a/frontend/src/features/profile/labels.ts
+++ b/frontend/src/features/profile/labels.ts
@@ -1,0 +1,41 @@
+import type {
+  CurrentLevel,
+  ProficiencyLevel,
+  SkillSourceType
+} from "@/features/profile/types";
+
+export const currentLevelOptions: CurrentLevel[] = [
+  "BEGINNER",
+  "BASIC",
+  "JUNIOR",
+  "INTERMEDIATE",
+  "ADVANCED"
+];
+
+export const proficiencyLevelOptions: ProficiencyLevel[] = [
+  "NONE",
+  "BASIC",
+  "WORKING",
+  "STRONG"
+];
+
+export const currentLevelLabels: Record<CurrentLevel, string> = {
+  ADVANCED: "고급",
+  BASIC: "기초",
+  BEGINNER: "입문",
+  INTERMEDIATE: "중급",
+  JUNIOR: "주니어"
+};
+
+export const proficiencyLevelLabels: Record<ProficiencyLevel, string> = {
+  BASIC: "기초",
+  NONE: "없음",
+  STRONG: "강함",
+  WORKING: "실무 가능"
+};
+
+export const skillSourceTypeLabels: Record<SkillSourceType, string> = {
+  GITHUB_ESTIMATED: "GitHub 추정",
+  SYSTEM_DERIVED: "시스템 추론",
+  USER_INPUT: "사용자 입력"
+};

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
-import { getMyProfile } from "@/features/profile/api";
+import { getMyProfile, saveProfile } from "@/features/profile/api";
 import {
   currentLevelLabels,
   currentLevelOptions,
+  proficiencyLevelOptions,
   proficiencyLevelLabels
 } from "@/features/profile/labels";
-import type { ProfileDetail, ProfileSkill } from "@/features/profile/types";
+import type {
+  CurrentLevel,
+  ProfileDetail,
+  ProfileSaveRequest,
+  ProfileSaveResponse,
+  ProfileSkill,
+  ProficiencyLevel
+} from "@/features/profile/types";
 import { ApiError } from "@/lib/api";
 
 type ProfileState =
@@ -18,6 +26,9 @@ type ProfileState =
 
 export function ProfileView() {
   const [state, setState] = useState<ProfileState>({ status: "loading" });
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveResult, setSaveResult] = useState<ProfileSaveResponse | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -63,6 +74,36 @@ export function ProfileView() {
     return <ProfileStatePanel message={state.message} tone="danger" />;
   }
 
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    setSaveError(null);
+    setSaveResult(null);
+
+    let payload: ProfileSaveRequest;
+
+    try {
+      payload = toProfileSaveRequest(new FormData(event.currentTarget));
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "입력 값을 확인해 주세요.");
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      const result = await saveProfile(payload);
+      setSaveResult(result);
+
+      const profile = await getMyProfile();
+      setState({ profile, status: "ready" });
+    } catch (error) {
+      setSaveError(getErrorMessage(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <section className="profile-page" aria-labelledby="profile-title">
       <div className="screen-hero">
@@ -76,14 +117,36 @@ export function ProfileView() {
         </div>
       </div>
 
-      <ProfileForm profile={state.profile} />
+      <ProfileForm
+        onSubmit={handleSubmit}
+        profile={state.profile}
+        saveError={saveError}
+        saveResult={saveResult}
+        saving={saving}
+      />
     </section>
   );
 }
 
-function ProfileForm({ profile }: { profile: ProfileDetail | null }) {
+function ProfileForm({
+  onSubmit,
+  profile,
+  saveError,
+  saveResult,
+  saving
+}: {
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  profile: ProfileDetail | null;
+  saveError: string | null;
+  saveResult: ProfileSaveResponse | null;
+  saving: boolean;
+}) {
   return (
-    <form className="profile-form" key={profile?.profileId ?? "new"}>
+    <form
+      className="profile-form"
+      key={profile?.profileId ?? "new"}
+      onSubmit={onSubmit}
+    >
       <section className="panel profile-form-section">
         <div className="profile-section-heading">
           <h2>기본 정보</h2>
@@ -105,7 +168,10 @@ function ProfileForm({ profile }: { profile: ProfileDetail | null }) {
 
         <label>
           <span>현재 수준</span>
-          <select defaultValue={profile?.currentLevel ?? "JUNIOR"} name="currentLevel">
+          <select
+            defaultValue={profile?.currentLevel ?? "JUNIOR"}
+            name="currentLevel"
+          >
             {currentLevelOptions.map((level) => (
               <option key={level} value={level}>
                 {currentLevelLabels[level]}
@@ -185,9 +251,19 @@ function ProfileForm({ profile }: { profile: ProfileDetail | null }) {
         </div>
       </section>
 
-      <p className="profile-form-note">
-        프로필 저장은 다음 단계에서 연결됩니다.
-      </p>
+      <div className="profile-form-actions">
+        <div>
+          {saveError ? <p className="profile-form-error">{saveError}</p> : null}
+          {saveResult ? (
+            <p className="profile-form-success">
+              {saveResult.message} · {formatDateTime(saveResult.savedAt)}
+            </p>
+          ) : null}
+        </div>
+        <button disabled={saving} type="submit">
+          {saving ? "저장 중" : "프로필 저장"}
+        </button>
+      </div>
     </form>
   );
 }
@@ -222,4 +298,151 @@ function formatSkillLines(skills: ProfileSkill[]) {
         : skill.skillName
     )
     .join("\n");
+}
+
+function toProfileSaveRequest(formData: FormData): ProfileSaveRequest {
+  const targetRole = getTextValue(formData, "targetRole").trim();
+  const currentLevel = getTextValue(formData, "currentLevel");
+  const skills = parseSkills(getTextValue(formData, "skills"));
+  const interestAreas = parseInterestAreas(getTextValue(formData, "interestAreas"));
+  const weeklyStudyHours = parseWeeklyStudyHours(
+    getTextValue(formData, "weeklyStudyHours")
+  );
+  const targetDate = parseTargetDate(getTextValue(formData, "targetDate"));
+
+  if (!targetRole) {
+    throw new Error("목표 직무를 입력해 주세요.");
+  }
+
+  if (!isCurrentLevel(currentLevel)) {
+    throw new Error("현재 수준을 선택해 주세요.");
+  }
+
+  return {
+    currentLevel,
+    interestAreas,
+    skills,
+    targetDate,
+    targetRole,
+    weeklyStudyHours
+  };
+}
+
+function parseSkills(value: string): ProfileSaveRequest["skills"] {
+  const lines = splitLines(value);
+
+  if (lines.length === 0) {
+    throw new Error("기술 스택을 1개 이상 입력해 주세요.");
+  }
+
+  if (lines.length > 20) {
+    throw new Error("기술 스택은 최대 20개까지 입력할 수 있습니다.");
+  }
+
+  const names = new Set<string>();
+
+  return lines.map((line) => {
+    const [rawName, rawLevel] = line.split("|").map((part) => part.trim());
+    const skillName = rawName ?? "";
+    const proficiencyLevel = rawLevel ? rawLevel.toUpperCase() : "";
+
+    if (!skillName) {
+      throw new Error("기술명을 입력해 주세요.");
+    }
+
+    if (skillName.length > 100) {
+      throw new Error("기술명은 100자 이하로 입력해 주세요.");
+    }
+
+    const normalizedName = skillName.toLowerCase();
+
+    if (names.has(normalizedName)) {
+      throw new Error(`중복된 기술이 있습니다: ${skillName}`);
+    }
+
+    names.add(normalizedName);
+
+    if (!proficiencyLevel) {
+      return { proficiencyLevel: null, skillName };
+    }
+
+    if (!isProficiencyLevel(proficiencyLevel)) {
+      throw new Error(`지원하지 않는 숙련도입니다: ${proficiencyLevel}`);
+    }
+
+    return { proficiencyLevel, skillName };
+  });
+}
+
+function parseInterestAreas(value: string) {
+  const lines = splitLines(value);
+
+  if (lines.length > 10) {
+    throw new Error("관심 분야는 최대 10개까지 입력할 수 있습니다.");
+  }
+
+  const tooLong = lines.find((line) => line.length > 50);
+
+  if (tooLong) {
+    throw new Error(`관심 분야는 50자 이하로 입력해 주세요: ${tooLong}`);
+  }
+
+  return lines;
+}
+
+function parseWeeklyStudyHours(value: string) {
+  if (!value.trim()) {
+    return null;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 40) {
+    throw new Error("주당 학습 시간은 1~40 사이의 정수로 입력해 주세요.");
+  }
+
+  return parsed;
+}
+
+function parseTargetDate(value: string) {
+  const targetDate = value.trim();
+
+  if (!targetDate) {
+    return null;
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (targetDate <= today) {
+    throw new Error("목표 날짜는 내일 이후로 선택해 주세요.");
+  }
+
+  return targetDate;
+}
+
+function splitLines(value: string) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function getTextValue(formData: FormData, name: string) {
+  const value = formData.get(name);
+  return typeof value === "string" ? value : "";
+}
+
+function isCurrentLevel(value: string): value is CurrentLevel {
+  return currentLevelOptions.includes(value as CurrentLevel);
+}
+
+function isProficiencyLevel(value: string): value is ProficiencyLevel {
+  return proficiencyLevelOptions.includes(value as ProficiencyLevel);
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
 }

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getMyProfile } from "@/features/profile/api";
+import {
+  currentLevelLabels,
+  currentLevelOptions,
+  proficiencyLevelLabels
+} from "@/features/profile/labels";
+import type { ProfileDetail, ProfileSkill } from "@/features/profile/types";
+import { ApiError } from "@/lib/api";
+
+type ProfileState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { profile: ProfileDetail | null; status: "ready" };
+
+export function ProfileView() {
+  const [state, setState] = useState<ProfileState>({ status: "loading" });
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadProfile() {
+      setState({ status: "loading" });
+
+      try {
+        const profile = await getMyProfile();
+
+        if (!ignore) {
+          setState({ profile, status: "ready" });
+        }
+      } catch (error) {
+        if (ignore) {
+          return;
+        }
+
+        if (error instanceof ApiError && error.status === 404) {
+          setState({ profile: null, status: "ready" });
+          return;
+        }
+
+        setState({
+          message: getErrorMessage(error),
+          status: "error"
+        });
+      }
+    }
+
+    loadProfile();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  if (state.status === "loading") {
+    return <ProfileStatePanel message="프로필을 불러오는 중입니다." />;
+  }
+
+  if (state.status === "error") {
+    return <ProfileStatePanel message={state.message} tone="danger" />;
+  }
+
+  return (
+    <section className="profile-page" aria-labelledby="profile-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v1 필수</p>
+        <div className="screen-heading">
+          <h1 id="profile-title">프로필 입력 / 수정</h1>
+          <p>
+            목표 직무, 현재 수준, 기술 스택과 학습 가능 시간을 저장하는
+            시작 화면입니다.
+          </p>
+        </div>
+      </div>
+
+      <ProfileForm profile={state.profile} />
+    </section>
+  );
+}
+
+function ProfileForm({ profile }: { profile: ProfileDetail | null }) {
+  return (
+    <form className="profile-form" key={profile?.profileId ?? "new"}>
+      <section className="panel profile-form-section">
+        <div className="profile-section-heading">
+          <h2>기본 정보</h2>
+          <p>
+            목표 직무는 백엔드 job role code를 입력합니다. 예: BACKEND_ENGINEER
+          </p>
+        </div>
+
+        <label>
+          <span>목표 직무</span>
+          <input
+            defaultValue={profile?.targetRole ?? "BACKEND_ENGINEER"}
+            maxLength={100}
+            name="targetRole"
+            placeholder="BACKEND_ENGINEER"
+            required
+          />
+        </label>
+
+        <label>
+          <span>현재 수준</span>
+          <select defaultValue={profile?.currentLevel ?? "JUNIOR"} name="currentLevel">
+            {currentLevelOptions.map((level) => (
+              <option key={level} value={level}>
+                {currentLevelLabels[level]}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <section className="panel profile-form-section">
+        <div className="profile-section-heading">
+          <h2>기술 스택</h2>
+          <p>
+            한 줄에 하나씩 입력합니다. 숙련도를 함께 쓰려면
+            <code>기술명|숙련도</code> 형식을 사용합니다.
+          </p>
+        </div>
+
+        <label>
+          <span>기술 목록</span>
+          <textarea
+            defaultValue={formatSkillLines(profile?.skills ?? [])}
+            name="skills"
+            placeholder={`Spring Boot|BASIC\nPostgreSQL|WORKING`}
+            required
+            rows={6}
+          />
+        </label>
+
+        <div className="profile-helper-list" aria-label="숙련도 값">
+          {Object.entries(proficiencyLevelLabels).map(([value, label]) => (
+            <span key={value}>
+              {value}: {label}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel profile-form-section">
+        <div className="profile-section-heading">
+          <h2>학습 조건</h2>
+          <p>관심 분야와 주당 학습 가능 시간을 입력합니다.</p>
+        </div>
+
+        <label>
+          <span>관심 분야</span>
+          <textarea
+            defaultValue={(profile?.interestAreas ?? []).join("\n")}
+            maxLength={600}
+            name="interestAreas"
+            placeholder={`백엔드\n성능 최적화`}
+            rows={4}
+          />
+        </label>
+
+        <div className="profile-inline-fields">
+          <label>
+            <span>주당 학습 시간</span>
+            <input
+              defaultValue={profile?.weeklyStudyHours ?? ""}
+              max={40}
+              min={1}
+              name="weeklyStudyHours"
+              placeholder="10"
+              type="number"
+            />
+          </label>
+
+          <label>
+            <span>목표 날짜</span>
+            <input
+              defaultValue={profile?.targetDate ?? ""}
+              name="targetDate"
+              type="date"
+            />
+          </label>
+        </div>
+      </section>
+
+      <p className="profile-form-note">
+        프로필 저장은 다음 단계에서 연결됩니다.
+      </p>
+    </form>
+  );
+}
+
+function ProfileStatePanel({
+  message,
+  tone = "neutral"
+}: {
+  message: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
+    <section className="panel profile-state-panel" data-tone={tone}>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "프로필을 불러오지 못했습니다.";
+}
+
+function formatSkillLines(skills: ProfileSkill[]) {
+  return skills
+    .map((skill) =>
+      skill.proficiencyLevel
+        ? `${skill.skillName}|${skill.proficiencyLevel}`
+        : skill.skillName
+    )
+    .join("\n");
+}

--- a/frontend/src/features/profile/types.ts
+++ b/frontend/src/features/profile/types.ts
@@ -1,0 +1,51 @@
+export type CurrentLevel =
+  | "BEGINNER"
+  | "BASIC"
+  | "JUNIOR"
+  | "INTERMEDIATE"
+  | "ADVANCED";
+
+export type ProficiencyLevel = "NONE" | "BASIC" | "WORKING" | "STRONG";
+
+export type SkillSourceType =
+  | "USER_INPUT"
+  | "GITHUB_ESTIMATED"
+  | "SYSTEM_DERIVED";
+
+export type ProfileSkillInput = {
+  proficiencyLevel?: ProficiencyLevel | null;
+  skillName: string;
+};
+
+export type ProfileSkill = ProfileSkillInput & {
+  sourceType: SkillSourceType;
+};
+
+export type ProfileSaveRequest = {
+  currentLevel: CurrentLevel;
+  interestAreas?: string[];
+  portfolioAssetId?: string | null;
+  resumeAssetId?: string | null;
+  skills: ProfileSkillInput[];
+  targetDate?: string | null;
+  targetRole: string;
+  weeklyStudyHours?: number | null;
+};
+
+export type ProfileSaveResponse = {
+  message: string;
+  profileId: string;
+  savedAt: string;
+};
+
+export type ProfileDetail = {
+  currentLevel: CurrentLevel;
+  interestAreas: string[];
+  portfolioAssetId?: string | null;
+  profileId: string;
+  resumeAssetId?: string | null;
+  skills: ProfileSkill[];
+  targetDate?: string | null;
+  targetRole: string;
+  weeklyStudyHours?: number | null;
+};


### PR DESCRIPTION
## 변경 사항
- 프로필 API 타입과 enum 한글 라벨 추가
- `GET /api/profiles/me` 내 프로필 조회 연결
- `POST /api/profiles` 프로필 저장 연결
- 목표 직무, 현재 수준, 기술 스택, 관심 분야, 학습 시간, 목표 날짜 입력 form 추가
- loading/error/empty/saved 상태와 기본 client validation 추가

## 왜 필요한가
프로필은 GitHub 분석, 진단, 로드맵 생성의 입력값입니다. 사용자가 목표 직무와 기술 스택을 저장해야 이후 대시보드와 로드맵 흐름이 실제 사용자 데이터로 이어집니다.

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #110