### PR TITLE
fix(frontend-api): 보호 API 요청에 인증 쿠키 포함

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -64,11 +64,12 @@ async function request<TData>(
   path: string,
   options: ApiRequestOptions = {}
 ) {
-  const { body, token, headers, ...requestInit } = options;
+  const { body, token, headers, credentials = "include", ...requestInit } = options;
   const resolvedToken = token ?? (await tokenProvider?.()) ?? undefined;
   const response = await fetch(resolveApiUrl(path), {
     ...requestInit,
     body: serializeBody(body),
+    credentials,
     headers: buildHeaders(headers, body, resolvedToken),
     method
   });


### PR DESCRIPTION
## 연관 이슈

Closes #118

## 변경 요약

- `apiClient` fetch 요청에 `credentials: include` 기본값 추가
- 호출자가 `credentials`를 명시하면 해당 값을 우선하도록 기존 옵션 구조 유지

## 왜 필요한가

- OAuth 로그인 후 발급된 HttpOnly 쿠키가 보호 API 요청에 포함되지 않으면 대시보드, 프로필, 분석/진단/로드맵 조회가 401로 실패할 수 있다.

## 테스트

실행 내용:

```text
npm run lint
npm run build
```