### PR TITLE
refactor(frontend-labels): 공통 enum 라벨 정리

### DIFF
--- a/frontend/src/features/dashboard/labels.ts
+++ b/frontend/src/features/dashboard/labels.ts
@@ -1,9 +1,1 @@
-import type { CurrentLevel } from "@/features/dashboard/types";
-
-export const currentLevelLabels: Record<CurrentLevel, string> = {
-  ADVANCED: "고급",
-  BASIC: "기초",
-  BEGINNER: "입문",
-  INTERMEDIATE: "중급",
-  JUNIOR: "주니어"
-};
+export { currentLevelLabels } from "@/lib/enum-labels";

--- a/frontend/src/features/diagnosis/labels.ts
+++ b/frontend/src/features/diagnosis/labels.ts
@@ -1,24 +1,5 @@
-import type {
-  CurrentLevel,
-  DiagnosisSeverity
-} from "@/features/diagnosis/types";
-
-export const currentLevelLabels: Record<CurrentLevel, string> = {
-  ADVANCED: "고급",
-  BASIC: "기초",
-  BEGINNER: "입문",
-  INTERMEDIATE: "중급",
-  JUNIOR: "주니어"
-};
-
-export const diagnosisSeverityLabels: Record<DiagnosisSeverity, string> = {
-  HIGH: "높음",
-  LOW: "낮음",
-  MEDIUM: "중간"
-};
-
-export const diagnosisSeverityClassNames: Record<DiagnosisSeverity, string> = {
-  HIGH: "high",
-  LOW: "low",
-  MEDIUM: "medium"
-};
+export {
+  currentLevelLabels,
+  diagnosisSeverityClassNames,
+  diagnosisSeverityLabels
+} from "@/lib/enum-labels";

--- a/frontend/src/features/github-analysis/labels.ts
+++ b/frontend/src/features/github-analysis/labels.ts
@@ -1,26 +1,5 @@
-import type {
-  GithubDepthLevel,
-  GithubEvidenceType
-} from "@/features/github-analysis/types";
-
-export const githubDepthLevelLabels: Record<GithubDepthLevel, string> = {
-  APPLIED: "적용",
-  DEEP: "심화",
-  INTRO: "입문",
-  PRACTICAL: "실무"
-};
-
-export const githubDepthLevelClassNames: Record<GithubDepthLevel, string> = {
-  APPLIED: "applied",
-  DEEP: "deep",
-  INTRO: "intro",
-  PRACTICAL: "practical"
-};
-
-export const githubEvidenceTypeLabels: Record<GithubEvidenceType, string> = {
-  CODE: "코드",
-  COMMIT: "커밋",
-  CONFIG: "설정",
-  README: "README",
-  REPO_METADATA: "저장소 메타"
-};
+export {
+  githubDepthLevelClassNames,
+  githubDepthLevelLabels,
+  githubEvidenceTypeLabels
+} from "@/lib/enum-labels";

--- a/frontend/src/features/profile/labels.ts
+++ b/frontend/src/features/profile/labels.ts
@@ -1,41 +1,7 @@
-import type {
-  CurrentLevel,
-  ProficiencyLevel,
-  SkillSourceType
-} from "@/features/profile/types";
-
-export const currentLevelOptions: CurrentLevel[] = [
-  "BEGINNER",
-  "BASIC",
-  "JUNIOR",
-  "INTERMEDIATE",
-  "ADVANCED"
-];
-
-export const proficiencyLevelOptions: ProficiencyLevel[] = [
-  "NONE",
-  "BASIC",
-  "WORKING",
-  "STRONG"
-];
-
-export const currentLevelLabels: Record<CurrentLevel, string> = {
-  ADVANCED: "고급",
-  BASIC: "기초",
-  BEGINNER: "입문",
-  INTERMEDIATE: "중급",
-  JUNIOR: "주니어"
-};
-
-export const proficiencyLevelLabels: Record<ProficiencyLevel, string> = {
-  BASIC: "기초",
-  NONE: "없음",
-  STRONG: "강함",
-  WORKING: "실무 가능"
-};
-
-export const skillSourceTypeLabels: Record<SkillSourceType, string> = {
-  GITHUB_ESTIMATED: "GitHub 추정",
-  SYSTEM_DERIVED: "시스템 추론",
-  USER_INPUT: "사용자 입력"
-};
+export {
+  currentLevelLabels,
+  currentLevelOptions,
+  proficiencyLevelLabels,
+  proficiencyLevelOptions,
+  skillSourceTypeLabels
+} from "@/lib/enum-labels";

