### PR TITLE
feat(roadmap): 로드맵 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapCommandController.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapCommandController.java
@@ -1,0 +1,38 @@
+package com.back.coach.domain.roadmap.controller;
+
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.service.RoadmapCommandService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/roadmaps", produces = MediaType.APPLICATION_JSON_VALUE)
+public class RoadmapCommandController {
+
+    private final RoadmapCommandService roadmapCommandService;
+
+    public RoadmapCommandController(RoadmapCommandService roadmapCommandService) {
+        this.roadmapCommandService = roadmapCommandService;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<RoadmapDetailResponse> createRoadmap(
+            Authentication authentication,
+            @Valid @RequestBody RoadmapRequest request
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+        return ApiResponse.success(roadmapCommandService.createRoadmap(
+                authenticatedUser.userId(),
+                request
+        ));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapPayload.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapPayload.java
@@ -1,0 +1,35 @@
+package com.back.coach.domain.roadmap.dto;
+
+import com.back.coach.global.code.MaterialType;
+import com.back.coach.global.code.RoadmapTaskType;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record RoadmapPayload(
+        List<Week> weeks
+) {
+
+    public record Week(
+            Integer weekNumber,
+            String topic,
+            String reason,
+            List<Task> tasks,
+            List<Material> materials,
+            BigDecimal estimatedHours
+    ) {
+    }
+
+    public record Task(
+            RoadmapTaskType type,
+            String title
+    ) {
+    }
+
+    public record Material(
+            MaterialType type,
+            String title,
+            String url
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapRequest.java
@@ -1,0 +1,17 @@
+package com.back.coach.domain.roadmap.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record RoadmapRequest(
+        @NotNull Long diagnosisId,
+        Long githubAnalysisId,
+        Long codingTestAnalysisId,
+        @Min(1) @Max(40) Integer weeklyStudyHours,
+        @Future LocalDate targetDate
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/LearningRoadmap.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/LearningRoadmap.java
@@ -44,4 +44,22 @@ public class LearningRoadmap extends BaseEntity {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    public static LearningRoadmap create(
+            Long userId,
+            Long diagnosisId,
+            Integer version,
+            Integer totalWeeks,
+            String summary,
+            String roadmapPayload
+    ) {
+        LearningRoadmap roadmap = new LearningRoadmap();
+        roadmap.userId = userId;
+        roadmap.diagnosisId = diagnosisId;
+        roadmap.version = version;
+        roadmap.totalWeeks = totalWeeks;
+        roadmap.summary = summary;
+        roadmap.roadmapPayload = roadmapPayload;
+        return roadmap;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/entity/RoadmapWeek.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/entity/RoadmapWeek.java
@@ -40,4 +40,24 @@ public class RoadmapWeek extends BaseEntity {
 
     @Column(name = "estimated_hours", nullable = false, precision = 4, scale = 1)
     private BigDecimal estimatedHours;
+
+    public static RoadmapWeek create(
+            Long roadmapId,
+            Integer weekNumber,
+            String topic,
+            String reasonText,
+            String tasksJson,
+            String materialsJson,
+            BigDecimal estimatedHours
+    ) {
+        RoadmapWeek roadmapWeek = new RoadmapWeek();
+        roadmapWeek.roadmapId = roadmapId;
+        roadmapWeek.weekNumber = weekNumber;
+        roadmapWeek.topic = topic;
+        roadmapWeek.reasonText = reasonText;
+        roadmapWeek.tasksJson = tasksJson;
+        roadmapWeek.materialsJson = materialsJson;
+        roadmapWeek.estimatedHours = estimatedHours;
+        return roadmapWeek;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
@@ -1,0 +1,182 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.result.service.ResultVersionService;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
+import com.back.coach.domain.roadmap.dto.RoadmapPayload;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+public class RoadmapCommandService {
+
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final JobRoleRepository jobRoleRepository;
+    private final LearningRoadmapRepository learningRoadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
+    private final ResultVersionService resultVersionService;
+    private final RoadmapPromptBuilder roadmapPromptBuilder;
+    private final RoadmapResponseParser roadmapResponseParser;
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public RoadmapCommandService(
+            CapabilityDiagnosisRepository capabilityDiagnosisRepository,
+            GithubAnalysisRepository githubAnalysisRepository,
+            UserProfileRepository userProfileRepository,
+            JobRoleRepository jobRoleRepository,
+            LearningRoadmapRepository learningRoadmapRepository,
+            RoadmapWeekRepository roadmapWeekRepository,
+            ResultVersionService resultVersionService,
+            RoadmapPromptBuilder roadmapPromptBuilder,
+            RoadmapResponseParser roadmapResponseParser,
+            LlmClient llmClient,
+            ObjectMapper objectMapper
+    ) {
+        this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
+        this.githubAnalysisRepository = githubAnalysisRepository;
+        this.userProfileRepository = userProfileRepository;
+        this.jobRoleRepository = jobRoleRepository;
+        this.learningRoadmapRepository = learningRoadmapRepository;
+        this.roadmapWeekRepository = roadmapWeekRepository;
+        this.resultVersionService = resultVersionService;
+        this.roadmapPromptBuilder = roadmapPromptBuilder;
+        this.roadmapResponseParser = roadmapResponseParser;
+        this.llmClient = llmClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public RoadmapDetailResponse createRoadmap(Long userId, RoadmapRequest request) {
+        CapabilityDiagnosis diagnosis = capabilityDiagnosisRepository.findByIdAndUserId(request.diagnosisId(), userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+        validateGithubAnalysisOwnership(userId, request.githubAnalysisId());
+        UserProfile profile = userProfileRepository.findByIdAndUserId(diagnosis.getProfileId(), userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+        JobRole jobRole = jobRoleRepository.findById(diagnosis.getJobRoleId())
+                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+        DiagnosisPayload diagnosisPayload = parseDiagnosisPayload(diagnosis);
+
+        String prompt = roadmapPromptBuilder.build(new RoadmapPromptBuilder.Input(
+                jobRole,
+                profile,
+                diagnosis,
+                diagnosisPayload,
+                request.weeklyStudyHours(),
+                request.targetDate()
+        ));
+        RoadmapResponseParser.RoadmapResult roadmapResult =
+                roadmapResponseParser.parse(llmClient.complete(prompt));
+        RoadmapPayload roadmapPayload = new RoadmapPayload(roadmapResult.weeks());
+
+        LearningRoadmap savedRoadmap = learningRoadmapRepository.save(LearningRoadmap.create(
+                userId,
+                diagnosis.getId(),
+                resultVersionService.nextLearningRoadmapVersion(userId),
+                roadmapResult.weeks().size(),
+                roadmapResult.summary(),
+                toJson(roadmapPayload)
+        ));
+        List<RoadmapWeek> savedWeeks = roadmapWeekRepository.saveAll(toRoadmapWeeks(
+                savedRoadmap.getId(),
+                roadmapResult.weeks()
+        ));
+
+        return RoadmapDetailResponse.from(
+                toSnapshot(savedRoadmap, savedWeeks),
+                objectMapper
+        );
+    }
+
+    private void validateGithubAnalysisOwnership(Long userId, Long githubAnalysisId) {
+        if (githubAnalysisId != null && !githubAnalysisRepository.existsByIdAndUserId(githubAnalysisId, userId)) {
+            throw new ServiceException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+
+    private DiagnosisPayload parseDiagnosisPayload(CapabilityDiagnosis diagnosis) {
+        try {
+            return objectMapper.readValue(diagnosis.getDiagnosisPayload(), DiagnosisPayload.class);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private List<RoadmapWeek> toRoadmapWeeks(Long roadmapId, List<RoadmapPayload.Week> weeks) {
+        return weeks.stream()
+                .map(week -> RoadmapWeek.create(
+                        roadmapId,
+                        week.weekNumber(),
+                        week.topic(),
+                        week.reason(),
+                        toJson(week.tasks()),
+                        toJson(week.materials()),
+                        week.estimatedHours()
+                ))
+                .toList();
+    }
+
+    private RoadmapDetailSnapshot toSnapshot(LearningRoadmap roadmap, List<RoadmapWeek> weeks) {
+        return new RoadmapDetailSnapshot(
+                roadmap.getId(),
+                roadmap.getVersion(),
+                roadmap.getTotalWeeks(),
+                roadmap.getSummary(),
+                createdAtOrNow(roadmap),
+                weeks.stream()
+                        .map(this::toWeekSnapshot)
+                        .toList()
+        );
+    }
+
+    private RoadmapDetailSnapshot.WeekSnapshot toWeekSnapshot(RoadmapWeek week) {
+        return new RoadmapDetailSnapshot.WeekSnapshot(
+                week.getId(),
+                week.getWeekNumber(),
+                week.getTopic(),
+                week.getReasonText(),
+                week.getTasksJson(),
+                week.getMaterialsJson(),
+                week.getEstimatedHours(),
+                ProgressStatus.TODO,
+                null,
+                null
+        );
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private Instant createdAtOrNow(LearningRoadmap roadmap) {
+        return roadmap.getCreatedAt() == null ? Instant.now() : roadmap.getCreatedAt();
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -1,0 +1,96 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.user.entity.UserProfile;
+
+import java.time.LocalDate;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoadmapPromptBuilder {
+
+    public String build(Input input) {
+        Integer weeklyStudyHours = input.weeklyStudyHours() == null
+                ? input.profile().getWeeklyStudyHours()
+                : input.weeklyStudyHours();
+        LocalDate targetDate = input.targetDate() == null
+                ? input.profile().getTargetDate()
+                : input.targetDate();
+
+        return """
+                You are a planner for an AI developer growth coaching service.
+                Generate a practical weekly learning roadmap from the user's saved capability diagnosis.
+
+                Rules:
+                - Return JSON only.
+                - The JSON must match this shape:
+                  {
+                    "summary": "short roadmap summary",
+                    "weeks": [
+                      {
+                        "weekNumber": 1,
+                        "topic": "topic",
+                        "reason": "why this week matters",
+                        "tasks": [{"type": "READ_DOCS", "title": "task title"}],
+                        "materials": [{"type": "DOCS", "title": "material title", "url": "https://example.com"}],
+                        "estimatedHours": 8.0
+                      }
+                    ]
+                  }
+                - weekNumber must start at 1 and increase by 1.
+                - tasks[].type must be one of READ_DOCS, BUILD_EXAMPLE, WRITE_NOTE, APPLY_PROJECT, REVIEW.
+                - materials[].type must be one of DOCS, ARTICLE, REPOSITORY, VIDEO, TEMPLATE.
+                - Do not include progress status.
+
+                User context:
+                - targetRole: %s
+                - currentLevel: %s
+                - weeklyStudyHours: %s
+                - targetDate: %s
+
+                Diagnosis:
+                - summary: %s
+                - missingSkills: %s
+                - strengths: %s
+                - recommendations: %s
+                """.formatted(
+                input.jobRole().getRoleCode(),
+                input.diagnosis().getCurrentLevel(),
+                valueOrUnknown(weeklyStudyHours),
+                valueOrUnknown(targetDate),
+                input.diagnosis().getSummary(),
+                missingSkills(input.diagnosisPayload()),
+                input.diagnosisPayload().strengths(),
+                input.diagnosisPayload().recommendations()
+        );
+    }
+
+    private String missingSkills(DiagnosisPayload diagnosisPayload) {
+        return diagnosisPayload.missingSkills().stream()
+                .map(skill -> "%s(%s, priority %d): %s".formatted(
+                        skill.skillName(),
+                        skill.severity(),
+                        skill.priorityOrder(),
+                        skill.reason()
+                ))
+                .collect(Collectors.joining("; "));
+    }
+
+    private String valueOrUnknown(Object value) {
+        return value == null ? "unknown" : String.valueOf(value);
+    }
+
+    public record Input(
+            JobRole jobRole,
+            UserProfile profile,
+            CapabilityDiagnosis diagnosis,
+            DiagnosisPayload diagnosisPayload,
+            Integer weeklyStudyHours,
+            LocalDate targetDate
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapResponseParser.java
@@ -1,0 +1,119 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.domain.roadmap.dto.RoadmapPayload;
+import com.back.coach.global.code.MaterialType;
+import com.back.coach.global.code.RoadmapTaskType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class RoadmapResponseParser {
+
+    private static final Logger log = LoggerFactory.getLogger(RoadmapResponseParser.class);
+    private static final String SCHEMA_PATH = "ai/schema/roadmap.schema.json";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonSchema schema = loadSchema();
+
+    public RoadmapResult parse(String llmJson) {
+        JsonNode root;
+        try {
+            root = mapper.readTree(llmJson);
+        } catch (IOException ex) {
+            log.warn("Roadmap 응답 JSON 파싱 실패: {}", ex.getMessage());
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        Set<ValidationMessage> errors = schema.validate(root);
+        if (!errors.isEmpty()) {
+            log.warn("Roadmap 응답 schema 위반: {}", errors);
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        List<RoadmapPayload.Week> weeks = mapWeeks(root.get("weeks"));
+        validateWeekSequence(weeks);
+
+        return new RoadmapResult(
+                root.get("summary").asText(),
+                weeks.stream()
+                        .sorted(Comparator.comparing(RoadmapPayload.Week::weekNumber))
+                        .toList()
+        );
+    }
+
+    private List<RoadmapPayload.Week> mapWeeks(JsonNode weeksNode) {
+        List<RoadmapPayload.Week> weeks = new ArrayList<>();
+        weeksNode.forEach(node -> weeks.add(new RoadmapPayload.Week(
+                node.get("weekNumber").asInt(),
+                node.get("topic").asText(),
+                node.get("reason").asText(),
+                mapList(node.get("tasks"), task -> new RoadmapPayload.Task(
+                        RoadmapTaskType.valueOf(task.get("type").asText()),
+                        task.get("title").asText()
+                )),
+                mapList(node.get("materials"), material -> new RoadmapPayload.Material(
+                        MaterialType.valueOf(material.get("type").asText()),
+                        material.get("title").asText(),
+                        material.hasNonNull("url") ? material.get("url").asText() : null
+                )),
+                node.get("estimatedHours").decimalValue()
+        )));
+        return weeks;
+    }
+
+    private void validateWeekSequence(List<RoadmapPayload.Week> weeks) {
+        Set<Integer> weekNumbers = new HashSet<>();
+        for (RoadmapPayload.Week week : weeks) {
+            if (!weekNumbers.add(week.weekNumber())) {
+                log.warn("Roadmap 응답 weekNumber 중복: {}", week.weekNumber());
+                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            }
+        }
+        List<Integer> sortedWeekNumbers = weekNumbers.stream().sorted().toList();
+        for (int i = 0; i < sortedWeekNumbers.size(); i++) {
+            if (sortedWeekNumbers.get(i) != i + 1) {
+                log.warn("Roadmap 응답 weekNumber 순서 위반: {}", sortedWeekNumbers);
+                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            }
+        }
+    }
+
+    private static <T> List<T> mapList(JsonNode array, java.util.function.Function<JsonNode, T> mapper) {
+        List<T> values = new ArrayList<>();
+        array.forEach(node -> values.add(mapper.apply(node)));
+        return values;
+    }
+
+    private static JsonSchema loadSchema() {
+        JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+        try (InputStream inputStream = new ClassPathResource(SCHEMA_PATH).getInputStream()) {
+            return factory.getSchema(inputStream);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Roadmap schema 로드 실패: " + SCHEMA_PATH, ex);
+        }
+    }
+
+    public record RoadmapResult(
+            String summary,
+            List<RoadmapPayload.Week> weeks
+    ) {
+    }
+}

--- a/backend/src/main/resources/ai/schema/roadmap.schema.json
+++ b/backend/src/main/resources/ai/schema/roadmap.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RoadmapResponse",
+  "type": "object",
+  "required": ["summary", "weeks"],
+  "additionalProperties": false,
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "weeks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["weekNumber", "topic", "reason", "tasks", "materials", "estimatedHours"],
+        "additionalProperties": false,
+        "properties": {
+          "weekNumber": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "topic": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "tasks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["type", "title"],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["READ_DOCS", "BUILD_EXAMPLE", "WRITE_NOTE", "APPLY_PROJECT", "REVIEW"]
+                },
+                "title": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "materials": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["type", "title"],
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["DOCS", "ARTICLE", "REPOSITORY", "VIDEO", "TEMPLATE"]
+                },
+                "title": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "estimatedHours": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapCommandControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapCommandControllerTest.java
@@ -1,0 +1,137 @@
+package com.back.coach.domain.roadmap.controller;
+
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.service.RoadmapCommandService;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.JwtTokenProvider;
+import com.back.coach.support.ApiTestBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RoadmapCommandControllerTest extends ApiTestBase {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RoadmapCommandService roadmapCommandService;
+
+    @Test
+    void createRoadmap_whenRequestIsValid_returnsRoadmapDetail() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-roadmap-1", "roadmap1@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        given(roadmapCommandService.createRoadmap(eq(user.getId()), any(RoadmapRequest.class)))
+                .willReturn(response());
+
+        mockMvc.perform(post("/api/roadmaps")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "diagnosisId", 20,
+                                "githubAnalysisId", 30,
+                                "weeklyStudyHours", 8
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roadmapId").value("40"))
+                .andExpect(jsonPath("$.data.version").value(2))
+                .andExpect(jsonPath("$.data.totalWeeks").value(2))
+                .andExpect(jsonPath("$.data.summary").value("Redis 중심 로드맵"))
+                .andExpect(jsonPath("$.data.weeks[0].roadmapWeekId").value("100"))
+                .andExpect(jsonPath("$.data.weeks[0].weekNumber").value(1))
+                .andExpect(jsonPath("$.data.weeks[0].topic").value("Redis 기초"))
+                .andExpect(jsonPath("$.data.weeks[0].progressStatus").value("TODO"))
+                .andExpect(jsonPath("$.meta").isMap());
+    }
+
+    @Test
+    void createRoadmap_withoutAuth_returnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/roadmaps")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"diagnosisId\":20}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createRoadmap_whenDiagnosisIdIsMissing_returnsBadRequest() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-roadmap-2", "roadmap2@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+
+        mockMvc.perform(post("/api/roadmaps")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createRoadmap_whenDiagnosisDoesNotExist_returnsNotFound() throws Exception {
+        User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-roadmap-3", "roadmap3@example.com"));
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        given(roadmapCommandService.createRoadmap(eq(user.getId()), any(RoadmapRequest.class)))
+                .willThrow(new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        mockMvc.perform(post("/api/roadmaps")
+                        .cookie(new Cookie("accessToken", accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"diagnosisId\":999}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+    }
+
+    private RoadmapDetailResponse response() {
+        return new RoadmapDetailResponse(
+                "40",
+                2,
+                2,
+                "Redis 중심 로드맵",
+                Instant.parse("2026-04-30T01:00:00Z"),
+                List.of(new RoadmapDetailResponse.WeekResponse(
+                        "100",
+                        1,
+                        "Redis 기초",
+                        "캐시 설계 역량을 먼저 보완해야 함",
+                        List.of(Map.of(
+                                "type", "READ_DOCS",
+                                "title", "Redis 공식 문서 읽기"
+                        )),
+                        List.of(Map.of(
+                                "type", "DOCS",
+                                "title", "Redis Documentation",
+                                "url", "https://redis.io/docs"
+                        )),
+                        new BigDecimal("8.0"),
+                        ProgressStatus.TODO,
+                        null,
+                        null
+                ))
+        );
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -1,0 +1,314 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.result.service.ResultVersionService;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapPayload;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapCommandServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long PROFILE_ID = 10L;
+    private static final Long DIAGNOSIS_ID = 20L;
+    private static final Long GITHUB_ANALYSIS_ID = 30L;
+    private static final Long JOB_ROLE_ID = 100L;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Mock
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Mock
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private JobRoleRepository jobRoleRepository;
+
+    @Mock
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Mock
+    private RoadmapWeekRepository roadmapWeekRepository;
+
+    @Mock
+    private ResultVersionService resultVersionService;
+
+    @Mock
+    private LlmClient llmClient;
+
+    private RoadmapCommandService roadmapCommandService;
+
+    @BeforeEach
+    void setUp() {
+        roadmapCommandService = new RoadmapCommandService(
+                capabilityDiagnosisRepository,
+                githubAnalysisRepository,
+                userProfileRepository,
+                jobRoleRepository,
+                learningRoadmapRepository,
+                roadmapWeekRepository,
+                resultVersionService,
+                new RoadmapPromptBuilder(),
+                new RoadmapResponseParser(),
+                llmClient,
+                objectMapper
+        );
+    }
+
+    @Test
+    void createRoadmap_whenInputsAreValid_savesVersionedRoadmapAndWeeks() throws Exception {
+        primeValidInputs();
+        given(githubAnalysisRepository.existsByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(true);
+        given(resultVersionService.nextLearningRoadmapVersion(USER_ID)).willReturn(2);
+        given(llmClient.complete(anyString())).willReturn(validLlmResponse());
+        given(learningRoadmapRepository.save(any(LearningRoadmap.class)))
+                .willAnswer(invocation -> withIdAndCreatedAt(invocation.getArgument(0), 40L));
+        given(roadmapWeekRepository.saveAll(any()))
+                .willAnswer(invocation -> withWeekIds(invocation.getArgument(0)));
+
+        RoadmapDetailResponse result = roadmapCommandService.createRoadmap(
+                USER_ID,
+                new RoadmapRequest(DIAGNOSIS_ID, GITHUB_ANALYSIS_ID, null, 8, LocalDate.of(2099, 12, 31))
+        );
+
+        assertThat(result.roadmapId()).isEqualTo("40");
+        assertThat(result.version()).isEqualTo(2);
+        assertThat(result.totalWeeks()).isEqualTo(2);
+        assertThat(result.summary()).isEqualTo("Redis 중심 로드맵");
+        assertThat(result.weeks()).hasSize(2);
+        assertThat(result.weeks().get(0).roadmapWeekId()).isEqualTo("100");
+        assertThat(result.weeks().get(0).progressStatus()).isEqualTo(ProgressStatus.TODO);
+        assertThat(result.weeks().get(0).progressNote()).isNull();
+
+        ArgumentCaptor<LearningRoadmap> roadmapCaptor = ArgumentCaptor.forClass(LearningRoadmap.class);
+        verify(learningRoadmapRepository).save(roadmapCaptor.capture());
+        LearningRoadmap savedRoadmap = roadmapCaptor.getValue();
+        assertThat(savedRoadmap.getUserId()).isEqualTo(USER_ID);
+        assertThat(savedRoadmap.getDiagnosisId()).isEqualTo(DIAGNOSIS_ID);
+        assertThat(savedRoadmap.getVersion()).isEqualTo(2);
+        assertThat(savedRoadmap.getTotalWeeks()).isEqualTo(2);
+        assertThat(savedRoadmap.getRoadmapPayload()).doesNotContain("progressStatus");
+
+        RoadmapPayload storedPayload = objectMapper.readValue(savedRoadmap.getRoadmapPayload(), RoadmapPayload.class);
+        assertThat(storedPayload.weeks()).hasSize(2);
+        assertThat(storedPayload.weeks().get(0).topic()).isEqualTo("Redis 기초");
+
+        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(promptCaptor.capture());
+        assertThat(promptCaptor.getValue()).contains("BACKEND_DEVELOPER", "Redis", "weeklyStudyHours: 8");
+    }
+
+    @Test
+    void createRoadmap_whenDiagnosisDoesNotBelongToUser_throwsResourceNotFound() {
+        given(capabilityDiagnosisRepository.findByIdAndUserId(DIAGNOSIS_ID, USER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roadmapCommandService.createRoadmap(
+                USER_ID,
+                new RoadmapRequest(DIAGNOSIS_ID, null, null, null, null)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verifyNoInteractions(llmClient, learningRoadmapRepository, roadmapWeekRepository);
+    }
+
+    @Test
+    void createRoadmap_whenGithubAnalysisDoesNotBelongToUser_throwsResourceNotFound() {
+        given(capabilityDiagnosisRepository.findByIdAndUserId(DIAGNOSIS_ID, USER_ID))
+                .willReturn(Optional.of(diagnosis()));
+        given(githubAnalysisRepository.existsByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(false);
+
+        assertThatThrownBy(() -> roadmapCommandService.createRoadmap(
+                USER_ID,
+                new RoadmapRequest(DIAGNOSIS_ID, GITHUB_ANALYSIS_ID, null, null, null)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+
+        verifyNoInteractions(llmClient, learningRoadmapRepository, roadmapWeekRepository);
+    }
+
+    @Test
+    void createRoadmap_whenLlmResponseIsInvalid_throwsLlmInvalidResponseAndDoesNotSave() {
+        primeValidInputs();
+        given(llmClient.complete(anyString())).willReturn("{}");
+
+        assertThatThrownBy(() -> roadmapCommandService.createRoadmap(
+                USER_ID,
+                new RoadmapRequest(DIAGNOSIS_ID, null, null, null, null)
+        ))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+
+        verify(learningRoadmapRepository, never()).save(any());
+        verify(roadmapWeekRepository, never()).saveAll(any());
+    }
+
+    private void primeValidInputs() {
+        JobRole jobRole = jobRole();
+        given(capabilityDiagnosisRepository.findByIdAndUserId(DIAGNOSIS_ID, USER_ID))
+                .willReturn(Optional.of(diagnosis()));
+        given(userProfileRepository.findByIdAndUserId(PROFILE_ID, USER_ID)).willReturn(Optional.of(profile()));
+        given(jobRoleRepository.findById(JOB_ROLE_ID)).willReturn(Optional.of(jobRole));
+    }
+
+    private CapabilityDiagnosis diagnosis() {
+        CapabilityDiagnosis diagnosis = CapabilityDiagnosis.create(
+                USER_ID,
+                PROFILE_ID,
+                GITHUB_ANALYSIS_ID,
+                JOB_ROLE_ID,
+                3,
+                CurrentLevel.JUNIOR,
+                "Redis 보완 필요",
+                diagnosisPayloadJson()
+        );
+        ReflectionTestUtils.setField(diagnosis, "id", DIAGNOSIS_ID);
+        return diagnosis;
+    }
+
+    private UserProfile profile() {
+        UserProfile profile = UserProfile.create(
+                USER_ID,
+                JOB_ROLE_ID,
+                CurrentLevel.JUNIOR,
+                10,
+                LocalDate.of(2099, 12, 31),
+                "[]",
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(profile, "id", PROFILE_ID);
+        return profile;
+    }
+
+    private JobRole jobRole() {
+        JobRole jobRole = org.mockito.Mockito.mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn("BACKEND_DEVELOPER");
+        return jobRole;
+    }
+
+    private String diagnosisPayloadJson() {
+        try {
+            return objectMapper.writeValueAsString(new DiagnosisPayload(
+                    List.of(new DiagnosisPayload.MissingSkill(
+                            "Redis",
+                            DiagnosisSeverity.HIGH,
+                            "캐시 설계 경험이 부족함",
+                            1
+                    )),
+                    List.of("Spring Boot"),
+                    List.of("Redis 캐시와 TTL 기반 설계를 먼저 학습")
+            ));
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private LearningRoadmap withIdAndCreatedAt(LearningRoadmap roadmap, Long roadmapId) {
+        ReflectionTestUtils.setField(roadmap, "id", roadmapId);
+        ReflectionTestUtils.setField(roadmap, "createdAt", Instant.parse("2026-04-30T01:00:00Z"));
+        return roadmap;
+    }
+
+    private List<RoadmapWeek> withWeekIds(List<RoadmapWeek> weeks) {
+        List<RoadmapWeek> savedWeeks = new ArrayList<>(weeks);
+        for (int i = 0; i < savedWeeks.size(); i++) {
+            ReflectionTestUtils.setField(savedWeeks.get(i), "id", 100L + i);
+        }
+        return savedWeeks;
+    }
+
+    private String validLlmResponse() {
+        return """
+                {
+                  "summary": "Redis 중심 로드맵",
+                  "weeks": [
+                    {
+                      "weekNumber": 1,
+                      "topic": "Redis 기초",
+                      "reason": "캐시 설계 역량을 먼저 보완해야 함",
+                      "tasks": [
+                        {
+                          "type": "READ_DOCS",
+                          "title": "Redis 공식 문서 읽기"
+                        }
+                      ],
+                      "materials": [
+                        {
+                          "type": "DOCS",
+                          "title": "Redis Documentation",
+                          "url": "https://redis.io/docs"
+                        }
+                      ],
+                      "estimatedHours": 8.0
+                    },
+                    {
+                      "weekNumber": 2,
+                      "topic": "Redis 적용",
+                      "reason": "실제 프로젝트 적용 경험이 필요함",
+                      "tasks": [
+                        {
+                          "type": "BUILD_EXAMPLE",
+                          "title": "캐시 예제 구현"
+                        }
+                      ],
+                      "materials": [],
+                      "estimatedHours": 6.0
+                    }
+                  ]
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapResponseParserTest.java
@@ -1,0 +1,109 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.global.code.MaterialType;
+import com.back.coach.global.code.RoadmapTaskType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoadmapResponseParserTest {
+
+    private final RoadmapResponseParser parser = new RoadmapResponseParser();
+
+    @Test
+    void parse_whenSchemaIsValid_returnsRoadmapResult() {
+        RoadmapResponseParser.RoadmapResult result = parser.parse(validResponse());
+
+        assertThat(result.summary()).isEqualTo("Redis 중심 로드맵");
+        assertThat(result.weeks()).hasSize(2);
+        assertThat(result.weeks().get(0).weekNumber()).isEqualTo(1);
+        assertThat(result.weeks().get(0).tasks().get(0).type()).isEqualTo(RoadmapTaskType.READ_DOCS);
+        assertThat(result.weeks().get(0).materials().get(0).type()).isEqualTo(MaterialType.DOCS);
+    }
+
+    @Test
+    void parse_whenTaskTypeIsInvalid_throwsLlmInvalidResponse() {
+        String invalidResponse = validResponse().replace("READ_DOCS", "UNKNOWN_TASK");
+
+        assertInvalidResponse(invalidResponse);
+    }
+
+    @Test
+    void parse_whenRequiredFieldIsMissing_throwsLlmInvalidResponse() {
+        String invalidResponse = """
+                {
+                  "summary": "잘못된 로드맵",
+                  "weeks": [
+                    {
+                      "weekNumber": 1,
+                      "topic": "Redis 기초",
+                      "tasks": [{"type": "READ_DOCS", "title": "Redis 문서 읽기"}],
+                      "materials": [],
+                      "estimatedHours": 8.0
+                    }
+                  ]
+                }
+                """;
+
+        assertInvalidResponse(invalidResponse);
+    }
+
+    @Test
+    void parse_whenWeekNumberIsDuplicated_throwsLlmInvalidResponse() {
+        String invalidResponse = validResponse().replace("\"weekNumber\": 2", "\"weekNumber\": 1");
+
+        assertInvalidResponse(invalidResponse);
+    }
+
+    private void assertInvalidResponse(String invalidResponse) {
+        assertThatThrownBy(() -> parser.parse(invalidResponse))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    private String validResponse() {
+        return """
+                {
+                  "summary": "Redis 중심 로드맵",
+                  "weeks": [
+                    {
+                      "weekNumber": 1,
+                      "topic": "Redis 기초",
+                      "reason": "캐시 설계 역량을 먼저 보완해야 함",
+                      "tasks": [
+                        {
+                          "type": "READ_DOCS",
+                          "title": "Redis 공식 문서 읽기"
+                        }
+                      ],
+                      "materials": [
+                        {
+                          "type": "DOCS",
+                          "title": "Redis Documentation",
+                          "url": "https://redis.io/docs"
+                        }
+                      ],
+                      "estimatedHours": 8.0
+                    },
+                    {
+                      "weekNumber": 2,
+                      "topic": "Redis 적용",
+                      "reason": "실제 프로젝트 적용 경험이 필요함",
+                      "tasks": [
+                        {
+                          "type": "BUILD_EXAMPLE",
+                          "title": "캐시 예제 구현"
+                        }
+                      ],
+                      "materials": [],
+                      "estimatedHours": 6.0
+                    }
+                  ]
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -38,6 +38,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/roadmaps/{roadmapId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/roadmaps", "post")
+                .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/dashboard", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
@@ -74,6 +76,9 @@ class OpenApiContractTest {
         assertThat(mapValue(schemas, "DiagnosisRequest").get("required"))
                 .asList()
                 .contains("profileId", "githubAnalysisId");
+        assertThat(mapValue(schemas, "RoadmapRequest").get("required"))
+                .asList()
+                .contains("diagnosisId");
     }
 
     private Map<String, Object> loadOpenApiDocument() throws IOException {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -267,7 +267,7 @@ paths:
         - Roadmaps
       summary: Generate learning roadmap
       operationId: createRoadmap
-      x-implementation-status: planned
+      x-implementation-status: implemented
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## 연관 이슈

Closes #128

## 변경 요약

- `POST /api/roadmaps` 생성 API 추가
- 진단 결과 및 선택 GitHub 분석 소유권 검증
- 로드맵 version row와 주차 원본 저장 연결
- 로드맵 LLM 응답 schema 검증 추가
- OpenAPI에서 로드맵 생성 API를 implemented로 갱신

## 왜 필요한가

진단 결과 이후 로드맵 생성 API가 없으면 v1 핵심 흐름이 `진단 -> 로드맵` 단계에서 끊깁니다. 생성 결과를 `learning_roadmaps + roadmap_weeks` 원본 구조에 저장해야 재조회와 진도 체크가 가능합니다.

## 테스트

```text
cd backend
.\gradlew.bat test --tests *Roadmap*
.\gradlew.bat test --tests *OpenApiContractTest
.\gradlew.bat prVerification
```