### PR TITLE
feat(frontend): v1 생성 흐름 연결

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -459,6 +459,86 @@ a {
   color: #a32020;
 }
 
+.roadmap-create-page,
+.roadmap-create-form {
+  display: grid;
+  gap: 24px;
+}
+
+.roadmap-create-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.roadmap-create-heading h2 {
+  margin: 0;
+}
+
+.roadmap-create-heading p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.roadmap-create-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.roadmap-create-fields label {
+  display: grid;
+  gap: 6px;
+}
+
+.roadmap-create-fields label span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.roadmap-create-fields input {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--foreground);
+  padding: 0 10px;
+}
+
+.roadmap-create-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.roadmap-create-error {
+  margin: 0;
+  color: #a32020;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.roadmap-create-actions button {
+  min-height: 40px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  padding: 0 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.roadmap-create-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .dashboard-summary-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -1243,6 +1323,11 @@ a {
   }
 
   .roadmap-progress-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .roadmap-create-actions {
     align-items: stretch;
     flex-direction: column;
   }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -140,12 +140,18 @@ a {
   color: var(--foreground);
   font-size: 14px;
   font-weight: 700;
+  cursor: pointer;
 }
 
 .action-link.primary {
   border-color: var(--accent);
   background: var(--accent);
   color: #ffffff;
+}
+
+.action-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .content-grid {
@@ -1122,6 +1128,13 @@ a {
 
 .github-analysis-state-panel[data-tone="danger"] p {
   color: #a32020;
+}
+
+.github-analysis-action-error {
+  margin: 0;
+  color: #a32020;
+  font-size: 13px;
+  line-height: 1.45;
 }
 
 .github-correction-form {

--- a/frontend/src/app/roadmaps/new/page.tsx
+++ b/frontend/src/app/roadmaps/new/page.tsx
@@ -1,6 +1,5 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { RoadmapCreateView } from "@/features/roadmap/roadmap-create-view";
 
 export default function RoadmapCreatePage() {
-  return <ScreenShell screen={screens.roadmapCreate} />;
+  return <RoadmapCreateView />;
 }

--- a/frontend/src/features/diagnosis/api.ts
+++ b/frontend/src/features/diagnosis/api.ts
@@ -1,5 +1,12 @@
 import { apiClient } from "@/lib/api";
-import type { Diagnosis } from "@/features/diagnosis/types";
+import type {
+  Diagnosis,
+  DiagnosisRequest
+} from "@/features/diagnosis/types";
+
+export function createDiagnosis(payload: DiagnosisRequest) {
+  return apiClient.post<Diagnosis>("/api/diagnoses", payload);
+}
 
 export function getDiagnosis(diagnosisId: string) {
   return apiClient.get<Diagnosis>(`/api/diagnoses/${diagnosisId}`);

--- a/frontend/src/features/diagnosis/types.ts
+++ b/frontend/src/features/diagnosis/types.ts
@@ -27,3 +27,8 @@ export type Diagnosis = {
   targetRole: string;
   version: number;
 };
+
+export type DiagnosisRequest = {
+  githubAnalysisId: string;
+  profileId: string;
+};

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
+import { createDiagnosis } from "@/features/diagnosis/api";
 import {
   getGithubAnalysis,
   saveGithubAnalysisCorrections
@@ -33,17 +35,21 @@ type GithubAnalysisState =
       status: "success";
       analysis: GithubAnalysis;
       diagnosisId: string | null;
+      profileId: string | null;
     };
 
 export function GithubAnalysisView({
   initialGithubAnalysisId
 }: GithubAnalysisViewProps) {
+  const router = useRouter();
   const [state, setState] = useState<GithubAnalysisState>({
     status: "loading"
   });
   const [isSaving, setIsSaving] = useState(false);
+  const [isCreatingDiagnosis, setIsCreatingDiagnosis] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [diagnosisError, setDiagnosisError] = useState<string | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -77,6 +83,7 @@ export function GithubAnalysisView({
           setState({
             analysis,
             diagnosisId: dashboard?.diagnosis?.diagnosisId ?? null,
+            profileId: dashboard?.profile?.profileId ?? null,
             status: "success"
           });
         }
@@ -154,6 +161,29 @@ export function GithubAnalysisView({
     }
   }
 
+  async function handleDiagnosisCreate() {
+    if (state.status !== "success" || !state.profileId) {
+      setDiagnosisError("진단 생성 전에 프로필을 먼저 저장해 주세요.");
+      return;
+    }
+
+    setIsCreatingDiagnosis(true);
+    setDiagnosisError(null);
+
+    try {
+      const diagnosis = await createDiagnosis({
+        githubAnalysisId: state.analysis.githubAnalysisId,
+        profileId: state.profileId
+      });
+
+      router.push(`/diagnoses/${diagnosis.diagnosisId}`);
+    } catch (error) {
+      setDiagnosisError(getDiagnosisErrorMessage(error));
+    } finally {
+      setIsCreatingDiagnosis(false);
+    }
+  }
+
   if (state.status === "loading") {
     return (
       <StatePanel
@@ -182,7 +212,7 @@ export function GithubAnalysisView({
     );
   }
 
-  const { analysis, diagnosisId } = state;
+  const { analysis, diagnosisId, profileId } = state;
 
   return (
     <section className="github-analysis-page" aria-labelledby="analysis-title">
@@ -200,11 +230,23 @@ export function GithubAnalysisView({
             >
               진단 결과 보기
             </Link>
-          ) : null}
+          ) : (
+            <button
+              className="action-link primary"
+              disabled={isCreatingDiagnosis || !profileId}
+              onClick={handleDiagnosisCreate}
+              type="button"
+            >
+              {isCreatingDiagnosis ? "진단 생성 중" : "진단 생성"}
+            </button>
+          )}
           <Link className="action-link" href="/github">
             저장소 선택
           </Link>
         </div>
+        {diagnosisError ? (
+          <p className="github-analysis-action-error">{diagnosisError}</p>
+        ) : null}
         <dl className="github-analysis-summary-list" aria-label="분석 요약">
           <div>
             <dt>분석 ID</dt>
@@ -587,6 +629,14 @@ function getSaveErrorMessage(error: unknown) {
   }
 
   return "GitHub 분석 보정을 저장하지 못했습니다.";
+}
+
+function getDiagnosisErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "진단을 생성하지 못했습니다.";
 }
 
 function formatDateTime(value: string) {

--- a/frontend/src/features/roadmap/api.ts
+++ b/frontend/src/features/roadmap/api.ts
@@ -1,9 +1,14 @@
 import { apiClient } from "@/lib/api";
 import type {
   Roadmap,
+  RoadmapRequest,
   RoadmapProgressRequest,
   RoadmapProgressResponse
 } from "@/features/roadmap/types";
+
+export function createRoadmap(payload: RoadmapRequest) {
+  return apiClient.post<Roadmap>("/api/roadmaps", payload);
+}
 
 export function getRoadmap(roadmapId: string) {
   return apiClient.get<Roadmap>(`/api/roadmaps/${roadmapId}`);

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, type FormEvent } from "react";
+
+import { StatePanel } from "@/components/state-panel";
+import { getDashboard } from "@/features/dashboard/api";
+import type { Dashboard } from "@/features/dashboard/types";
+import { createRoadmap } from "@/features/roadmap/api";
+import { ApiError } from "@/lib/api";
+
+type RoadmapCreateState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; dashboard: Dashboard };
+
+export function RoadmapCreateView() {
+  const router = useRouter();
+  const [state, setState] = useState<RoadmapCreateState>({ status: "loading" });
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadDashboard() {
+      setState({ status: "loading" });
+
+      try {
+        const dashboard = await getDashboard();
+
+        if (!ignore) {
+          setState({ dashboard, status: "success" });
+        }
+      } catch (error) {
+        if (!ignore) {
+          setState({
+            message: getErrorMessage(error),
+            status: "error"
+          });
+        }
+      }
+    }
+
+    loadDashboard();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (state.status !== "success" || !state.dashboard.diagnosis) {
+      setCreateError("로드맵 생성 전에 진단 결과를 먼저 생성해 주세요.");
+      return;
+    }
+
+    const formData = new FormData(event.currentTarget);
+    const diagnosisId = getStringFormValue(formData, "diagnosisId");
+
+    if (!diagnosisId) {
+      setCreateError("진단 결과 ID가 필요합니다.");
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+
+    try {
+      const roadmap = await createRoadmap({
+        diagnosisId,
+        githubAnalysisId: getOptionalStringFormValue(formData, "githubAnalysisId"),
+        targetDate: getOptionalStringFormValue(formData, "targetDate"),
+        weeklyStudyHours: getOptionalNumberFormValue(formData, "weeklyStudyHours")
+      });
+
+      router.push(`/roadmaps/${roadmap.roadmapId}`);
+    } catch (error) {
+      setCreateError(getCreateErrorMessage(error));
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  if (state.status === "loading") {
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message="로드맵 생성에 필요한 최신 결과를 불러오는 중입니다."
+      />
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
+  }
+
+  const { dashboard } = state;
+
+  return (
+    <section className="roadmap-create-page" aria-labelledby="roadmap-create-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v1 필수</p>
+        <div className="screen-heading">
+          <h1 id="roadmap-create-title">학습 로드맵 생성</h1>
+          <p>최신 진단 결과를 기준으로 학습 로드맵을 생성합니다.</p>
+        </div>
+        <div className="action-row" aria-label="로드맵 생성 관련 화면 이동">
+          {dashboard.diagnosis ? (
+            <Link
+              className="action-link"
+              href={`/diagnoses/${dashboard.diagnosis.diagnosisId}`}
+            >
+              진단 결과 보기
+            </Link>
+          ) : (
+            <Link className="action-link primary" href="/github/analysis">
+              분석 보정으로 이동
+            </Link>
+          )}
+          {dashboard.roadmap ? (
+            <Link
+              className="action-link"
+              href={`/roadmaps/${dashboard.roadmap.roadmapId}`}
+            >
+              최근 로드맵 보기
+            </Link>
+          ) : null}
+        </div>
+      </div>
+
+      {dashboard.diagnosis ? (
+        <form className="panel roadmap-create-form" onSubmit={handleSubmit}>
+          <div className="roadmap-create-heading">
+            <h2>생성 기준</h2>
+            <p>{dashboard.diagnosis.summary}</p>
+          </div>
+
+          <div className="roadmap-create-fields">
+            <label>
+              <span>진단 결과 ID</span>
+              <input
+                defaultValue={dashboard.diagnosis.diagnosisId}
+                name="diagnosisId"
+                required
+              />
+            </label>
+            <label>
+              <span>GitHub 분석 ID</span>
+              <input
+                defaultValue={dashboard.githubAnalysis?.githubAnalysisId ?? ""}
+                name="githubAnalysisId"
+              />
+            </label>
+            <label>
+              <span>주당 학습 시간</span>
+              <input
+                defaultValue={dashboard.profile?.weeklyStudyHours ?? ""}
+                max={40}
+                min={1}
+                name="weeklyStudyHours"
+                type="number"
+              />
+            </label>
+            <label>
+              <span>목표 날짜</span>
+              <input
+                defaultValue={dashboard.profile?.targetDate ?? ""}
+                name="targetDate"
+                type="date"
+              />
+            </label>
+          </div>
+
+          <div className="roadmap-create-actions">
+            <div>
+              {createError ? (
+                <p className="roadmap-create-error">{createError}</p>
+              ) : null}
+            </div>
+            <button disabled={isCreating} type="submit">
+              {isCreating ? "로드맵 생성 중" : "로드맵 생성"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <StatePanel
+          className="roadmap-state-panel"
+          message="저장된 진단 결과가 없습니다. GitHub 분석 보정 후 진단을 먼저 생성해 주세요."
+        />
+      )}
+    </section>
+  );
+}
+
+function getStringFormValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getOptionalStringFormValue(formData: FormData, key: string) {
+  const value = getStringFormValue(formData, key);
+
+  return value.length > 0 ? value : undefined;
+}
+
+function getOptionalNumberFormValue(formData: FormData, key: string) {
+  const value = getStringFormValue(formData, key);
+
+  return value.length > 0 ? Number(value) : undefined;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "로드맵 생성 기준을 불러오지 못했습니다.";
+}
+
+function getCreateErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "로드맵을 생성하지 못했습니다.";
+}

--- a/frontend/src/features/roadmap/types.ts
+++ b/frontend/src/features/roadmap/types.ts
@@ -48,6 +48,14 @@ export type Roadmap = {
   weeks: RoadmapWeek[];
 };
 
+export type RoadmapRequest = {
+  codingTestAnalysisId?: string | null;
+  diagnosisId: string;
+  githubAnalysisId?: string | null;
+  targetDate?: string | null;
+  weeklyStudyHours?: number | null;
+};
+
 export type RoadmapProgressRequest = {
   note?: string | null;
   roadmapWeekId: string;


### PR DESCRIPTION
## 변경 요약

- GitHub 분석 보정 화면에서 `POST /api/diagnoses`를 호출해 진단 생성 후 상세 화면으로 이동
- `/roadmaps/new`를 실제 로드맵 생성 화면으로 교체하고 `POST /api/roadmaps` 연결
- 최신 대시보드 snapshot의 프로필, GitHub 분석, 진단 값을 생성 입력 기본값으로 사용

## 왜 필요한가

GitHub 분석 보정 이후 사용자가 화면에서 진단과 로드맵 생성 단계로 이어갈 수 있어야 v1 결과 흐름을 끝까지 테스트할 수 있습니다.

## 테스트

- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`

Closes #138