### PR TITLE
Feature: openapi.yml 갱신 및 AI Gateway 포맷 교체

### DIFF
--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -13,16 +13,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
-/**
- * Team AI Gateway client boundary.
- *
- * <p>Minimum HTTP contract:
- * <ul>
- *   <li>POST /v1/completions</li>
- *   <li>request: { "model": "...", "prompt": "..." }</li>
- *   <li>response: { "text": "..." }</li>
- * </ul>
- */
+// Grepp AI Gateway — OpenAI-compatible chat completions endpoint.
+// POST {base-url}/v1/chat/completions
+// request:  { "model": "...", "messages": [{"role": "user", "content": "..."}] }
+// response: { "choices": [{ "message": { "content": "..." } }] }
 @Component
 public class AiGatewayLlmClient implements LlmClient {
 
@@ -50,12 +44,15 @@ public class AiGatewayLlmClient implements LlmClient {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "prompt is empty");
         }
         try {
-            CompletionResponse response = restClient.post()
-                    .uri("/v1/completions")
+            ChatCompletionResponse response = restClient.post()
+                    .uri("/v1/chat/completions")
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .headers(headers -> setAuthorization(headers, properties.apiKey()))
-                    .body(new CompletionRequest(properties.model(), prompt))
+                    .body(new ChatCompletionRequest(
+                            properties.model(),
+                            java.util.List.of(new Message("user", prompt))
+                    ))
                     .retrieve()
                     .onStatus(status -> status.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
                             (request, responseEntity) -> {
@@ -69,12 +66,16 @@ public class AiGatewayLlmClient implements LlmClient {
                             (request, responseEntity) -> {
                                 throw new ServiceException(ErrorCode.ANALYSIS_FAILED);
                             })
-                    .body(CompletionResponse.class);
+                    .body(ChatCompletionResponse.class);
 
-            if (response == null || response.text() == null || response.text().isBlank()) {
+            if (response == null || response.choices() == null || response.choices().isEmpty()) {
                 throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
             }
-            return response.text();
+            String content = response.choices().get(0).message().content();
+            if (content == null || content.isBlank()) {
+                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            }
+            return content;
         } catch (ServiceException e) {
             throw e;
         } catch (RuntimeException e) {
@@ -92,25 +93,19 @@ public class AiGatewayLlmClient implements LlmClient {
     }
 
     private ErrorCode classify(RuntimeException e) {
-        if (e instanceof ResourceAccessException) {
-            return ErrorCode.LLM_TIMEOUT;
-        }
+        if (e instanceof ResourceAccessException) return ErrorCode.LLM_TIMEOUT;
         String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
-        if (msg.contains("timeout") || msg.contains("timed out")) {
-            return ErrorCode.LLM_TIMEOUT;
-        }
-        if (msg.contains("rate") && msg.contains("limit")) {
-            return ErrorCode.LLM_RATE_LIMITED;
-        }
-        if (msg.contains("invalid") || msg.contains("schema") || msg.contains("parse")) {
-            return ErrorCode.LLM_INVALID_RESPONSE;
-        }
+        if (msg.contains("timeout") || msg.contains("timed out")) return ErrorCode.LLM_TIMEOUT;
+        if (msg.contains("rate") && msg.contains("limit")) return ErrorCode.LLM_RATE_LIMITED;
+        if (msg.contains("invalid") || msg.contains("schema") || msg.contains("parse")) return ErrorCode.LLM_INVALID_RESPONSE;
         return ErrorCode.ANALYSIS_FAILED;
     }
 
-    private record CompletionRequest(String model, String prompt) {
-    }
+    private record Message(String role, String content) {}
 
-    private record CompletionResponse(String text) {
-    }
+    private record ChatCompletionRequest(String model, java.util.List<Message> messages) {}
+
+    private record ChatCompletionResponse(java.util.List<Choice> choices) {}
+
+    private record Choice(Message message) {}
 }

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -50,27 +50,27 @@ class AiGatewayLlmClientTest {
 
     @Test
     void complete_callsGatewayAndReturnsText() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"ok\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}")));
 
         String result = client.complete("hello");
 
         assertThat(result).isEqualTo("ok");
-        wireMock.verify(postRequestedFor(urlEqualTo("/v1/completions"))
+        wireMock.verify(postRequestedFor(urlEqualTo("/v1/chat/completions"))
                 .withHeader("Authorization", com.github.tomakehurst.wiremock.client.WireMock.equalTo("Bearer dummy-key"))
                 .withRequestBody(equalToJson("""
                         {
                           "model": "test-model",
-                          "prompt": "hello"
+                          "messages": [{"role": "user", "content": "hello"}]
                         }
                         """)));
     }
 
     @Test
     void rateLimitedResponse_throwsRateLimitedError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse().withStatus(429)));
 
         assertThatThrownBy(() -> client.complete("hello"))