--- a/frontend/src/features/roadmap/labels.ts
+++ b/frontend/src/features/roadmap/labels.ts
@@ -1,38 +1,7 @@
-import type { MaterialType, ProgressStatus, RoadmapTaskType } from "@/features/roadmap/types";
-
-export const progressStatusOptions: ProgressStatus[] = [
-  "TODO",
-  "IN_PROGRESS",
-  "DONE",
-  "SKIPPED"
-];
-
-export const progressStatusLabels: Record<ProgressStatus, string> = {
-  DONE: "완료",
-  IN_PROGRESS: "진행 중",
-  SKIPPED: "건너뜀",
-  TODO: "예정"
-};
-
-export const progressStatusClassNames: Record<ProgressStatus, string> = {
-  DONE: "done",
-  IN_PROGRESS: "in-progress",
-  SKIPPED: "skipped",
-  TODO: "todo"
-};
-
-export const taskTypeLabels: Record<RoadmapTaskType, string> = {
-  APPLY_PROJECT: "프로젝트 적용",
-  BUILD_EXAMPLE: "예제 구현",
-  READ_DOCS: "문서 읽기",
-  REVIEW: "복습",
-  WRITE_NOTE: "노트 작성"
-};
-
-export const materialTypeLabels: Record<MaterialType, string> = {
-  ARTICLE: "아티클",
-  DOCS: "문서",
-  REPOSITORY: "저장소",
-  TEMPLATE: "템플릿",
-  VIDEO: "영상"
-};
+export {
+  materialTypeLabels,
+  progressStatusClassNames,
+  progressStatusLabels,
+  progressStatusOptions,
+  roadmapTaskTypeLabels as taskTypeLabels
+} from "@/lib/enum-labels";

--- a/frontend/src/lib/enum-labels.ts
+++ b/frontend/src/lib/enum-labels.ts
@@ -1,0 +1,147 @@
+export type CurrentLevelCode =
+  | "BEGINNER"
+  | "BASIC"
+  | "JUNIOR"
+  | "INTERMEDIATE"
+  | "ADVANCED";
+
+export type ProficiencyLevelCode = "NONE" | "BASIC" | "WORKING" | "STRONG";
+
+export type SkillSourceTypeCode =
+  | "USER_INPUT"
+  | "GITHUB_ESTIMATED"
+  | "SYSTEM_DERIVED";
+
+export type DiagnosisSeverityCode = "LOW" | "MEDIUM" | "HIGH";
+
+export type GithubDepthLevelCode = "INTRO" | "APPLIED" | "PRACTICAL" | "DEEP";
+
+export type GithubEvidenceTypeCode =
+  | "README"
+  | "CODE"
+  | "CONFIG"
+  | "REPO_METADATA"
+  | "COMMIT";
+
+export type ProgressStatusCode = "TODO" | "IN_PROGRESS" | "DONE" | "SKIPPED";
+
+export type RoadmapTaskTypeCode =
+  | "READ_DOCS"
+  | "BUILD_EXAMPLE"
+  | "WRITE_NOTE"
+  | "APPLY_PROJECT"
+  | "REVIEW";
+
+export type MaterialTypeCode =
+  | "DOCS"
+  | "ARTICLE"
+  | "REPOSITORY"
+  | "VIDEO"
+  | "TEMPLATE";
+
+export const currentLevelOptions: CurrentLevelCode[] = [
+  "BEGINNER",
+  "BASIC",
+  "JUNIOR",
+  "INTERMEDIATE",
+  "ADVANCED"
+];
+
+export const proficiencyLevelOptions: ProficiencyLevelCode[] = [
+  "NONE",
+  "BASIC",
+  "WORKING",
+  "STRONG"
+];
+
+export const progressStatusOptions: ProgressStatusCode[] = [
+  "TODO",
+  "IN_PROGRESS",
+  "DONE",
+  "SKIPPED"
+];
+
+export const currentLevelLabels: Record<CurrentLevelCode, string> = {
+  ADVANCED: "고급",
+  BASIC: "기초",
+  BEGINNER: "입문",
+  INTERMEDIATE: "중급",
+  JUNIOR: "주니어"
+};
+
+export const proficiencyLevelLabels: Record<ProficiencyLevelCode, string> = {
+  BASIC: "기초",
+  NONE: "없음",
+  STRONG: "강함",
+  WORKING: "실무 가능"
+};
+
+export const skillSourceTypeLabels: Record<SkillSourceTypeCode, string> = {
+  GITHUB_ESTIMATED: "GitHub 추정",
+  SYSTEM_DERIVED: "시스템 추론",
+  USER_INPUT: "사용자 입력"
+};
+
+export const diagnosisSeverityLabels: Record<DiagnosisSeverityCode, string> = {
+  HIGH: "높음",
+  LOW: "낮음",
+  MEDIUM: "중간"
+};
+
+export const diagnosisSeverityClassNames: Record<DiagnosisSeverityCode, string> = {
+  HIGH: "high",
+  LOW: "low",
+  MEDIUM: "medium"
+};
+
+export const githubDepthLevelLabels: Record<GithubDepthLevelCode, string> = {
+  APPLIED: "적용",
+  DEEP: "심화",
+  INTRO: "입문",
+  PRACTICAL: "실무"
+};
+
+export const githubDepthLevelClassNames: Record<GithubDepthLevelCode, string> = {
+  APPLIED: "applied",
+  DEEP: "deep",
+  INTRO: "intro",
+  PRACTICAL: "practical"
+};
+
+export const githubEvidenceTypeLabels: Record<GithubEvidenceTypeCode, string> = {
+  CODE: "코드",
+  COMMIT: "커밋",
+  CONFIG: "설정",
+  README: "README",
+  REPO_METADATA: "저장소 메타"
+};
+
+export const progressStatusLabels: Record<ProgressStatusCode, string> = {
+  DONE: "완료",
+  IN_PROGRESS: "진행 중",
+  SKIPPED: "건너뜀",
+  TODO: "예정"
+};
+
+export const progressStatusClassNames: Record<ProgressStatusCode, string> = {
+  DONE: "done",
+  IN_PROGRESS: "in-progress",
+  SKIPPED: "skipped",
+  TODO: "todo"
+};
+
+export const roadmapTaskTypeLabels: Record<RoadmapTaskTypeCode, string> = {
+  APPLY_PROJECT: "프로젝트 적용",
+  BUILD_EXAMPLE: "예제 구현",
+  READ_DOCS: "문서 읽기",
+  REVIEW: "복습",
+  WRITE_NOTE: "노트 작성"
+};
+
+export const materialTypeLabels: Record<MaterialTypeCode, string> = {
+  ARTICLE: "아티클",
+  DOCS: "문서",
+  REPOSITORY: "저장소",
+  TEMPLATE: "템플릿",
+  VIDEO: "영상"
+};


### PR DESCRIPTION
## 연관 이슈

Closes #120

## 변경 요약

- 공통 enum 라벨 모듈 `frontend/src/lib/enum-labels.ts` 추가
- 기능별 `labels.ts`는 기존 import 경로를 유지하면서 공통 라벨을 re-export하도록 정리
- 프로필/진도 옵션 배열 순서는 기존 화면 동작과 동일하게 유지

## 왜 필요한가

- 같은 enum 값을 화면별로 따로 관리하면 `CurrentLevel` 같은 공통 값의 한글 라벨이 화면마다 달라질 수 있다.

## 테스트

실행 내용:

```text
npm run lint
npm run build
```