### PR TITLE
feat(llm): Grepp AI Gateway chat completions 연결

### DIFF
--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -13,16 +13,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
-/**
- * Team AI Gateway client boundary.
- *
- * <p>Minimum HTTP contract:
- * <ul>
- *   <li>POST /v1/completions</li>
- *   <li>request: { "model": "...", "prompt": "..." }</li>
- *   <li>response: { "text": "..." }</li>
- * </ul>
- */
+// Grepp AI Gateway — OpenAI-compatible chat completions endpoint.
+// POST {base-url}/v1/chat/completions
+// request:  { "model": "...", "messages": [{"role": "user", "content": "..."}] }
+// response: { "choices": [{ "message": { "content": "..." } }] }
 @Component
 public class AiGatewayLlmClient implements LlmClient {
 
@@ -50,12 +44,15 @@ public class AiGatewayLlmClient implements LlmClient {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "prompt is empty");
         }
         try {
-            CompletionResponse response = restClient.post()
-                    .uri("/v1/completions")
+            ChatCompletionResponse response = restClient.post()
+                    .uri("/v1/chat/completions")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .headers(headers -> setAuthorization(headers, properties.apiKey()))
-                    .body(new CompletionRequest(properties.model(), prompt))
+                    .body(new ChatCompletionRequest(
+                            properties.model(),
+                            java.util.List.of(new Message("user", prompt))
+                    ))
                     .retrieve()
                     .onStatus(status -> status.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
                             (request, responseEntity) -> {
@@ -69,12 +66,16 @@ public class AiGatewayLlmClient implements LlmClient {
                             (request, responseEntity) -> {
                                 throw new ServiceException(ErrorCode.ANALYSIS_FAILED);
                             })
-                    .body(CompletionResponse.class);
+                    .body(ChatCompletionResponse.class);
 
-            if (response == null || response.text() == null || response.text().isBlank()) {
+            if (response == null || response.choices() == null || response.choices().isEmpty()) {
                 throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
             }
-            return response.text();
+            String content = response.choices().get(0).message().content();
+            if (content == null || content.isBlank()) {
+                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            }
+            return content;
         } catch (ServiceException e) {
             throw e;
         } catch (RuntimeException e) {
@@ -92,25 +93,19 @@ public class AiGatewayLlmClient implements LlmClient {
     }
 
     private ErrorCode classify(RuntimeException e) {
-        if (e instanceof ResourceAccessException) {
-            return ErrorCode.LLM_TIMEOUT;
-        }
+        if (e instanceof ResourceAccessException) return ErrorCode.LLM_TIMEOUT;
         String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
-        if (msg.contains("timeout") || msg.contains("timed out")) {
-            return ErrorCode.LLM_TIMEOUT;
-        }
-        if (msg.contains("rate") && msg.contains("limit")) {
-            return ErrorCode.LLM_RATE_LIMITED;
-        }
-        if (msg.contains("invalid") || msg.contains("schema") || msg.contains("parse")) {
-            return ErrorCode.LLM_INVALID_RESPONSE;
-        }
+        if (msg.contains("timeout") || msg.contains("timed out")) return ErrorCode.LLM_TIMEOUT;
+        if (msg.contains("rate") && msg.contains("limit")) return ErrorCode.LLM_RATE_LIMITED;
+        if (msg.contains("invalid") || msg.contains("schema") || msg.contains("parse")) return ErrorCode.LLM_INVALID_RESPONSE;
         return ErrorCode.ANALYSIS_FAILED;
     }
 
-    private record CompletionRequest(String model, String prompt) {
-    }
+    private record Message(String role, String content) {}
 
-    private record CompletionResponse(String text) {
-    }
+    private record ChatCompletionRequest(String model, java.util.List<Message> messages) {}
+
+    private record ChatCompletionResponse(java.util.List<Choice> choices) {}
+
+    private record Choice(Message message) {}
 }

--- a/backend/src/main/resources/application-secret.yml.example
+++ b/backend/src/main/resources/application-secret.yml.example
@@ -10,7 +10,12 @@ spring:
           github:
             clientId: PASTE_GITHUB_CLIENT_ID_HERE
             clientSecret: PASTE_GITHUB_CLIENT_SECRET_HERE
-
+ai:
+  gateway:
+    api-key: 그렙-스레드-키
+    base-url: https://aigw.alpha.grepp.co
+    model: glm-4.5-flash
+    
 # (선택) JWT 비밀키를 로컬에서 고정하고 싶을 때만:
 # security:
 #   jwt:

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -50,27 +50,27 @@ class AiGatewayLlmClientTest {
 
     @Test
     void complete_callsGatewayAndReturnsText() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"ok\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}")));
 
         String result = client.complete("hello");
 
         assertThat(result).isEqualTo("ok");
-        wireMock.verify(postRequestedFor(urlEqualTo("/v1/completions"))
+        wireMock.verify(postRequestedFor(urlEqualTo("/v1/chat/completions"))
                 .withHeader("Authorization", com.github.tomakehurst.wiremock.client.WireMock.equalTo("Bearer dummy-key"))
                 .withRequestBody(equalToJson("""
                         {
                           "model": "test-model",
-                          "prompt": "hello"
+                          "messages": [{"role": "user", "content": "hello"}]
                         }
                         """)));
     }
 
     @Test
     void rateLimitedResponse_throwsRateLimitedError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse().withStatus(429)));
 
         assertThatThrownBy(() -> client.complete("hello"))
@@ -81,7 +81,7 @@ class AiGatewayLlmClientTest {
 
     @Test
     void gatewayTimeoutResponse_throwsTimeoutError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse().withStatus(504)));
 
         assertThatThrownBy(() -> client.complete("hello"))
@@ -92,10 +92,10 @@ class AiGatewayLlmClientTest {
 
     @Test
     void blankTextResponse_throwsInvalidResponseError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"\"}}]}")));
 
         assertThatThrownBy(() -> client.complete("hello"))
                 .isInstanceOf(ServiceException.class)


### PR DESCRIPTION
## 연관 이슈

Closes #135

---

## 변경 요약

`AiGatewayLlmClient`가 레거시 `/v1/completions` 형식을 사용하고 있어 Grepp AI Gateway(OpenAI 호환)와 연결이 불가능한 상태였습니다.

**변경 내용**

- 엔드포인트: `/v1/completions` → `/v1/chat/completions`
- 요청 형식: `{ model, prompt }` → `{ model, messages: [{role: user, content}] }`
- 응답 파싱: `response.text()` → `choices[0].message.content`

**`application-secret.yml`에 추가 필요 (로컬, 커밋 금지)**

```yaml
ai:
  gateway:
    api-key: <Grepp AI Gateway API Key>
    base-url: https://aigw.alpha.grepp.co   # /v1 붙이지 말 것 — 클라이언트가 /v1/chat/completions 직접 붙임
    model: glm-4.5-flash
```

---

## 테스트

```bash
./gradlew test
```

- [x] `AiGatewayLlmClientTest` — WireMock 기반 chat completions 형식 검증