### PR TITLE
feat(github-analysis): GitHub 분석 결과 보정 연결

### DIFF
--- a/frontend/src/app/github/analysis/page.tsx
+++ b/frontend/src/app/github/analysis/page.tsx
@@ -1,6 +1,27 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { GithubAnalysisView } from "@/features/github-analysis/github-analysis-view";
 
-export default function GithubAnalysisPage() {
-  return <ScreenShell screen={screens.githubAnalysis} />;
+type GithubAnalysisPageProps = {
+  searchParams: Promise<{
+    githubAnalysisId?: string | string[];
+  }>;
+};
+
+export default async function GithubAnalysisPage({
+  searchParams
+}: GithubAnalysisPageProps) {
+  const { githubAnalysisId } = await searchParams;
+
+  return (
+    <GithubAnalysisView
+      initialGithubAnalysisId={getFirstQueryValue(githubAnalysisId)}
+    />
+  );
+}
+
+function getFirstQueryValue(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -905,6 +905,219 @@ a {
   color: #a32020;
 }
 
+.github-analysis-page {
+  display: grid;
+  gap: 24px;
+}
+
+.github-analysis-summary-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.github-analysis-summary-list div,
+.github-analysis-metric-list div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--surface);
+}
+
+.github-analysis-summary-list dt,
+.github-analysis-metric-list dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-analysis-summary-list dd,
+.github-analysis-metric-list dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.github-analysis-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.github-analysis-section {
+  display: grid;
+  gap: 14px;
+}
+
+.github-analysis-section h2 {
+  margin-bottom: 0;
+}
+
+.github-analysis-empty-text,
+.github-analysis-state-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.github-analysis-metric-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.github-tag-group {
+  display: grid;
+  gap: 8px;
+}
+
+.github-tag-group p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-tag-group div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.github-tag-group span,
+.github-depth-badge,
+.github-evidence-list span {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.github-repo-summary-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.github-repo-summary-card,
+.github-tech-tag-list li,
+.github-depth-list li,
+.github-evidence-list li {
+  display: grid;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px;
+  background: #fbfcfe;
+}
+
+.github-repo-summary-card p {
+  margin: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-repo-summary-card h3 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.github-repo-summary-card ul,
+.github-tech-tag-list,
+.github-depth-list,
+.github-evidence-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.github-repo-summary-card ul {
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.github-repo-summary-card li,
+.github-tech-tag-list p,
+.github-depth-list p,
+.github-evidence-list p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.github-tech-tag-list strong,
+.github-depth-list strong,
+.github-evidence-list strong {
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.github-depth-list li > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.github-depth-badge[data-depth="intro"] {
+  background: #eef2f7;
+  color: #475467;
+}
+
+.github-depth-badge[data-depth="applied"] {
+  background: #e8f0ff;
+  color: #2563eb;
+}
+
+.github-depth-badge[data-depth="practical"] {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.github-depth-badge[data-depth="deep"] {
+  background: #fff4e5;
+  color: #a15c00;
+}
+
+.github-evidence-list code {
+  display: block;
+  min-width: 0;
+  border-radius: 4px;
+  background: #eef2f7;
+  color: #475467;
+  padding: 4px 6px;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.github-analysis-state-panel[data-tone="danger"] {
+  border-color: #f3b4b4;
+  background: #fff5f5;
+}
+
+.github-analysis-state-panel[data-tone="danger"] p {
+  color: #a32020;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -945,6 +1158,11 @@ a {
   }
 
   .diagnosis-missing-header {
+    flex-direction: column;
+  }
+
+  .github-depth-list li > div {
+    align-items: flex-start;
     flex-direction: column;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -955,10 +955,16 @@ a {
   gap: 14px;
 }
 
+.github-analysis-section-heading {
+  display: grid;
+  gap: 6px;
+}
+
 .github-analysis-section h2 {
   margin-bottom: 0;
 }
 
+.github-analysis-section-heading p,
 .github-analysis-empty-text,
 .github-analysis-state-panel p {
   margin: 0;
@@ -1118,6 +1124,86 @@ a {
   color: #a32020;
 }
 
+.github-correction-form {
+  display: grid;
+  gap: 16px;
+}
+
+.github-correction-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.github-correction-form label span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-correction-form textarea {
+  width: 100%;
+  min-height: 120px;
+  resize: vertical;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--foreground);
+  padding: 10px;
+  font: inherit;
+  line-height: 1.5;
+}
+
+.github-correction-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.github-correction-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.github-correction-actions > div {
+  display: grid;
+  gap: 6px;
+}
+
+.github-correction-actions p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.github-correction-error {
+  color: #a32020;
+}
+
+.github-correction-success {
+  color: var(--success);
+}
+
+.github-correction-actions button {
+  min-height: 40px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 0 14px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.github-correction-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 @media (max-width: 640px) {
   .topbar {
     align-items: flex-start;
@@ -1163,6 +1249,11 @@ a {
 
   .github-depth-list li > div {
     align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .github-correction-actions {
+    align-items: stretch;
     flex-direction: column;
   }
 }

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -139,7 +139,10 @@ export function DashboardView() {
                 사용자 보정 {dashboard.githubAnalysis.userCorrectionCount}개 ·{" "}
                 {formatDateTime(dashboard.githubAnalysis.createdAt)}
               </p>
-              <Link className="dashboard-card-link" href="/github/analysis">
+              <Link
+                className="dashboard-card-link"
+                href={`/github/analysis?githubAnalysisId=${dashboard.githubAnalysis.githubAnalysisId}`}
+              >
                 분석 보정 보기
               </Link>
             </>

--- a/frontend/src/features/github-analysis/api.ts
+++ b/frontend/src/features/github-analysis/api.ts
@@ -1,0 +1,22 @@
+import { apiClient } from "@/lib/api";
+import type {
+  GithubAnalysis,
+  GithubAnalysisCorrectionRequest,
+  GithubAnalysisCorrectionResponse
+} from "@/features/github-analysis/types";
+
+export function getGithubAnalysis(githubAnalysisId: string) {
+  return apiClient.get<GithubAnalysis>(
+    `/api/github-analyses/${githubAnalysisId}`
+  );
+}
+
+export function saveGithubAnalysisCorrections(
+  githubAnalysisId: string,
+  payload: GithubAnalysisCorrectionRequest
+) {
+  return apiClient.patch<GithubAnalysisCorrectionResponse>(
+    `/api/github-analyses/${githubAnalysisId}/corrections`,
+    payload
+  );
+}

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getDashboard } from "@/features/dashboard/api";
+import { getGithubAnalysis } from "@/features/github-analysis/api";
+import {
+  githubDepthLevelClassNames,
+  githubDepthLevelLabels,
+  githubEvidenceTypeLabels
+} from "@/features/github-analysis/labels";
+import type {
+  DepthEstimate,
+  GithubAnalysis,
+  GithubUserCorrection
+} from "@/features/github-analysis/types";
+import { ApiError } from "@/lib/api";
+
+type GithubAnalysisViewProps = {
+  initialGithubAnalysisId?: string | null;
+};
+
+type GithubAnalysisState =
+  | { status: "loading" }
+  | { status: "empty"; message: string }
+  | { status: "error"; message: string }
+  | {
+      status: "success";
+      analysis: GithubAnalysis;
+      diagnosisId: string | null;
+    };
+
+export function GithubAnalysisView({
+  initialGithubAnalysisId
+}: GithubAnalysisViewProps) {
+  const [state, setState] = useState<GithubAnalysisState>({
+    status: "loading"
+  });
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadGithubAnalysis() {
+      setState({ status: "loading" });
+
+      try {
+        const queryGithubAnalysisId = normalizeOptionalId(initialGithubAnalysisId);
+        const dashboard = queryGithubAnalysisId
+          ? await getDashboard().catch(() => null)
+          : await getDashboard();
+        const githubAnalysisId =
+          queryGithubAnalysisId ??
+          dashboard?.githubAnalysis?.githubAnalysisId ??
+          null;
+
+        if (!githubAnalysisId) {
+          if (!ignore) {
+            setState({
+              message: "저장된 GitHub 분석 결과가 없습니다.",
+              status: "empty"
+            });
+          }
+          return;
+        }
+
+        const analysis = await getGithubAnalysis(githubAnalysisId);
+
+        if (!ignore) {
+          setState({
+            analysis,
+            diagnosisId: dashboard?.diagnosis?.diagnosisId ?? null,
+            status: "success"
+          });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({
+            message: getErrorMessage(error),
+            status: "error"
+          });
+        }
+      }
+    }
+
+    loadGithubAnalysis();
+
+    return () => {
+      ignore = true;
+    };
+  }, [initialGithubAnalysisId]);
+
+  if (state.status === "loading") {
+    return <GithubAnalysisStatePanel message="GitHub 분석 결과를 불러오는 중입니다." />;
+  }
+
+  if (state.status === "empty") {
+    return <GithubAnalysisStatePanel message={state.message} />;
+  }
+
+  if (state.status === "error") {
+    return <GithubAnalysisStatePanel message={state.message} tone="danger" />;
+  }
+
+  const { analysis, diagnosisId } = state;
+
+  return (
+    <section className="github-analysis-page" aria-labelledby="analysis-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v{analysis.version} GitHub 분석</p>
+        <div className="screen-heading">
+          <h1 id="analysis-title">GitHub 분석 결과 / 사용자 보정</h1>
+          <p>정적 분석 결과와 근거를 확인하고 최종 기술 프로필을 검수합니다.</p>
+        </div>
+        <div className="action-row" aria-label="GitHub 분석 관련 화면 이동">
+          {diagnosisId ? (
+            <Link
+              className="action-link primary"
+              href={`/diagnoses/${diagnosisId}`}
+            >
+              진단 결과 보기
+            </Link>
+          ) : null}
+          <Link className="action-link" href="/github">
+            저장소 선택
+          </Link>
+        </div>
+        <dl className="github-analysis-summary-list" aria-label="분석 요약">
+          <div>
+            <dt>분석 ID</dt>
+            <dd>{analysis.githubAnalysisId}</dd>
+          </div>
+          <div>
+            <dt>활성 저장소</dt>
+            <dd>{analysis.staticSignals.activeRepos}개</dd>
+          </div>
+          <div>
+            <dt>사용자 보정</dt>
+            <dd>{analysis.userCorrections.length}개</dd>
+          </div>
+          <div>
+            <dt>생성일</dt>
+            <dd>{formatDateTime(analysis.createdAt)}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="github-analysis-grid">
+        <StaticSignalsPanel analysis={analysis} />
+        <FinalTechProfilePanel analysis={analysis} />
+      </div>
+
+      <section className="panel github-analysis-section">
+        <h2>저장소 요약</h2>
+        {analysis.repoSummaries.length === 0 ? (
+          <p className="github-analysis-empty-text">표시할 저장소 요약이 없습니다.</p>
+        ) : (
+          <div className="github-repo-summary-list">
+            {analysis.repoSummaries.map((repo) => (
+              <article className="github-repo-summary-card" key={repo.repoId}>
+                <p>{repo.repoName}</p>
+                <h3>{repo.summary}</h3>
+                <ul>
+                  {repo.highlights.map((highlight) => (
+                    <li key={highlight}>{highlight}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <div className="github-analysis-grid">
+        <TechTagPanel analysis={analysis} />
+        <DepthEstimatePanel depthEstimates={analysis.depthEstimates} />
+      </div>
+
+      <section className="panel github-analysis-section">
+        <h2>근거</h2>
+        {analysis.evidences.length === 0 ? (
+          <p className="github-analysis-empty-text">표시할 근거가 없습니다.</p>
+        ) : (
+          <ul className="github-evidence-list">
+            {analysis.evidences.map((evidence) => (
+              <li
+                key={`${evidence.repoName}-${evidence.type}-${evidence.source}`}
+              >
+                <span>{githubEvidenceTypeLabels[evidence.type]}</span>
+                <strong>{evidence.repoName}</strong>
+                <code>{evidence.source}</code>
+                <p>{evidence.summary}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <UserCorrectionPreview corrections={analysis.userCorrections} />
+    </section>
+  );
+}
+
+function GithubAnalysisStatePanel({
+  message,
+  tone = "neutral"
+}: {
+  message: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
+    <section className="panel github-analysis-state-panel" data-tone={tone}>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function StaticSignalsPanel({ analysis }: { analysis: GithubAnalysis }) {
+  const { staticSignals } = analysis;
+
+  return (
+    <section className="panel github-analysis-section">
+      <h2>정적 신호</h2>
+      <dl className="github-analysis-metric-list">
+        <div>
+          <dt>커밋 빈도</dt>
+          <dd>{staticSignals.commitFrequency ?? "미확인"}</dd>
+        </div>
+        <div>
+          <dt>기여 패턴</dt>
+          <dd>{staticSignals.contributionPattern ?? "미확인"}</dd>
+        </div>
+      </dl>
+      <TagList
+        items={staticSignals.primaryLanguages.map(
+          (language) => `${language.lang} ${formatRatio(language.ratio)}`
+        )}
+        label="주요 언어"
+      />
+    </section>
+  );
+}
+
+function FinalTechProfilePanel({ analysis }: { analysis: GithubAnalysis }) {
+  return (
+    <section className="panel github-analysis-section">
+      <h2>최종 기술 프로필</h2>
+      <TagList
+        items={analysis.finalTechProfile.confirmedSkills}
+        label="확정 기술"
+      />
+      <TagList items={analysis.finalTechProfile.focusAreas} label="집중 영역" />
+    </section>
+  );
+}
+
+function TechTagPanel({ analysis }: { analysis: GithubAnalysis }) {
+  return (
+    <section className="panel github-analysis-section">
+      <h2>기술 태그</h2>
+      {analysis.techTags.length === 0 ? (
+        <p className="github-analysis-empty-text">표시할 기술 태그가 없습니다.</p>
+      ) : (
+        <ul className="github-tech-tag-list">
+          {analysis.techTags.map((tag) => (
+            <li key={`${tag.skillName}-${tag.tagReason}`}>
+              <strong>{tag.skillName}</strong>
+              <p>{tag.tagReason}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DepthEstimatePanel({
+  depthEstimates
+}: {
+  depthEstimates: DepthEstimate[];
+}) {
+  return (
+    <section className="panel github-analysis-section">
+      <h2>숙련도 추정</h2>
+      {depthEstimates.length === 0 ? (
+        <p className="github-analysis-empty-text">표시할 숙련도 추정이 없습니다.</p>
+      ) : (
+        <ul className="github-depth-list">
+          {depthEstimates.map((estimate) => (
+            <li key={`${estimate.skillName}-${estimate.level}`}>
+              <div>
+                <strong>{estimate.skillName}</strong>
+                <DepthBadge estimate={estimate} />
+              </div>
+              <p>{estimate.reason}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function UserCorrectionPreview({
+  corrections
+}: {
+  corrections: GithubUserCorrection[];
+}) {
+  return (
+    <section className="panel github-analysis-section">
+      <h2>사용자 보정</h2>
+      {corrections.length === 0 ? (
+        <p className="github-analysis-empty-text">저장된 사용자 보정이 없습니다.</p>
+      ) : (
+        <ul className="github-tech-tag-list">
+          {corrections.map((correction) => (
+            <li key={`${correction.skillName}-${correction.correction}`}>
+              <strong>{correction.skillName}</strong>
+              <p>{correction.correction}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DepthBadge({ estimate }: { estimate: DepthEstimate }) {
+  return (
+    <span
+      className="github-depth-badge"
+      data-depth={githubDepthLevelClassNames[estimate.level]}
+    >
+      {githubDepthLevelLabels[estimate.level]}
+    </span>
+  );
+}
+
+function TagList({ items, label }: { items: string[]; label: string }) {
+  if (items.length === 0) {
+    return (
+      <div className="github-tag-group">
+        <p>{label}</p>
+        <span>없음</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="github-tag-group">
+      <p>{label}</p>
+      <div>
+        {items.map((item) => (
+          <span key={item}>{item}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function normalizeOptionalId(value?: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "GitHub 분석 결과를 불러오지 못했습니다.";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}
+
+function formatRatio(value: number) {
+  const ratio = value <= 1 ? value * 100 : value;
+
+  return `${ratio.toLocaleString("ko-KR", {
+    maximumFractionDigits: 1
+  })}%`;
+}

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 
 import { getDashboard } from "@/features/dashboard/api";
-import { getGithubAnalysis } from "@/features/github-analysis/api";
+import {
+  getGithubAnalysis,
+  saveGithubAnalysisCorrections
+} from "@/features/github-analysis/api";
 import {
   githubDepthLevelClassNames,
   githubDepthLevelLabels,
@@ -37,6 +40,9 @@ export function GithubAnalysisView({
   const [state, setState] = useState<GithubAnalysisState>({
     status: "loading"
   });
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -89,6 +95,63 @@ export function GithubAnalysisView({
       ignore = true;
     };
   }, [initialGithubAnalysisId]);
+
+  async function handleCorrectionSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (state.status !== "success") {
+      return;
+    }
+
+    const formData = new FormData(event.currentTarget);
+    const correctionText = getStringFormValue(formData, "userCorrections");
+    const confirmedSkillsText = getStringFormValue(formData, "confirmedSkills");
+    const focusAreasText = getStringFormValue(formData, "focusAreas");
+    const parsedCorrections = parseCorrectionLines(correctionText);
+
+    if (parsedCorrections.error) {
+      setSaveError(parsedCorrections.error);
+      setSaveMessage(null);
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
+
+    try {
+      const saved = await saveGithubAnalysisCorrections(
+        state.analysis.githubAnalysisId,
+        {
+          finalTechProfile: {
+            confirmedSkills: parseLineList(confirmedSkillsText),
+            focusAreas: parseLineList(focusAreasText)
+          },
+          userCorrections: parsedCorrections.items
+        }
+      );
+
+      setState((current) => {
+        if (current.status !== "success") {
+          return current;
+        }
+
+        return {
+          ...current,
+          analysis: {
+            ...current.analysis,
+            finalTechProfile: saved.finalTechProfile,
+            userCorrections: parsedCorrections.items
+          }
+        };
+      });
+      setSaveMessage(`저장 완료 ${formatDateTime(saved.savedAt)}`);
+    } catch (error) {
+      setSaveError(getSaveErrorMessage(error));
+    } finally {
+      setIsSaving(false);
+    }
+  }
 
   if (state.status === "loading") {
     return <GithubAnalysisStatePanel message="GitHub 분석 결과를 불러오는 중입니다." />;
@@ -196,6 +259,13 @@ export function GithubAnalysisView({
         )}
       </section>
 
+      <GithubCorrectionForm
+        analysis={analysis}
+        isSaving={isSaving}
+        onSubmit={handleCorrectionSubmit}
+        saveError={saveError}
+        saveMessage={saveMessage}
+      />
       <UserCorrectionPreview corrections={analysis.userCorrections} />
     </section>
   );
@@ -325,6 +395,76 @@ function UserCorrectionPreview({
   );
 }
 
+function GithubCorrectionForm({
+  analysis,
+  isSaving,
+  onSubmit,
+  saveError,
+  saveMessage
+}: {
+  analysis: GithubAnalysis;
+  isSaving: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  saveError: string | null;
+  saveMessage: string | null;
+}) {
+  return (
+    <form
+      className="panel github-correction-form"
+      key={getCorrectionFormKey(analysis)}
+      onSubmit={onSubmit}
+    >
+      <div className="github-analysis-section-heading">
+        <h2>보정 저장</h2>
+        <p>사용자 판단을 반영해 최종 기술 프로필을 저장합니다.</p>
+      </div>
+
+      <label>
+        <span>사용자 보정</span>
+        <textarea
+          defaultValue={formatCorrections(analysis.userCorrections)}
+          name="userCorrections"
+          placeholder="Redis|학습만 해봄"
+          rows={5}
+        />
+      </label>
+
+      <div className="github-correction-fields">
+        <label>
+          <span>확정 기술</span>
+          <textarea
+            defaultValue={analysis.finalTechProfile.confirmedSkills.join("\n")}
+            name="confirmedSkills"
+            placeholder="Java&#10;Spring Boot"
+            rows={5}
+          />
+        </label>
+        <label>
+          <span>집중 영역</span>
+          <textarea
+            defaultValue={analysis.finalTechProfile.focusAreas.join("\n")}
+            name="focusAreas"
+            placeholder="백엔드&#10;성능 개선"
+            rows={5}
+          />
+        </label>
+      </div>
+
+      <div className="github-correction-actions">
+        <div>
+          {saveError ? <p className="github-correction-error">{saveError}</p> : null}
+          {saveMessage ? (
+            <p className="github-correction-success">{saveMessage}</p>
+          ) : null}
+        </div>
+        <button disabled={isSaving} type="submit">
+          {isSaving ? "저장 중" : "보정 저장"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
 function DepthBadge({ estimate }: { estimate: DepthEstimate }) {
   return (
     <span
@@ -367,12 +507,83 @@ function normalizeOptionalId(value?: string | null) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function parseCorrectionLines(value: string): {
+  error: string | null;
+  items: GithubUserCorrection[];
+} {
+  const items: GithubUserCorrection[] = [];
+  const lines = value.split(/\r?\n/);
+
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trim();
+
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    const [skillName, ...correctionParts] = trimmed.split("|");
+    const correction = correctionParts.join("|").trim();
+
+    if (!skillName.trim() || !correction) {
+      return {
+        error: `${index + 1}번째 보정은 기술명|보정내용 형식으로 입력해 주세요.`,
+        items: []
+      };
+    }
+
+    items.push({
+      correction,
+      skillName: skillName.trim()
+    });
+  }
+
+  return { error: null, items };
+}
+
+function parseLineList(value: string) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function getStringFormValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+
+  return typeof value === "string" ? value : "";
+}
+
+function formatCorrections(corrections: GithubUserCorrection[]) {
+  return corrections
+    .map((correction) => `${correction.skillName}|${correction.correction}`)
+    .join("\n");
+}
+
+function getCorrectionFormKey(analysis: GithubAnalysis) {
+  return [
+    analysis.githubAnalysisId,
+    analysis.userCorrections
+      .map((correction) => `${correction.skillName}:${correction.correction}`)
+      .join(","),
+    analysis.finalTechProfile.confirmedSkills.join(","),
+    analysis.finalTechProfile.focusAreas.join(",")
+  ].join("|");
+}
+
 function getErrorMessage(error: unknown) {
   if (error instanceof ApiError) {
     return error.message;
   }
 
   return "GitHub 분석 결과를 불러오지 못했습니다.";
+}
+
+function getSaveErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "GitHub 분석 보정을 저장하지 못했습니다.";
 }
 
 function formatDateTime(value: string) {

--- a/frontend/src/features/github-analysis/labels.ts
+++ b/frontend/src/features/github-analysis/labels.ts
@@ -1,0 +1,26 @@
+import type {
+  GithubDepthLevel,
+  GithubEvidenceType
+} from "@/features/github-analysis/types";
+
+export const githubDepthLevelLabels: Record<GithubDepthLevel, string> = {
+  APPLIED: "적용",
+  DEEP: "심화",
+  INTRO: "입문",
+  PRACTICAL: "실무"
+};
+
+export const githubDepthLevelClassNames: Record<GithubDepthLevel, string> = {
+  APPLIED: "applied",
+  DEEP: "deep",
+  INTRO: "intro",
+  PRACTICAL: "practical"
+};
+
+export const githubEvidenceTypeLabels: Record<GithubEvidenceType, string> = {
+  CODE: "코드",
+  COMMIT: "커밋",
+  CONFIG: "설정",
+  README: "README",
+  REPO_METADATA: "저장소 메타"
+};

--- a/frontend/src/features/github-analysis/types.ts
+++ b/frontend/src/features/github-analysis/types.ts
@@ -1,0 +1,79 @@
+export type GithubEvidenceType =
+  | "README"
+  | "CODE"
+  | "CONFIG"
+  | "REPO_METADATA"
+  | "COMMIT";
+
+export type GithubDepthLevel = "INTRO" | "APPLIED" | "PRACTICAL" | "DEEP";
+
+export type PrimaryLanguage = {
+  lang: string;
+  ratio: number;
+};
+
+export type StaticSignals = {
+  activeRepos: number;
+  commitFrequency?: string | null;
+  contributionPattern?: string | null;
+  primaryLanguages: PrimaryLanguage[];
+};
+
+export type RepoSummary = {
+  highlights: string[];
+  repoId: string;
+  repoName: string;
+  summary: string;
+};
+
+export type TechTag = {
+  skillName: string;
+  tagReason: string;
+};
+
+export type DepthEstimate = {
+  level: GithubDepthLevel;
+  reason: string;
+  skillName: string;
+};
+
+export type GithubEvidence = {
+  repoName: string;
+  source: string;
+  summary: string;
+  type: GithubEvidenceType;
+};
+
+export type GithubUserCorrection = {
+  correction: string;
+  skillName: string;
+};
+
+export type FinalTechProfile = {
+  confirmedSkills: string[];
+  focusAreas: string[];
+};
+
+export type GithubAnalysis = {
+  createdAt: string;
+  depthEstimates: DepthEstimate[];
+  evidences: GithubEvidence[];
+  finalTechProfile: FinalTechProfile;
+  githubAnalysisId: string;
+  repoSummaries: RepoSummary[];
+  staticSignals: StaticSignals;
+  techTags: TechTag[];
+  userCorrections: GithubUserCorrection[];
+  version: number;
+};
+
+export type GithubAnalysisCorrectionRequest = {
+  finalTechProfile: FinalTechProfile;
+  userCorrections: GithubUserCorrection[];
+};
+
+export type GithubAnalysisCorrectionResponse = {
+  finalTechProfile: FinalTechProfile;
+  githubAnalysisId: string;
+  savedAt: string;
+};


### PR DESCRIPTION
## 왜 필요한가
GitHub 분석 결과와 사용자 보정값은 최종 기술 프로필이 되고, 이후 진단/로드맵의 입력값으로 사용됩니다.

## 무엇을 변경했나
- `GET /api/github-analyses/{githubAnalysisId}` 연결
- `PATCH /api/github-analyses/{githubAnalysisId}/corrections` 연결
- 분석 ID query/dashboard fallback, loading/error/empty 상태 추가
- 대시보드의 분석 보정 링크에 최신 분석 ID query 추가

## 검증
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #114