### PR TITLE
refactor(frontend-ui): 상태 패널 공통화

### DIFF
--- a/frontend/src/components/state-panel.tsx
+++ b/frontend/src/components/state-panel.tsx
@@ -1,0 +1,20 @@
+type StatePanelProps = {
+  className?: string;
+  message: string;
+  tone?: "danger" | "neutral";
+};
+
+export function StatePanel({
+  className,
+  message,
+  tone = "neutral"
+}: StatePanelProps) {
+  return (
+    <section
+      className={["panel", className].filter(Boolean).join(" ")}
+      data-tone={tone}
+    >
+      <p>{message}</p>
+    </section>
+  );
+}

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { StatePanel } from "@/components/state-panel";
 import { getDiagnosis } from "@/features/diagnosis/api";
 import {
   currentLevelLabels,
@@ -54,11 +55,22 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
   }, [diagnosisId]);
 
   if (state.status === "loading") {
-    return <DiagnosisStatePanel message="진단 결과를 불러오는 중입니다." />;
+    return (
+      <StatePanel
+        className="diagnosis-state-panel"
+        message="진단 결과를 불러오는 중입니다."
+      />
+    );
   }
 
   if (state.status === "error") {
-    return <DiagnosisStatePanel message={state.message} tone="danger" />;
+    return (
+      <StatePanel
+        className="diagnosis-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
   }
 
   const { diagnosis } = state;
@@ -140,20 +152,6 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
           title="추천"
         />
       </div>
-    </section>
-  );
-}
-
-function DiagnosisStatePanel({
-  message,
-  tone = "neutral"
-}: {
-  message: string;
-  tone?: "danger" | "neutral";
-}) {
-  return (
-    <section className="panel diagnosis-state-panel" data-tone={tone}>
-      <p>{message}</p>
     </section>
   );
 }

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 
+import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
 import {
   getGithubAnalysis,
@@ -154,15 +155,31 @@ export function GithubAnalysisView({
   }
 
   if (state.status === "loading") {
-    return <GithubAnalysisStatePanel message="GitHub 분석 결과를 불러오는 중입니다." />;
+    return (
+      <StatePanel
+        className="github-analysis-state-panel"
+        message="GitHub 분석 결과를 불러오는 중입니다."
+      />
+    );
   }
 
   if (state.status === "empty") {
-    return <GithubAnalysisStatePanel message={state.message} />;
+    return (
+      <StatePanel
+        className="github-analysis-state-panel"
+        message={state.message}
+      />
+    );
   }
 
   if (state.status === "error") {
-    return <GithubAnalysisStatePanel message={state.message} tone="danger" />;
+    return (
+      <StatePanel
+        className="github-analysis-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
   }
 
   const { analysis, diagnosisId } = state;
@@ -267,20 +284,6 @@ export function GithubAnalysisView({
         saveMessage={saveMessage}
       />
       <UserCorrectionPreview corrections={analysis.userCorrections} />
-    </section>
-  );
-}
-
-function GithubAnalysisStatePanel({
-  message,
-  tone = "neutral"
-}: {
-  message: string;
-  tone?: "danger" | "neutral";
-}) {
-  return (
-    <section className="panel github-analysis-state-panel" data-tone={tone}>
-      <p>{message}</p>
     </section>
   );
 }

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
+import { StatePanel } from "@/components/state-panel";
 import { getMyProfile, saveProfile } from "@/features/profile/api";
 import {
   currentLevelLabels,
@@ -67,11 +68,22 @@ export function ProfileView() {
   }, []);
 
   if (state.status === "loading") {
-    return <ProfileStatePanel message="프로필을 불러오는 중입니다." />;
+    return (
+      <StatePanel
+        className="profile-state-panel"
+        message="프로필을 불러오는 중입니다."
+      />
+    );
   }
 
   if (state.status === "error") {
-    return <ProfileStatePanel message={state.message} tone="danger" />;
+    return (
+      <StatePanel
+        className="profile-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -265,20 +277,6 @@ function ProfileForm({
         </button>
       </div>
     </form>
-  );
-}
-
-function ProfileStatePanel({
-  message,
-  tone = "neutral"
-}: {
-  message: string;
-  tone?: "danger" | "neutral";
-}) {
-  return (
-    <section className="panel profile-state-panel" data-tone={tone}>
-      <p>{message}</p>
-    </section>
   );
 }
 

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
+import { StatePanel } from "@/components/state-panel";
 import { getRoadmap, saveRoadmapProgress } from "@/features/roadmap/api";
 import {
   materialTypeLabels,
@@ -124,11 +125,22 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
   }
 
   if (state.status === "loading") {
-    return <RoadmapStatePanel message="로드맵을 불러오는 중입니다." />;
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message="로드맵을 불러오는 중입니다."
+      />
+    );
   }
 
   if (state.status === "error") {
-    return <RoadmapStatePanel message={state.message} tone="danger" />;
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
   }
 
   const { roadmap } = state;
@@ -158,7 +170,10 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
       </div>
 
       {roadmap.weeks.length === 0 ? (
-        <RoadmapStatePanel message="표시할 주차 계획이 없습니다." />
+        <StatePanel
+          className="roadmap-state-panel"
+          message="표시할 주차 계획이 없습니다."
+        />
       ) : (
         <div className="roadmap-week-list">
           {roadmap.weeks.map((week) => {
@@ -287,20 +302,6 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
           })}
         </div>
       )}
-    </section>
-  );
-}
-
-function RoadmapStatePanel({
-  message,
-  tone = "neutral"
-}: {
-  message: string;
-  tone?: "danger" | "neutral";
-}) {
-  return (
-    <section className="panel roadmap-state-panel" data-tone={tone}>
-      <p>{message}</p>
     </section>
   );
 }


### PR DESCRIPTION
## 연관 이슈

Closes #122

## 변경 요약

- 공통 `StatePanel` 컴포넌트 추가
- 프로필, 진단, GitHub 분석, 로드맵 화면의 로컬 상태 패널을 공통 컴포넌트로 교체
- 기존 화면별 state panel CSS class는 그대로 유지

## 왜 필요한가

- loading/error/empty 상태 패널 구현이 화면마다 흩어져 있으면 tone 처리와 마크업이 쉽게 달라질 수 있다.

## 테스트

실행 내용:

```text
npm run lint
npm run build
```