### PR TITLE
test(flow): v1 결과 흐름 통합 검증 추가

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
@@ -1,0 +1,306 @@
+package com.back.coach.domain.flow;
+
+import com.back.coach.domain.dashboard.dto.DashboardSnapshot;
+import com.back.coach.domain.dashboard.service.DashboardSnapshotService;
+import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.diagnosis.service.DiagnosisCommandService;
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.entity.GithubConnection;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.github.repository.GithubConnectionRepository;
+import com.back.coach.domain.github.service.GithubAnalysisPayloadJson;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
+import com.back.coach.domain.roadmap.service.RoadmapCommandService;
+import com.back.coach.domain.roadmap.service.RoadmapDetailSnapshotService;
+import com.back.coach.domain.roadmap.service.RoadmapProgressCommandService;
+import com.back.coach.domain.user.dto.ProfileSaveRequest;
+import com.back.coach.domain.user.dto.ProfileSaveResult;
+import com.back.coach.domain.user.dto.ProfileSkillRequest;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.domain.user.service.ProfileService;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.GithubAccessType;
+import com.back.coach.global.code.ProgressStatus;
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@IntegrationTest
+class V1ResultFlowIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserSkillRepository userSkillRepository;
+
+    @Autowired
+    private GithubConnectionRepository githubConnectionRepository;
+
+    @Autowired
+    private GithubAnalysisRepository githubAnalysisRepository;
+
+    @Autowired
+    private CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+
+    @Autowired
+    private LearningRoadmapRepository learningRoadmapRepository;
+
+    @Autowired
+    private RoadmapWeekRepository roadmapWeekRepository;
+
+    @Autowired
+    private ProfileService profileService;
+
+    @Autowired
+    private DiagnosisCommandService diagnosisCommandService;
+
+    @Autowired
+    private RoadmapCommandService roadmapCommandService;
+
+    @Autowired
+    private RoadmapDetailSnapshotService roadmapDetailSnapshotService;
+
+    @Autowired
+    private RoadmapProgressCommandService roadmapProgressCommandService;
+
+    @Autowired
+    private DashboardSnapshotService dashboardSnapshotService;
+
+    @Autowired
+    private GithubAnalysisPayloadJson githubAnalysisPayloadJson;
+
+    @MockitoBean
+    private LlmClient llmClient;
+
+    @Test
+    @DisplayName("v1 결과 흐름이 DB 원본 기준으로 진단, 로드맵, 진도, 대시보드까지 이어진다")
+    void v1ResultFlow_persistsVersionedResultsAndDashboardSnapshot() {
+        given(llmClient.complete(anyString())).willReturn(diagnosisResponse(), roadmapResponse());
+
+        User user = userRepository.save(User.signupFromOAuth(
+                AuthProvider.GITHUB,
+                unique("flow-gh"),
+                unique("flow") + "@example.com"
+        ));
+        User otherUser = userRepository.save(User.signupFromOAuth(
+                AuthProvider.GITHUB,
+                unique("other-gh"),
+                unique("other") + "@example.com"
+        ));
+        ProfileSaveResult profile = saveProfile(user.getId());
+        GithubAnalysis githubAnalysis = saveGithubAnalysisFixture(user.getId());
+
+        List<UserSkill> userInputSkills = userSkillRepository
+                .findByUserIdAndSourceTypeOrderBySkillNameAsc(user.getId(), SkillSourceType.USER_INPUT);
+        assertThat(userInputSkills)
+                .extracting(UserSkill::getSkillName)
+                .containsExactly("Spring Boot");
+
+        DiagnosisDetailResponse diagnosis = diagnosisCommandService.createDiagnosis(
+                user.getId(),
+                new DiagnosisRequest(profile.profileId(), githubAnalysis.getId())
+        );
+        CapabilityDiagnosis persistedDiagnosis = capabilityDiagnosisRepository
+                .findByIdAndUserId(Long.valueOf(diagnosis.diagnosisId()), user.getId())
+                .orElseThrow();
+        assertThat(persistedDiagnosis.getVersion()).isEqualTo(1);
+        assertThat(persistedDiagnosis.getGithubAnalysisId()).isEqualTo(githubAnalysis.getId());
+        assertThat(diagnosis.summary()).isEqualTo("Redis 보완 필요");
+
+        RoadmapDetailResponse roadmap = roadmapCommandService.createRoadmap(
+                user.getId(),
+                new RoadmapRequest(Long.valueOf(diagnosis.diagnosisId()), githubAnalysis.getId(), null, 8, null)
+        );
+        LearningRoadmap persistedRoadmap = learningRoadmapRepository
+                .findByIdAndUserId(Long.valueOf(roadmap.roadmapId()), user.getId())
+                .orElseThrow();
+        List<RoadmapWeek> persistedWeeks = roadmapWeekRepository
+                .findByRoadmapIdOrderByWeekNumberAsc(persistedRoadmap.getId());
+        assertThat(persistedRoadmap.getVersion()).isEqualTo(1);
+        assertThat(persistedRoadmap.getDiagnosisId()).isEqualTo(persistedDiagnosis.getId());
+        assertThat(persistedRoadmap.getRoadmapPayload()).doesNotContain("progressStatus");
+        assertThat(persistedWeeks).hasSize(2);
+        assertThat(roadmap.weeks())
+                .extracting(RoadmapDetailResponse.WeekResponse::progressStatus)
+                .containsExactly(ProgressStatus.TODO, ProgressStatus.TODO);
+
+        roadmapProgressCommandService.appendProgress(
+                user.getId(),
+                Long.valueOf(roadmap.roadmapId()),
+                Long.valueOf(roadmap.weeks().get(1).roadmapWeekId()),
+                ProgressStatus.DONE,
+                "Redis 캐시 예제 완료"
+        );
+
+        RoadmapDetailResponse updatedRoadmap = RoadmapDetailResponse.from(
+                roadmapDetailSnapshotService.findSnapshot(user.getId(), Long.valueOf(roadmap.roadmapId())),
+                new com.fasterxml.jackson.databind.ObjectMapper().findAndRegisterModules()
+        );
+        assertThat(updatedRoadmap.weeks())
+                .extracting(RoadmapDetailResponse.WeekResponse::progressStatus)
+                .containsExactly(ProgressStatus.TODO, ProgressStatus.DONE);
+
+        DashboardSnapshot dashboard = dashboardSnapshotService.findSnapshot(user.getId());
+        assertThat(dashboard.profile().profileId()).isEqualTo(profile.profileId());
+        assertThat(dashboard.githubAnalysis().githubAnalysisId()).isEqualTo(githubAnalysis.getId());
+        assertThat(dashboard.diagnosis().diagnosisId()).isEqualTo(persistedDiagnosis.getId());
+        assertThat(dashboard.roadmap().roadmapId()).isEqualTo(persistedRoadmap.getId());
+        assertThat(dashboard.roadmap().progress())
+                .isEqualTo(new DashboardSnapshot.ProgressSummary(2, 1, 0, 1, 0));
+
+        DashboardSnapshot otherDashboard = dashboardSnapshotService.findSnapshot(otherUser.getId());
+        assertThat(otherDashboard.profile()).isNull();
+        assertThat(otherDashboard.githubAnalysis()).isNull();
+        assertThat(otherDashboard.diagnosis()).isNull();
+        assertThat(otherDashboard.roadmap()).isNull();
+        verify(llmClient, times(2)).complete(anyString());
+    }
+
+    private ProfileSaveResult saveProfile(Long userId) {
+        return profileService.saveProfile(userId, new ProfileSaveRequest(
+                "BACKEND_DEVELOPER",
+                CurrentLevel.JUNIOR,
+                List.of(new ProfileSkillRequest("Spring Boot", ProficiencyLevel.WORKING)),
+                List.of("Backend"),
+                10,
+                LocalDate.of(2099, 12, 31),
+                null,
+                null
+        ));
+    }
+
+    private GithubAnalysis saveGithubAnalysisFixture(Long userId) {
+        GithubConnection connection = githubConnectionRepository.save(GithubConnection.connect(
+                userId,
+                unique("ghu"),
+                unique("login"),
+                GithubAccessType.OAUTH,
+                "ghp_test_token"
+        ));
+        return githubAnalysisRepository.save(GithubAnalysis.create(
+                userId,
+                connection.getId(),
+                1,
+                "Spring Boot 중심 GitHub 분석",
+                githubAnalysisPayloadJson.toJson(githubAnalysisPayload())
+        ));
+    }
+
+    private GithubAnalysisPayload githubAnalysisPayload() {
+        return new GithubAnalysisPayload(
+                new GithubAnalysisPayload.StaticSignals(
+                        List.of(new GithubAnalysisPayload.PrimaryLanguage("Java", 1.0)),
+                        1,
+                        "WEEKLY",
+                        "CONSISTENT"
+                ),
+                List.of(new GithubAnalysisPayload.RepoSummary(
+                        "1",
+                        "user/backend",
+                        "Spring Boot API 구현 경험",
+                        List.of("REST API", "JPA")
+                )),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                new GithubAnalysisPayload.FinalTechProfile(
+                        List.of("Spring Boot"),
+                        List.of("Backend")
+                )
+        );
+    }
+
+    private String diagnosisResponse() {
+        return """
+                {
+                  "summary": "Redis 보완 필요",
+                  "missingSkills": [
+                    {
+                      "skillName": "Redis",
+                      "severity": "HIGH",
+                      "reason": "캐시 설계 경험이 부족함",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["Spring Boot"],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
+                }
+                """;
+    }
+
+    private String roadmapResponse() {
+        return """
+                {
+                  "summary": "Redis 중심 로드맵",
+                  "weeks": [
+                    {
+                      "weekNumber": 1,
+                      "topic": "Redis 기초",
+                      "reason": "캐시 설계 역량을 먼저 보완해야 함",
+                      "tasks": [
+                        {
+                          "type": "READ_DOCS",
+                          "title": "Redis 공식 문서 읽기"
+                        }
+                      ],
+                      "materials": [
+                        {
+                          "type": "DOCS",
+                          "title": "Redis Documentation",
+                          "url": "https://redis.io/docs"
+                        }
+                      ],
+                      "estimatedHours": 8.0
+                    },
+                    {
+                      "weekNumber": 2,
+                      "topic": "Redis 적용",
+                      "reason": "실제 프로젝트 적용 경험이 필요함",
+                      "tasks": [
+                        {
+                          "type": "BUILD_EXAMPLE",
+                          "title": "캐시 예제 구현"
+                        }
+                      ],
+                      "materials": [],
+                      "estimatedHours": 6.0
+                    }
+                  ]
+                }
+                """;
+    }
+
+    private String unique(String prefix) {
+        return prefix + "-" + UUID.randomUUID();
+    }
+}


### PR DESCRIPTION
## 연관 이슈

Closes #130

## 변경 요약

- v1 결과 흐름 통합 테스트 추가
- `프로필 저장 -> GitHub 분석 fixture -> 진단 생성 -> 로드맵 생성 -> 진도 저장 -> 대시보드 최신 결과` 저장 흐름 검증
- LLM 호출은 mock으로 대체하고 DB 저장/조회 경계만 검증
- GitHub fetcher/connection 영역은 제외

## 왜 필요한가

진단 생성과 로드맵 생성이 각각 통과해도, 실제 v1 흐름에서 저장 결과가 대시보드와 진도 체크까지 이어지는지는 별도 검증이 필요합니다. B 담당 핵심인 결과 이력, 원본 저장 구조, 최신 snapshot 기준을 한 번에 확인합니다.

## 테스트

```text
cd backend
.\gradlew.bat integrationTest --tests '*V1ResultFlowIntegrationTest'
.\gradlew.bat prVerification
```

둘 다 통과했습니다.