### PR TITLE
feat(diagnosis): 역량 진단 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisCommandController.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisCommandController.java
@@ -1,0 +1,38 @@
+package com.back.coach.domain.diagnosis.controller;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
+import com.back.coach.domain.diagnosis.service.DiagnosisCommandService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/diagnoses", produces = MediaType.APPLICATION_JSON_VALUE)
+public class DiagnosisCommandController {
+
+    private final DiagnosisCommandService diagnosisCommandService;
+
+    public DiagnosisCommandController(DiagnosisCommandService diagnosisCommandService) {
+        this.diagnosisCommandService = diagnosisCommandService;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<DiagnosisDetailResponse> createDiagnosis(
+            Authentication authentication,
+            @Valid @RequestBody DiagnosisRequest request
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(diagnosisCommandService.createDiagnosis(
+                authenticatedUser.userId(),
+                request
+        ));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisRequest.java
@@ -1,0 +1,9 @@
+package com.back.coach.domain.diagnosis.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DiagnosisRequest(
+        @NotNull Long profileId,
+        @NotNull Long githubAnalysisId
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/entity/CapabilityDiagnosis.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/entity/CapabilityDiagnosis.java
@@ -54,4 +54,26 @@ public class CapabilityDiagnosis extends BaseEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    public static CapabilityDiagnosis create(
+            Long userId,
+            Long profileId,
+            Long githubAnalysisId,
+            Long jobRoleId,
+            Integer version,
+            CurrentLevel currentLevel,
+            String summary,
+            String diagnosisPayload
+    ) {
+        CapabilityDiagnosis diagnosis = new CapabilityDiagnosis();
+        diagnosis.userId = userId;
+        diagnosis.profileId = profileId;
+        diagnosis.githubAnalysisId = githubAnalysisId;
+        diagnosis.jobRoleId = jobRoleId;
+        diagnosis.version = version;
+        diagnosis.currentLevel = currentLevel;
+        diagnosis.summary = summary;
+        diagnosis.diagnosisPayload = diagnosisPayload;
+        return diagnosis;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
@@ -1,0 +1,162 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.github.service.GithubAnalysisPayloadJson;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.jobrole.repository.SkillRequirementRepository;
+import com.back.coach.domain.result.service.ResultVersionService;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+public class DiagnosisCommandService {
+
+    private final UserProfileRepository userProfileRepository;
+    private final UserSkillRepository userSkillRepository;
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final JobRoleRepository jobRoleRepository;
+    private final SkillRequirementRepository skillRequirementRepository;
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final ResultVersionService resultVersionService;
+    private final GithubAnalysisPayloadJson githubAnalysisPayloadJson;
+    private final DiagnosisPromptBuilder diagnosisPromptBuilder;
+    private final DiagnosisResponseParser diagnosisResponseParser;
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public DiagnosisCommandService(
+            UserProfileRepository userProfileRepository,
+            UserSkillRepository userSkillRepository,
+            GithubAnalysisRepository githubAnalysisRepository,
+            JobRoleRepository jobRoleRepository,
+            SkillRequirementRepository skillRequirementRepository,
+            CapabilityDiagnosisRepository capabilityDiagnosisRepository,
+            ResultVersionService resultVersionService,
+            GithubAnalysisPayloadJson githubAnalysisPayloadJson,
+            DiagnosisPromptBuilder diagnosisPromptBuilder,
+            DiagnosisResponseParser diagnosisResponseParser,
+            LlmClient llmClient,
+            ObjectMapper objectMapper
+    ) {
+        this.userProfileRepository = userProfileRepository;
+        this.userSkillRepository = userSkillRepository;
+        this.githubAnalysisRepository = githubAnalysisRepository;
+        this.jobRoleRepository = jobRoleRepository;
+        this.skillRequirementRepository = skillRequirementRepository;
+        this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
+        this.resultVersionService = resultVersionService;
+        this.githubAnalysisPayloadJson = githubAnalysisPayloadJson;
+        this.diagnosisPromptBuilder = diagnosisPromptBuilder;
+        this.diagnosisResponseParser = diagnosisResponseParser;
+        this.llmClient = llmClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public DiagnosisDetailResponse createDiagnosis(Long userId, DiagnosisRequest request) {
+        UserProfile profile = userProfileRepository.findByIdAndUserId(request.profileId(), userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        GithubAnalysis githubAnalysis = githubAnalysisRepository.findByIdAndUserId(request.githubAnalysisId(), userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        JobRole jobRole = jobRoleRepository.findById(profile.getJobRoleId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+        List<UserSkill> userSkills = userSkillRepository
+                .findByUserIdAndSourceTypeOrderBySkillNameAsc(userId, SkillSourceType.USER_INPUT);
+        List<SkillRequirement> skillRequirements = skillRequirementRepository
+                .findByJobRoleIdOrderByImportanceDescSkillNameAsc(profile.getJobRoleId());
+        GithubAnalysisPayload githubAnalysisPayload = parseGithubAnalysisPayload(githubAnalysis);
+
+        String prompt = diagnosisPromptBuilder.build(new DiagnosisPromptBuilder.Input(
+                jobRole,
+                profile,
+                userSkills,
+                skillRequirements,
+                githubAnalysisPayload.finalTechProfile()
+        ));
+        DiagnosisResponseParser.DiagnosisResult diagnosisResult =
+                diagnosisResponseParser.parse(llmClient.complete(prompt));
+        DiagnosisPayload diagnosisPayload = new DiagnosisPayload(
+                diagnosisResult.missingSkills(),
+                diagnosisResult.strengths(),
+                diagnosisResult.recommendations()
+        );
+        CapabilityDiagnosis savedDiagnosis = capabilityDiagnosisRepository.save(
+                CapabilityDiagnosis.create(
+                        userId,
+                        profile.getId(),
+                        githubAnalysis.getId(),
+                        profile.getJobRoleId(),
+                        resultVersionService.nextCapabilityDiagnosisVersion(userId),
+                        profile.getCurrentLevel(),
+                        diagnosisResult.summary(),
+                        toJson(diagnosisPayload)
+                )
+        );
+
+        return toResponse(savedDiagnosis, jobRole, diagnosisPayload);
+    }
+
+    private GithubAnalysisPayload parseGithubAnalysisPayload(GithubAnalysis githubAnalysis) {
+        try {
+            return githubAnalysisPayloadJson.fromJson(githubAnalysis.getAnalysisPayload());
+        } catch (IllegalStateException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String toJson(DiagnosisPayload diagnosisPayload) {
+        try {
+            return objectMapper.writeValueAsString(diagnosisPayload);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private DiagnosisDetailResponse toResponse(
+            CapabilityDiagnosis diagnosis,
+            JobRole jobRole,
+            DiagnosisPayload payload
+    ) {
+        return new DiagnosisDetailResponse(
+                String.valueOf(diagnosis.getId()),
+                diagnosis.getVersion(),
+                String.valueOf(diagnosis.getProfileId()),
+                String.valueOf(diagnosis.getGithubAnalysisId()),
+                jobRole.getRoleCode(),
+                diagnosis.getCurrentLevel(),
+                diagnosis.getSummary(),
+                payload.missingSkills().stream()
+                        .map(DiagnosisDetailResponse.MissingSkillResponse::from)
+                        .toList(),
+                payload.strengths(),
+                payload.recommendations(),
+                createdAtOrNow(diagnosis)
+        );
+    }
+
+    private Instant createdAtOrNow(CapabilityDiagnosis diagnosis) {
+        return diagnosis.getCreatedAt() == null ? Instant.now() : diagnosis.getCreatedAt();
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
@@ -1,0 +1,83 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.global.code.DiagnosisSeverity;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DiagnosisPromptBuilder {
+
+    private static final String SEVERITY_VALUES = Arrays.stream(DiagnosisSeverity.values())
+            .map(Enum::name)
+            .collect(Collectors.joining(", "));
+
+    public String build(Input input) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("You are an AI developer growth diagnosis engine.\n");
+        prompt.append("Compare the user's profile and GitHub final tech profile against the target job role requirements.\n");
+        prompt.append("Return only one JSON object with summary, missingSkills, strengths, recommendations.\n\n");
+
+        prompt.append("## Target Role\n");
+        prompt.append("roleCode: ").append(input.jobRole().getRoleCode()).append("\n");
+        prompt.append("roleName: ").append(input.jobRole().getRoleName()).append("\n");
+        prompt.append("description: ").append(nullToEmpty(input.jobRole().getDescription())).append("\n\n");
+
+        prompt.append("## User Profile\n");
+        prompt.append("currentLevel: ").append(input.profile().getCurrentLevel()).append("\n");
+        prompt.append("weeklyStudyHours: ").append(input.profile().getWeeklyStudyHours()).append("\n");
+        prompt.append("targetDate: ").append(input.profile().getTargetDate()).append("\n");
+        prompt.append("userInputSkills:\n");
+        input.userSkills().forEach(skill -> prompt
+                .append("  - ")
+                .append(skill.getSkillName())
+                .append(" | proficiency=")
+                .append(skill.getProficiencyLevel())
+                .append("\n"));
+
+        prompt.append("\n## GitHub Final Tech Profile\n");
+        prompt.append("confirmedSkills:\n");
+        input.finalTechProfile().confirmedSkills()
+                .forEach(skill -> prompt.append("  - ").append(skill).append("\n"));
+        prompt.append("focusAreas:\n");
+        input.finalTechProfile().focusAreas()
+                .forEach(area -> prompt.append("  - ").append(area).append("\n"));
+
+        prompt.append("\n## Job Skill Requirements\n");
+        input.skillRequirements().forEach(requirement -> prompt
+                .append("  - ")
+                .append(requirement.getSkillName())
+                .append(" | category=")
+                .append(requirement.getCategory())
+                .append(" | importance=")
+                .append(requirement.getImportance())
+                .append("\n"));
+
+        prompt.append("\n## Output Rules\n");
+        prompt.append("missingSkills[].severity must be one of: ").append(SEVERITY_VALUES).append("\n");
+        prompt.append("missingSkills[].priorityOrder starts at 1 and must be sorted by learning priority.\n");
+        prompt.append("strengths should include skills supported by user input or GitHub confirmed skills.\n");
+        prompt.append("recommendations should be concrete next learning priorities.\n");
+        return prompt.toString();
+    }
+
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    public record Input(
+            JobRole jobRole,
+            UserProfile profile,
+            List<UserSkill> userSkills,
+            List<SkillRequirement> skillRequirements,
+            GithubAnalysisPayload.FinalTechProfile finalTechProfile
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParser.java
@@ -1,0 +1,83 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class DiagnosisResponseParser {
+
+    private static final Logger log = LoggerFactory.getLogger(DiagnosisResponseParser.class);
+    private static final String SCHEMA_PATH = "ai/schema/diagnosis.schema.json";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonSchema schema = loadSchema();
+
+    public DiagnosisResult parse(String llmJson) {
+        JsonNode root;
+        try {
+            root = mapper.readTree(llmJson);
+        } catch (IOException ex) {
+            log.warn("Diagnosis 응답 JSON 파싱 실패: {}", ex.getMessage());
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        Set<ValidationMessage> errors = schema.validate(root);
+        if (!errors.isEmpty()) {
+            log.warn("Diagnosis 응답 schema 위반: {}", errors);
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        return new DiagnosisResult(
+                root.get("summary").asText(),
+                mapList(root.get("missingSkills"), node -> new DiagnosisPayload.MissingSkill(
+                        node.get("skillName").asText(),
+                        DiagnosisSeverity.valueOf(node.get("severity").asText()),
+                        node.get("reason").asText(),
+                        node.get("priorityOrder").asInt()
+                )),
+                mapList(root.get("strengths"), JsonNode::asText),
+                mapList(root.get("recommendations"), JsonNode::asText)
+        );
+    }
+
+    private static <T> List<T> mapList(JsonNode array, java.util.function.Function<JsonNode, T> mapper) {
+        List<T> values = new ArrayList<>();
+        array.forEach(node -> values.add(mapper.apply(node)));
+        return values;
+    }
+
+    private static JsonSchema loadSchema() {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+        try (InputStream inputStream = new ClassPathResource(SCHEMA_PATH).getInputStream()) {
+            return factory.getSchema(inputStream);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Diagnosis schema 로드 실패: " + SCHEMA_PATH, ex);
+        }
+    }
+
+    public record DiagnosisResult(
+            String summary,
+            List<DiagnosisPayload.MissingSkill> missingSkills,
+            List<String> strengths,
+            List<String> recommendations
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/repository/SkillRequirementRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/repository/SkillRequirementRepository.java
@@ -3,5 +3,9 @@ package com.back.coach.domain.jobrole.repository;
 import com.back.coach.domain.jobrole.entity.SkillRequirement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SkillRequirementRepository extends JpaRepository<SkillRequirement, Long> {
+
+    List<SkillRequirement> findByJobRoleIdOrderByImportanceDescSkillNameAsc(Long jobRoleId);
 }

--- a/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/user/repository/UserProfileRepository.java
@@ -9,5 +9,7 @@ public interface UserProfileRepository extends JpaRepository<UserProfile, Long> 
 
     Optional<UserProfile> findByUserId(Long userId);
 
+    Optional<UserProfile> findByIdAndUserId(Long id, Long userId);
+
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/backend/src/main/resources/ai/schema/diagnosis.schema.json
+++ b/backend/src/main/resources/ai/schema/diagnosis.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DiagnosisResponse",
+  "type": "object",
+  "required": ["summary", "missingSkills", "strengths", "recommendations"],
+  "additionalProperties": false,
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "missingSkills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["skillName", "severity", "reason", "priorityOrder"],
+        "additionalProperties": false,
+        "properties": {
+          "skillName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["LOW", "MEDIUM", "HIGH"]
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "priorityOrder": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "strengths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/controller/DiagnosisCommandControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/controller/DiagnosisCommandControllerTest.java
@@ -1,0 +1,126 @@
+package com.back.coach.domain.diagnosis.controller;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
+import com.back.coach.domain.diagnosis.service.DiagnosisCommandService;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.JwtTokenProvider;
+import com.back.coach.support.ApiTestBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DiagnosisCommandControllerTest extends ApiTestBase {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private DiagnosisCommandService diagnosisCommandService;
+
+    @Test
+    void createDiagnosis_whenRequestIsValid_returnsDiagnosisResult() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-diagnosis-1", "diagnosis1@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        given(diagnosisCommandService.createDiagnosis(eq(user.getId()), any(DiagnosisRequest.class)))
+                .willReturn(response());
+
+        mockMvc.perform(post("/api/diagnoses")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "profileId", 10,
+                                "githubAnalysisId", 20
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.diagnosisId").value("30"))
+                .andExpect(jsonPath("$.data.version").value(4))
+                .andExpect(jsonPath("$.data.profileId").value("10"))
+                .andExpect(jsonPath("$.data.githubAnalysisId").value("20"))
+                .andExpect(jsonPath("$.data.targetRole").value("BACKEND_DEVELOPER"))
+                .andExpect(jsonPath("$.data.missingSkills[0].skillName").value("Redis"))
+                .andExpect(jsonPath("$.meta").isMap());
+    }
+
+    @Test
+    void createDiagnosis_withoutAuth_returnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/diagnoses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileId\":10,\"githubAnalysisId\":20}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createDiagnosis_whenGithubAnalysisIdIsMissing_returnsBadRequest() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-diagnosis-2", "diagnosis2@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+
+        mockMvc.perform(post("/api/diagnoses")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileId\":10}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createDiagnosis_whenProfileOrAnalysisDoesNotExist_returnsNotFound() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-diagnosis-3", "diagnosis3@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        given(diagnosisCommandService.createDiagnosis(eq(user.getId()), any(DiagnosisRequest.class)))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(post("/api/diagnoses")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileId\":999,\"githubAnalysisId\":20}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    private DiagnosisDetailResponse response() {
+        return new DiagnosisDetailResponse(
+                "30",
+                4,
+                "10",
+                "20",
+                "BACKEND_DEVELOPER",
+                CurrentLevel.JUNIOR,
+                "Redis 보완 필요",
+                List.of(new DiagnosisDetailResponse.MissingSkillResponse(
+                        "Redis",
+                        DiagnosisSeverity.HIGH,
+                        "캐시 설계 경험이 부족함",
+                        1
+                )),
+                List.of("Spring Boot"),
+                List.of("Redis 캐시와 TTL 기반 설계를 먼저 학습"),
+                Instant.parse("2026-04-29T01:00:00Z")
+        );
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
@@ -1,0 +1,312 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.github.service.GithubAnalysisPayloadJson;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.jobrole.repository.SkillRequirementRepository;
+import com.back.coach.domain.result.service.ResultVersionService;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DiagnosisCommandServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long PROFILE_ID = 10L;
+    private static final Long GITHUB_ANALYSIS_ID = 20L;
+    private static final Long JOB_ROLE_ID = 100L;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+    private final GithubAnalysisPayloadJson githubAnalysisPayloadJson = new GithubAnalysisPayloadJson();
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private UserSkillRepository userSkillRepository;
+
+    @Mock
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Mock
+    private JobRoleRepository jobRoleRepository;
+
+    @Mock
+    private SkillRequirementRepository skillRequirementRepository;
+
+    @Mock
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Mock
+    private ResultVersionService resultVersionService;
+
+    @Mock
+    private LlmClient llmClient;
+
+    private DiagnosisCommandService diagnosisCommandService;
+
+    @BeforeEach
+    void setUp() {
+        diagnosisCommandService = new DiagnosisCommandService(
+                userProfileRepository,
+                userSkillRepository,
+                githubAnalysisRepository,
+                jobRoleRepository,
+                skillRequirementRepository,
+                capabilityDiagnosisRepository,
+                resultVersionService,
+                githubAnalysisPayloadJson,
+                new DiagnosisPromptBuilder(),
+                new DiagnosisResponseParser(),
+                llmClient,
+                objectMapper
+        );
+    }
+
+    @Test
+    void createDiagnosis_whenInputsAreValid_savesVersionedDiagnosisPayload() throws Exception {
+        primeValidInputs();
+        given(resultVersionService.nextCapabilityDiagnosisVersion(USER_ID)).willReturn(4);
+        given(llmClient.complete(anyString())).willReturn(validLlmResponse());
+        given(capabilityDiagnosisRepository.save(any(CapabilityDiagnosis.class)))
+                .willAnswer(invocation -> withIdAndCreatedAt(invocation.getArgument(0), 30L));
+
+        DiagnosisDetailResponse result = diagnosisCommandService.createDiagnosis(
+                USER_ID,
+                new DiagnosisRequest(PROFILE_ID, GITHUB_ANALYSIS_ID)
+        );
+
+        assertThat(result.diagnosisId()).isEqualTo("30");
+        assertThat(result.version()).isEqualTo(4);
+        assertThat(result.profileId()).isEqualTo("10");
+        assertThat(result.githubAnalysisId()).isEqualTo("20");
+        assertThat(result.targetRole()).isEqualTo("BACKEND_DEVELOPER");
+        assertThat(result.summary()).isEqualTo("Redis 보완 필요");
+        assertThat(result.missingSkills()).containsExactly(new DiagnosisDetailResponse.MissingSkillResponse(
+                "Redis",
+                DiagnosisSeverity.HIGH,
+                "캐시 설계 경험이 부족함",
+                1
+        ));
+
+        ArgumentCaptor<CapabilityDiagnosis> diagnosisCaptor = ArgumentCaptor.forClass(CapabilityDiagnosis.class);
+        verify(capabilityDiagnosisRepository).save(diagnosisCaptor.capture());
+        CapabilityDiagnosis saved = diagnosisCaptor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(USER_ID);
+        assertThat(saved.getProfileId()).isEqualTo(PROFILE_ID);
+        assertThat(saved.getGithubAnalysisId()).isEqualTo(GITHUB_ANALYSIS_ID);
+        assertThat(saved.getJobRoleId()).isEqualTo(JOB_ROLE_ID);
+        assertThat(saved.getVersion()).isEqualTo(4);
+        assertThat(saved.getCurrentLevel()).isEqualTo(CurrentLevel.JUNIOR);
+
+        DiagnosisPayload storedPayload = objectMapper.readValue(saved.getDiagnosisPayload(), DiagnosisPayload.class);
+        assertThat(storedPayload.missingSkills())
+                .extracting(DiagnosisPayload.MissingSkill::skillName)
+                .containsExactly("Redis");
+        assertThat(storedPayload.strengths()).containsExactly("Spring Boot");
+        assertThat(storedPayload.recommendations()).containsExactly("Redis 캐시와 TTL 기반 설계를 먼저 학습");
+
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(promptCaptor.capture());
+        assertThat(promptCaptor.getValue()).contains("Spring Boot", "Redis", "BACKEND_DEVELOPER");
+    }
+
+    @Test
+    void createDiagnosis_whenProfileDoesNotBelongToUser_throwsResourceNotFound() {
+        given(userProfileRepository.findByIdAndUserId(PROFILE_ID, USER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> diagnosisCommandService.createDiagnosis(
+                USER_ID,
+                new DiagnosisRequest(PROFILE_ID, GITHUB_ANALYSIS_ID)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verifyNoInteractions(githubAnalysisRepository, llmClient, capabilityDiagnosisRepository);
+    }
+
+    @Test
+    void createDiagnosis_whenGithubAnalysisDoesNotBelongToUser_throwsResourceNotFound() {
+        UserProfile profile = profile();
+        given(userProfileRepository.findByIdAndUserId(PROFILE_ID, USER_ID)).willReturn(Optional.of(profile));
+        given(githubAnalysisRepository.findByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> diagnosisCommandService.createDiagnosis(
+                USER_ID,
+                new DiagnosisRequest(PROFILE_ID, GITHUB_ANALYSIS_ID)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verifyNoInteractions(llmClient, capabilityDiagnosisRepository);
+    }
+
+    @Test
+    void createDiagnosis_whenGithubAnalysisPayloadIsInvalid_throwsInternalServerError() {
+        UserProfile profile = profile();
+        GithubAnalysis analysis = GithubAnalysis.create(USER_ID, 200L, 1, "summary", "not-json");
+        JobRole jobRole = org.mockito.Mockito.mock(JobRole.class);
+        given(userProfileRepository.findByIdAndUserId(PROFILE_ID, USER_ID)).willReturn(Optional.of(profile));
+        given(githubAnalysisRepository.findByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(Optional.of(analysis));
+        given(jobRoleRepository.findById(JOB_ROLE_ID)).willReturn(Optional.of(jobRole));
+        given(userSkillRepository.findByUserIdAndSourceTypeOrderBySkillNameAsc(USER_ID, SkillSourceType.USER_INPUT))
+                .willReturn(List.of());
+        given(skillRequirementRepository.findByJobRoleIdOrderByImportanceDescSkillNameAsc(JOB_ROLE_ID))
+                .willReturn(List.of());
+
+        assertThatThrownBy(() -> diagnosisCommandService.createDiagnosis(
+                USER_ID,
+                new DiagnosisRequest(PROFILE_ID, GITHUB_ANALYSIS_ID)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        verifyNoInteractions(llmClient, capabilityDiagnosisRepository);
+    }
+
+    @Test
+    void createDiagnosis_whenLlmResponseIsInvalid_throwsLlmInvalidResponseAndDoesNotSave() {
+        primeValidInputs();
+        given(llmClient.complete(anyString())).willReturn("{}");
+
+        assertThatThrownBy(() -> diagnosisCommandService.createDiagnosis(
+                USER_ID,
+                new DiagnosisRequest(PROFILE_ID, GITHUB_ANALYSIS_ID)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+
+        verify(capabilityDiagnosisRepository, never()).save(any());
+    }
+
+    private void primeValidInputs() {
+        UserProfile profile = profile();
+        GithubAnalysis analysis = GithubAnalysis.create(USER_ID, 200L, 1, "summary",
+                githubAnalysisPayloadJson.toJson(githubPayload()));
+        JobRole jobRole = jobRole();
+        SkillRequirement springBoot = skillRequirement("Spring Boot", 5);
+        SkillRequirement redis = skillRequirement("Redis", 3);
+        ReflectionTestUtils.setField(analysis, "id", GITHUB_ANALYSIS_ID);
+        given(userProfileRepository.findByIdAndUserId(PROFILE_ID, USER_ID)).willReturn(Optional.of(profile));
+        given(githubAnalysisRepository.findByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(Optional.of(analysis));
+        given(jobRoleRepository.findById(JOB_ROLE_ID)).willReturn(Optional.of(jobRole));
+        given(userSkillRepository.findByUserIdAndSourceTypeOrderBySkillNameAsc(USER_ID, SkillSourceType.USER_INPUT))
+                .willReturn(List.of(UserSkill.create(USER_ID, "Spring Boot", ProficiencyLevel.WORKING, SkillSourceType.USER_INPUT)));
+        given(skillRequirementRepository.findByJobRoleIdOrderByImportanceDescSkillNameAsc(JOB_ROLE_ID))
+                .willReturn(List.of(springBoot, redis));
+    }
+
+    private UserProfile profile() {
+        UserProfile profile = UserProfile.create(
+                USER_ID,
+                JOB_ROLE_ID,
+                CurrentLevel.JUNIOR,
+                10,
+                LocalDate.of(2099, 12, 31),
+                "[]",
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(profile, "id", PROFILE_ID);
+        return profile;
+    }
+
+    private JobRole jobRole() {
+        JobRole jobRole = org.mockito.Mockito.mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn("BACKEND_DEVELOPER");
+        given(jobRole.getRoleName()).willReturn("백엔드 개발자");
+        given(jobRole.getDescription()).willReturn("Java와 Spring Boot 기반 백엔드 직무");
+        return jobRole;
+    }
+
+    private SkillRequirement skillRequirement(String skillName, int importance) {
+        SkillRequirement requirement = org.mockito.Mockito.mock(SkillRequirement.class);
+        given(requirement.getSkillName()).willReturn(skillName);
+        given(requirement.getCategory()).willReturn("BACKEND");
+        given(requirement.getImportance()).willReturn(importance);
+        return requirement;
+    }
+
+    private GithubAnalysisPayload githubPayload() {
+        return new GithubAnalysisPayload(
+                new GithubAnalysisPayload.StaticSignals(List.of(), 1, "WEEKLY", "CONSISTENT"),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                new GithubAnalysisPayload.FinalTechProfile(List.of("Spring Boot"), List.of("Backend"))
+        );
+    }
+
+    private CapabilityDiagnosis withIdAndCreatedAt(CapabilityDiagnosis diagnosis, Long diagnosisId) {
+        ReflectionTestUtils.setField(diagnosis, "id", diagnosisId);
+        ReflectionTestUtils.setField(diagnosis, "createdAt", Instant.parse("2026-04-29T01:00:00Z"));
+        return diagnosis;
+    }
+
+    private String validLlmResponse() {
+        return """
+                {
+                  "summary": "Redis 보완 필요",
+                  "missingSkills": [
+                    {
+                      "skillName": "Redis",
+                      "severity": "HIGH",
+                      "reason": "캐시 설계 경험이 부족함",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["Spring Boot"],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
@@ -1,0 +1,80 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DiagnosisResponseParserTest {
+
+    private final DiagnosisResponseParser parser = new DiagnosisResponseParser();
+
+    @Test
+    void parse_whenResponseMatchesSchema_returnsDiagnosisResult() {
+        DiagnosisResponseParser.DiagnosisResult result = parser.parse(validJson());
+
+        assertThat(result.summary()).isEqualTo("Redis 보완 필요");
+        assertThat(result.missingSkills()).hasSize(1);
+        assertThat(result.missingSkills().get(0).skillName()).isEqualTo("Redis");
+        assertThat(result.missingSkills().get(0).severity()).isEqualTo(DiagnosisSeverity.HIGH);
+        assertThat(result.strengths()).containsExactly("Spring Boot");
+        assertThat(result.recommendations()).containsExactly("Redis 캐시와 TTL 기반 설계를 먼저 학습");
+    }
+
+    @Test
+    void parse_whenSeverityIsInvalid_throwsLlmInvalidResponse() {
+        String json = validJson().replace("\"HIGH\"", "\"CRITICAL\"");
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    @Test
+    void parse_whenPriorityOrderIsInvalid_throwsLlmInvalidResponse() {
+        String json = validJson().replace("\"priorityOrder\": 1", "\"priorityOrder\": 0");
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    @Test
+    void parse_whenRequiredFieldIsMissing_throwsLlmInvalidResponse() {
+        String json = """
+                {
+                  "summary": "Redis 보완 필요",
+                  "missingSkills": [],
+                  "strengths": []
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    private String validJson() {
+        return """
+                {
+                  "summary": "Redis 보완 필요",
+                  "missingSkills": [
+                    {
+                      "skillName": "Redis",
+                      "severity": "HIGH",
+                      "reason": "캐시 설계 경험이 부족함",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["Spring Boot"],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -42,6 +42,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/diagnoses", "post")
+                .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses", "post")
                 .get("x-implementation-status")).isEqualTo("planned");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}", "get")
@@ -68,6 +70,10 @@ class OpenApiContractTest {
         Map<String, Object> dashboardGithubAnalysisProperties =
                 mapValue(dashboardGithubAnalysisSummary, "properties");
         assertThat(dashboardGithubAnalysisProperties).containsKeys("finalTechProfile", "userCorrectionCount");
+
+        assertThat(mapValue(schemas, "DiagnosisRequest").get("required"))
+                .asList()
+                .contains("profileId", "githubAnalysisId");
     }
 
     private Map<String, Object> loadOpenApiDocument() throws IOException {

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -381,7 +381,7 @@ v1 처리 기준
 
 필드 규칙
 - `profileId`: 필수, 현재 로그인 사용자 소유 프로필이어야 함
-- `githubAnalysisId`: 선택, 현재 로그인 사용자 소유 GitHub 분석 결과여야 함. 제공 시 진단 품질이 향상된다
+- `githubAnalysisId`: 필수, 현재 로그인 사용자 소유 GitHub 분석 결과여야 함
 
 응답 body
 ```json

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -215,7 +215,7 @@ paths:
         - Diagnoses
       summary: Run capability diagnosis
       operationId: createDiagnosis
-      x-implementation-status: planned
+      x-implementation-status: implemented
       requestBody:
         required: true
         content:
@@ -1053,13 +1053,13 @@ components:
       type: object
       required:
         - profileId
+        - githubAnalysisId
       properties:
         profileId:
           type: string
           example: '101'
         githubAnalysisId:
           type: string
-          nullable: true
           example: '401'
 
     MissingSkill:


### PR DESCRIPTION
## 연관 이슈

Closes #126

## 변경 요약

- `POST /api/diagnoses` 생성 API 추가
- 프로필/GitHub 분석 소유권 검증 및 진단 결과 version 저장 연결
- 진단 LLM 응답 schema 검증 추가
- OpenAPI에서 진단 생성 API를 implemented로 갱신

## 왜 필요한가

v1 필수 흐름에서 GitHub 분석 이후 로드맵 생성으로 넘어가려면 저장 가능한 역량 진단 결과가 필요합니다.

## 테스트

```text
cd backend
.\gradlew.bat test --tests *Diagnosis*
.\gradlew.bat prVerification
```