@@ -81,7 +81,7 @@ class AiGatewayLlmClientTest {
 
     @Test
     void gatewayTimeoutResponse_throwsTimeoutError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse().withStatus(504)));
 
         assertThatThrownBy(() -> client.complete("hello"))
@@ -92,10 +92,10 @@ class AiGatewayLlmClientTest {
 
     @Test
     void blankTextResponse_throwsInvalidResponseError() {
-        wireMock.stubFor(post("/v1/completions")
+        wireMock.stubFor(post("/v1/chat/completions")
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"\"}}]}")));
 
         assertThatThrownBy(() -> client.complete("hello"))
                 .isInstanceOf(ServiceException.class)

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -47,7 +47,7 @@ class OpenApiContractTest {
         assertThat(operation(paths, "/api/diagnoses", "post")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses", "post")
-                .get("x-implementation-status")).isEqualTo("planned");
+                .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/github-analyses/{githubAnalysisId}/corrections", "patch")

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -81,7 +81,7 @@ paths:
         - GitHub Connections
       summary: Register GitHub OAuth connection
       operationId: createGithubConnection
-      x-implementation-status: planned
+      x-implementation-status: implemented
       requestBody:
         required: true
         content:
@@ -106,7 +106,7 @@ paths:
         - GitHub Connections
       summary: Get connected GitHub repositories
       operationId: getGithubRepositories
-      x-implementation-status: planned
+      x-implementation-status: implemented
       parameters:
         - name: githubConnectionId
           in: query
@@ -134,7 +134,7 @@ paths:
         - GitHub Analyses
       summary: Run GitHub analysis
       operationId: createGithubAnalysis
-      x-implementation-status: planned
+      x-implementation-status: implemented
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## 연관 이슈

Closes #134

---

## 변경 요약

### 1. OpenAPI 구현 상태 갱신 (`docs/openapi.yml`)

Slice 1~3에서 이미 구현됐지만 `planned`로 남아 있던 엔드포인트 4개를 `implemented`로 갱신합니다.

| 엔드포인트 | 구현 슬라이스 | 변경 |
|-----------|-------------|------|
| `POST /api/github/connections` | Slice 1 (OAuth 연결) | `planned` → `implemented` |
| `GET /api/github/repositories` | Slice 3 (HTTP fetcher) | `planned` → `implemented` |
| `POST /api/github-analyses` | Slice 2 (분석 실행) | `planned` → `implemented` |

### 2. AI Gateway 포맷 교체 (`AiGatewayLlmClient`)

Grepp AI Gateway가 OpenAI 호환 chat completions만 지원함에 따라 클라이언트 요청/응답 형식 교체.

- 엔드포인트: `/v1/completions` → `/v1/chat/completions`
- 요청 바디: `{prompt, text}` → `{model, messages: [{role, content}]}`
- 응답 파싱: `{text}` → `{choices[0].message.content}`
- WireMock 테스트 stub/verify도 새 형식으로 업데이트

### 3. OpenApiContractTest 픽스

`POST /api/github-analyses` 상태가 `implemented`로 갱신됨에 따라 테스트 기댓값도 동기화.

---

## 테스트

- `./gradlew test` — `AiGatewayLlmClientTest`, `OpenApiContractTest` 포함 전체 통과
- Swagger UI(`/swagger-ui.html`)에서 네 엔드포인트 상태 확인