### PR TITLE
refactor(frontend-ui): 대시보드 상태 패널 공통화

### DIFF
--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
 import { currentLevelLabels } from "@/features/dashboard/labels";
 import type {
@@ -49,11 +50,22 @@ export function DashboardView() {
   }, []);
 
   if (state.status === "loading") {
-    return <DashboardStatePanel message="대시보드를 불러오는 중입니다." />;
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message="대시보드를 불러오는 중입니다."
+      />
+    );
   }
 
   if (state.status === "error") {
-    return <DashboardStatePanel message={state.message} tone="danger" />;
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
   }
 
   const { dashboard } = state;
@@ -208,20 +220,6 @@ export function DashboardView() {
           )}
         </section>
       </div>
-    </section>
-  );
-}
-
-function DashboardStatePanel({
-  message,
-  tone = "neutral"
-}: {
-  message: string;
-  tone?: "danger" | "neutral";
-}) {
-  return (
-    <section className="panel roadmap-state-panel" data-tone={tone}>
-      <p>{message}</p>
     </section>
   );
 }


### PR DESCRIPTION
## 연관 이슈

Closes #124

## 변경 요약

- dashboard loading/error 상태에서 공통 StatePanel 사용
- 로컬 DashboardStatePanel 제거
- 기존 roadmap-state-panel class는 유지

## 왜 필요한가

- 같은 loading/error 패널 구조가 화면마다 다시 생기는 것을 막는다.

## 테스트

- npm run lint
- npm run build