### PR TITLE
feat(diagnosis): 진단 결과 상세 조회 연결

### DIFF
--- a/frontend/src/app/diagnoses/[diagnosisId]/page.tsx
+++ b/frontend/src/app/diagnoses/[diagnosisId]/page.tsx
@@ -1,6 +1,15 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { DiagnosisDetailView } from "@/features/diagnosis/diagnosis-detail-view";
 
-export default function DiagnosisDetailPage() {
-  return <ScreenShell screen={screens.diagnosisDetail} />;
+type DiagnosisDetailPageProps = {
+  params: Promise<{
+    diagnosisId: string;
+  }>;
+};
+
+export default async function DiagnosisDetailPage({
+  params
+}: DiagnosisDetailPageProps) {
+  const { diagnosisId } = await params;
+
+  return <DiagnosisDetailView diagnosisId={diagnosisId} />;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -752,6 +752,159 @@ a {
   opacity: 0.65;
 }
 
+.diagnosis-detail {
+  display: grid;
+  gap: 24px;
+}
+
+.diagnosis-summary-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.diagnosis-summary-list div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--surface);
+}
+
+.diagnosis-summary-list dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.diagnosis-summary-list dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.diagnosis-section {
+  display: grid;
+  gap: 14px;
+}
+
+.diagnosis-section h2 {
+  margin-bottom: 0;
+}
+
+.diagnosis-section-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.diagnosis-section-heading p,
+.diagnosis-empty-text,
+.diagnosis-state-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.diagnosis-missing-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.diagnosis-missing-item {
+  display: grid;
+  gap: 10px;
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  padding: 12px 14px;
+  background: #fbfcfe;
+}
+
+.diagnosis-missing-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.diagnosis-missing-header span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.diagnosis-missing-header h3 {
+  margin: 4px 0 0;
+  font-size: 17px;
+  line-height: 1.35;
+}
+
+.diagnosis-missing-item p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.diagnosis-severity-badge {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.diagnosis-severity-badge[data-severity="low"] {
+  background: #eef2f7;
+  color: #475467;
+}
+
+.diagnosis-severity-badge[data-severity="medium"] {
+  background: #fff4e5;
+  color: #a15c00;
+}
+
+.diagnosis-severity-badge[data-severity="high"] {
+  background: #fff1f1;
+  color: #b42318;
+}
+
+.diagnosis-result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.diagnosis-bullet-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.diagnosis-state-panel[data-tone="danger"] {
+  border-color: #f3b4b4;
+  background: #fff5f5;
+}
+
+.diagnosis-state-panel[data-tone="danger"] p {
+  color: #a32020;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -788,6 +941,10 @@ a {
 
   .profile-form-actions {
     align-items: stretch;
+    flex-direction: column;
+  }
+
+  .diagnosis-missing-header {
     flex-direction: column;
   }
 }

--- a/frontend/src/features/diagnosis/api.ts
+++ b/frontend/src/features/diagnosis/api.ts
@@ -1,0 +1,6 @@
+import { apiClient } from "@/lib/api";
+import type { Diagnosis } from "@/features/diagnosis/types";
+
+export function getDiagnosis(diagnosisId: string) {
+  return apiClient.get<Diagnosis>(`/api/diagnoses/${diagnosisId}`);
+}

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getDiagnosis } from "@/features/diagnosis/api";
+import {
+  currentLevelLabels,
+  diagnosisSeverityClassNames,
+  diagnosisSeverityLabels
+} from "@/features/diagnosis/labels";
+import type { Diagnosis, MissingSkill } from "@/features/diagnosis/types";
+import { ApiError } from "@/lib/api";
+
+type DiagnosisDetailViewProps = {
+  diagnosisId: string;
+};
+
+type DiagnosisState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; diagnosis: Diagnosis };
+
+export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
+  const [state, setState] = useState<DiagnosisState>({ status: "loading" });
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadDiagnosis() {
+      setState({ status: "loading" });
+
+      try {
+        const diagnosis = await getDiagnosis(diagnosisId);
+
+        if (!ignore) {
+          setState({ diagnosis, status: "success" });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({
+            message: getErrorMessage(error),
+            status: "error"
+          });
+        }
+      }
+    }
+
+    loadDiagnosis();
+
+    return () => {
+      ignore = true;
+    };
+  }, [diagnosisId]);
+
+  if (state.status === "loading") {
+    return <DiagnosisStatePanel message="진단 결과를 불러오는 중입니다." />;
+  }
+
+  if (state.status === "error") {
+    return <DiagnosisStatePanel message={state.message} tone="danger" />;
+  }
+
+  const { diagnosis } = state;
+  const missingSkills = [...diagnosis.missingSkills].sort(comparePriorityOrder);
+
+  return (
+    <section className="diagnosis-detail" aria-labelledby="diagnosis-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v{diagnosis.version} 진단</p>
+        <div className="screen-heading">
+          <h1 id="diagnosis-title">역량 진단 결과</h1>
+          <p>{diagnosis.summary}</p>
+        </div>
+        <div className="action-row" aria-label="진단 관련 화면 이동">
+          <Link className="action-link primary" href="/roadmaps/new">
+            로드맵 생성
+          </Link>
+          <Link className="action-link" href="/github/analysis">
+            분석 보정
+          </Link>
+        </div>
+        <dl className="diagnosis-summary-list" aria-label="진단 요약">
+          <div>
+            <dt>진단 ID</dt>
+            <dd>{diagnosis.diagnosisId}</dd>
+          </div>
+          <div>
+            <dt>목표 직무</dt>
+            <dd>{diagnosis.targetRole}</dd>
+          </div>
+          <div>
+            <dt>현재 수준</dt>
+            <dd>{currentLevelLabels[diagnosis.currentLevel]}</dd>
+          </div>
+          <div>
+            <dt>생성일</dt>
+            <dd>{formatDateTime(diagnosis.createdAt)}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <section className="panel diagnosis-section" aria-labelledby="missing-title">
+        <div className="diagnosis-section-heading">
+          <h2 id="missing-title">부족 기술</h2>
+          <p>우선순위가 높은 기술부터 확인합니다.</p>
+        </div>
+        {missingSkills.length === 0 ? (
+          <p className="diagnosis-empty-text">표시할 부족 기술이 없습니다.</p>
+        ) : (
+          <ol className="diagnosis-missing-list">
+            {missingSkills.map((skill) => (
+              <li
+                className="diagnosis-missing-item"
+                key={`${skill.priorityOrder}-${skill.skillName}`}
+              >
+                <div className="diagnosis-missing-header">
+                  <div>
+                    <span>우선순위 {skill.priorityOrder}</span>
+                    <h3>{skill.skillName}</h3>
+                  </div>
+                  <SeverityBadge skill={skill} />
+                </div>
+                <p>{skill.reason}</p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <div className="diagnosis-result-grid">
+        <DiagnosisListSection
+          emptyMessage="표시할 강점이 없습니다."
+          items={diagnosis.strengths}
+          title="강점"
+        />
+        <DiagnosisListSection
+          emptyMessage="표시할 추천이 없습니다."
+          items={diagnosis.recommendations}
+          title="추천"
+        />
+      </div>
+    </section>
+  );
+}
+
+function DiagnosisStatePanel({
+  message,
+  tone = "neutral"
+}: {
+  message: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
+    <section className="panel diagnosis-state-panel" data-tone={tone}>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function DiagnosisListSection({
+  emptyMessage,
+  items,
+  title
+}: {
+  emptyMessage: string;
+  items: string[];
+  title: string;
+}) {
+  return (
+    <section className="panel diagnosis-section">
+      <h2>{title}</h2>
+      {items.length === 0 ? (
+        <p className="diagnosis-empty-text">{emptyMessage}</p>
+      ) : (
+        <ul className="diagnosis-bullet-list">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SeverityBadge({ skill }: { skill: MissingSkill }) {
+  return (
+    <span
+      className="diagnosis-severity-badge"
+      data-severity={diagnosisSeverityClassNames[skill.severity]}
+    >
+      {diagnosisSeverityLabels[skill.severity]}
+    </span>
+  );
+}
+
+function comparePriorityOrder(a: MissingSkill, b: MissingSkill) {
+  return a.priorityOrder - b.priorityOrder;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "진단 결과를 불러오지 못했습니다.";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}

--- a/frontend/src/features/diagnosis/labels.ts
+++ b/frontend/src/features/diagnosis/labels.ts
@@ -1,0 +1,24 @@
+import type {
+  CurrentLevel,
+  DiagnosisSeverity
+} from "@/features/diagnosis/types";
+
+export const currentLevelLabels: Record<CurrentLevel, string> = {
+  ADVANCED: "고급",
+  BASIC: "기초",
+  BEGINNER: "입문",
+  INTERMEDIATE: "중급",
+  JUNIOR: "주니어"
+};
+
+export const diagnosisSeverityLabels: Record<DiagnosisSeverity, string> = {
+  HIGH: "높음",
+  LOW: "낮음",
+  MEDIUM: "중간"
+};
+
+export const diagnosisSeverityClassNames: Record<DiagnosisSeverity, string> = {
+  HIGH: "high",
+  LOW: "low",
+  MEDIUM: "medium"
+};

--- a/frontend/src/features/diagnosis/types.ts
+++ b/frontend/src/features/diagnosis/types.ts
@@ -1,0 +1,29 @@
+export type CurrentLevel =
+  | "BEGINNER"
+  | "BASIC"
+  | "JUNIOR"
+  | "INTERMEDIATE"
+  | "ADVANCED";
+
+export type DiagnosisSeverity = "LOW" | "MEDIUM" | "HIGH";
+
+export type MissingSkill = {
+  priorityOrder: number;
+  reason: string;
+  severity: DiagnosisSeverity;
+  skillName: string;
+};
+
+export type Diagnosis = {
+  createdAt: string;
+  currentLevel: CurrentLevel;
+  diagnosisId: string;
+  githubAnalysisId?: string | null;
+  missingSkills: MissingSkill[];
+  profileId: string;
+  recommendations: string[];
+  strengths: string[];
+  summary: string;
+  targetRole: string;
+  version: number;
+};


### PR DESCRIPTION
## 왜 필요한가
진단 결과는 프로필/GitHub 분석 이후 로드맵 생성 전, 사용자가 부족 기술과 추천 방향을 확인하는 중간 단계입니다.

## 무엇을 변경했나
- `GET /api/diagnoses/{diagnosisId}` 연결
- 진단 심각도 한글 라벨과 badge 추가
- 진단 결과 상세 UI와 loading/error 상태 추가

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #112