### PR TITLE
feat(frontend): GitHub 연결 분석 흐름 연결

### DIFF
--- a/frontend/src/app/github/page.tsx
+++ b/frontend/src/app/github/page.tsx
@@ -1,6 +1,5 @@
-import { ScreenShell } from "@/components/screen-shell";
-import { screens } from "@/config/routes";
+import { GithubConnectionView } from "@/features/github-connection/github-connection-view";
 
 export default function GithubConnectionPage() {
-  return <ScreenShell screen={screens.githubConnection} />;
+  return <GithubConnectionView />;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1217,6 +1217,199 @@ a {
   line-height: 1.45;
 }
 
+.github-connection-page {
+  display: grid;
+  gap: 24px;
+}
+
+.github-connection-form,
+.github-repository-section,
+.github-connection-summary {
+  display: grid;
+  gap: 16px;
+}
+
+.github-connection-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.github-connection-heading h2 {
+  margin: 0;
+}
+
+.github-connection-heading p,
+.github-connection-state-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.github-connection-form label {
+  display: grid;
+  gap: 6px;
+}
+
+.github-connection-form label span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-connection-form input {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--foreground);
+  padding: 0 10px;
+}
+
+.github-connection-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.github-connection-actions > div {
+  display: grid;
+  gap: 6px;
+}
+
+.github-connection-actions p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.github-connection-error {
+  color: #a32020;
+}
+
+.github-connection-success {
+  color: var(--success);
+}
+
+.github-connection-actions button {
+  min-height: 40px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  padding: 0 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.github-connection-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.github-connection-summary dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.github-connection-summary dl div,
+.github-repository-card dl div {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfe;
+  padding: 10px;
+}
+
+.github-connection-summary dt,
+.github-repository-card dt {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.github-connection-summary dd,
+.github-repository-card dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.github-repository-list {
+  display: grid;
+  gap: 12px;
+}
+
+.github-repository-card {
+  display: grid;
+  gap: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfe;
+  padding: 14px;
+}
+
+.github-repository-card > div:first-child {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.github-repository-card h3 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.github-repository-card a {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.github-repository-card dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.github-repository-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.github-repository-options label {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  padding: 0 10px;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.github-repository-options input:disabled + span {
+  color: var(--muted);
+}
+
 .github-correction-form {
   display: grid;
   gap: 16px;
@@ -1347,6 +1540,12 @@ a {
 
   .github-depth-list li > div {
     align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .github-connection-actions,
+  .github-repository-card > div:first-child {
+    align-items: stretch;
     flex-direction: column;
   }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1344,6 +1344,46 @@ a {
   overflow-wrap: anywhere;
 }
 
+.github-analysis-start-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.github-analysis-start-panel > div {
+  display: grid;
+  gap: 6px;
+}
+
+.github-analysis-start-panel h2,
+.github-analysis-start-panel p {
+  margin: 0;
+}
+
+.github-analysis-start-panel p {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.github-analysis-start-panel button {
+  min-height: 40px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 0 18px;
+  white-space: nowrap;
+}
+
+.github-analysis-start-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .github-repository-list {
   display: grid;
   gap: 12px;
@@ -1544,6 +1584,7 @@ a {
   }
 
   .github-connection-actions,
+  .github-analysis-start-panel,
   .github-repository-card > div:first-child {
     align-items: stretch;
     flex-direction: column;

--- a/frontend/src/features/github-analysis/api.ts
+++ b/frontend/src/features/github-analysis/api.ts
@@ -2,8 +2,13 @@ import { apiClient } from "@/lib/api";
 import type {
   GithubAnalysis,
   GithubAnalysisCorrectionRequest,
-  GithubAnalysisCorrectionResponse
+  GithubAnalysisCorrectionResponse,
+  GithubAnalysisRequest
 } from "@/features/github-analysis/types";
+
+export function createGithubAnalysis(payload: GithubAnalysisRequest) {
+  return apiClient.post<GithubAnalysis>("/api/github-analyses", payload);
+}
 
 export function getGithubAnalysis(githubAnalysisId: string) {
   return apiClient.get<GithubAnalysis>(

--- a/frontend/src/features/github-analysis/types.ts
+++ b/frontend/src/features/github-analysis/types.ts
@@ -67,6 +67,12 @@ export type GithubAnalysis = {
   version: number;
 };
 
+export type GithubAnalysisRequest = {
+  coreRepositoryIds: string[];
+  githubConnectionId: string;
+  selectedRepositoryIds: string[];
+};
+
 export type GithubAnalysisCorrectionRequest = {
   finalTechProfile: FinalTechProfile;
   userCorrections: GithubUserCorrection[];

--- a/frontend/src/features/github-connection/api.ts
+++ b/frontend/src/features/github-connection/api.ts
@@ -1,0 +1,21 @@
+import { apiClient } from "@/lib/api";
+import type {
+  GithubConnectionRequest,
+  GithubConnectionResponse,
+  GithubRepositoryListResponse
+} from "@/features/github-connection/types";
+
+export function connectGithub(payload: GithubConnectionRequest) {
+  return apiClient.post<GithubConnectionResponse>(
+    "/api/github/connections",
+    payload
+  );
+}
+
+export function getGithubRepositories(githubConnectionId: string) {
+  return apiClient.get<GithubRepositoryListResponse>(
+    `/api/github/repositories?githubConnectionId=${encodeURIComponent(
+      githubConnectionId
+    )}`
+  );
+}

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type FormEvent } from "react";
+
+import { StatePanel } from "@/components/state-panel";
+import {
+  connectGithub,
+  getGithubRepositories
+} from "@/features/github-connection/api";
+import type {
+  GithubConnectionResponse,
+  GithubRepository
+} from "@/features/github-connection/types";
+import { ApiError } from "@/lib/api";
+
+type RepositorySelection = {
+  coreRepositoryIds: string[];
+  selectedRepositoryIds: string[];
+};
+
+export function GithubConnectionView() {
+  const [connection, setConnection] = useState<GithubConnectionResponse | null>(
+    null
+  );
+  const [repositories, setRepositories] = useState<GithubRepository[]>([]);
+  const [selection, setSelection] = useState<RepositorySelection>({
+    coreRepositoryIds: [],
+    selectedRepositoryIds: []
+  });
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
+
+  async function handleConnectSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const formData = new FormData(event.currentTarget);
+    const authorizationCode = getStringFormValue(formData, "authorizationCode");
+
+    if (!authorizationCode) {
+      setLoadError("GitHub authorization code를 입력해 주세요.");
+      return;
+    }
+
+    setIsConnecting(true);
+    setLoadError(null);
+    setConnectionMessage(null);
+
+    try {
+      const connected = await connectGithub({ authorizationCode });
+      const repositoryList = await getGithubRepositories(
+        connected.githubConnectionId
+      );
+
+      setConnection(connected);
+      setRepositories(repositoryList.repositories);
+      setSelection({ coreRepositoryIds: [], selectedRepositoryIds: [] });
+      setConnectionMessage(
+        `${connected.githubLogin} 계정의 저장소 ${repositoryList.repositories.length}개를 불러왔습니다.`
+      );
+    } catch (error) {
+      setLoadError(getErrorMessage(error));
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  function toggleSelectedRepository(repositoryId: string) {
+    setSelection((current) => {
+      const selected = new Set(current.selectedRepositoryIds);
+      const core = new Set(current.coreRepositoryIds);
+
+      if (selected.has(repositoryId)) {
+        selected.delete(repositoryId);
+        core.delete(repositoryId);
+      } else {
+        selected.add(repositoryId);
+      }
+
+      return {
+        coreRepositoryIds: [...core],
+        selectedRepositoryIds: [...selected]
+      };
+    });
+  }
+
+  function toggleCoreRepository(repositoryId: string) {
+    setSelection((current) => {
+      if (!current.selectedRepositoryIds.includes(repositoryId)) {
+        return current;
+      }
+
+      const core = new Set(current.coreRepositoryIds);
+
+      if (core.has(repositoryId)) {
+        core.delete(repositoryId);
+      } else {
+        core.add(repositoryId);
+      }
+
+      return {
+        ...current,
+        coreRepositoryIds: [...core]
+      };
+    });
+  }
+
+  return (
+    <section className="github-connection-page" aria-labelledby="github-title">
+      <div className="screen-hero">
+        <p className="eyebrow">v1 필수</p>
+        <div className="screen-heading">
+          <h1 id="github-title">GitHub 연동 / 저장소 선택</h1>
+          <p>GitHub authorization code로 계정을 연결하고 분석할 저장소를 고릅니다.</p>
+        </div>
+        <div className="action-row" aria-label="GitHub 관련 화면 이동">
+          <Link className="action-link" href="/profile">
+            프로필로 돌아가기
+          </Link>
+          <Link className="action-link" href="/github/analysis">
+            최근 분석 보기
+          </Link>
+        </div>
+      </div>
+
+      <form className="panel github-connection-form" onSubmit={handleConnectSubmit}>
+        <div className="github-connection-heading">
+          <h2>GitHub 연결</h2>
+          <p>GitHub OAuth authorization code를 입력하면 저장소 목록을 불러옵니다.</p>
+        </div>
+        <label>
+          <span>Authorization code</span>
+          <input
+            autoComplete="off"
+            name="authorizationCode"
+            placeholder="GitHub OAuth redirect URL의 code 값"
+          />
+        </label>
+        <div className="github-connection-actions">
+          <div>
+            {loadError ? (
+              <p className="github-connection-error">{loadError}</p>
+            ) : null}
+            {connectionMessage ? (
+              <p className="github-connection-success">{connectionMessage}</p>
+            ) : null}
+          </div>
+          <button disabled={isConnecting} type="submit">
+            {isConnecting ? "연결 중" : "저장소 불러오기"}
+          </button>
+        </div>
+      </form>
+
+      {connection ? (
+        <section className="panel github-connection-summary">
+          <h2>연결 상태</h2>
+          <dl>
+            <div>
+              <dt>계정</dt>
+              <dd>{connection.githubLogin}</dd>
+            </div>
+            <div>
+              <dt>연결 ID</dt>
+              <dd>{connection.githubConnectionId}</dd>
+            </div>
+            <div>
+              <dt>연결 시각</dt>
+              <dd>{formatDateTime(connection.connectedAt)}</dd>
+            </div>
+          </dl>
+        </section>
+      ) : null}
+
+      {connection && repositories.length === 0 ? (
+        <StatePanel
+          className="github-connection-state-panel"
+          message="표시할 저장소가 없습니다."
+        />
+      ) : null}
+
+      {repositories.length > 0 ? (
+        <RepositorySelectionPanel
+          onCoreToggle={toggleCoreRepository}
+          onSelectedToggle={toggleSelectedRepository}
+          repositories={repositories}
+          selection={selection}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function RepositorySelectionPanel({
+  onCoreToggle,
+  onSelectedToggle,
+  repositories,
+  selection
+}: {
+  onCoreToggle: (repositoryId: string) => void;
+  onSelectedToggle: (repositoryId: string) => void;
+  repositories: GithubRepository[];
+  selection: RepositorySelection;
+}) {
+  return (
+    <section className="panel github-repository-section">
+      <div className="github-connection-heading">
+        <h2>저장소 선택</h2>
+        <p>분석 대상 저장소와 LLM 요약에 사용할 핵심 저장소를 선택합니다.</p>
+      </div>
+      <div className="github-repository-list">
+        {repositories.map((repository) => {
+          const isSelected = selection.selectedRepositoryIds.includes(
+            repository.repositoryId
+          );
+          const isCore = selection.coreRepositoryIds.includes(
+            repository.repositoryId
+          );
+
+          return (
+            <article className="github-repository-card" key={repository.repositoryId}>
+              <div>
+                <h3>{repository.repoFullName}</h3>
+                <a href={repository.repoUrl} rel="noreferrer" target="_blank">
+                  저장소 열기
+                </a>
+              </div>
+              <dl>
+                <div>
+                  <dt>언어</dt>
+                  <dd>{repository.primaryLanguage ?? "미확인"}</dd>
+                </div>
+                <div>
+                  <dt>기본 브랜치</dt>
+                  <dd>{repository.defaultBranch ?? "미확인"}</dd>
+                </div>
+              </dl>
+              <div className="github-repository-options">
+                <label>
+                  <input
+                    checked={isSelected}
+                    onChange={() => onSelectedToggle(repository.repositoryId)}
+                    type="checkbox"
+                  />
+                  <span>분석 대상</span>
+                </label>
+                <label>
+                  <input
+                    checked={isCore}
+                    disabled={!isSelected}
+                    onChange={() => onCoreToggle(repository.repositoryId)}
+                    type="checkbox"
+                  />
+                  <span>핵심 repo</span>
+                </label>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function getStringFormValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "GitHub 저장소를 불러오지 못했습니다.";
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import { createGithubAnalysis } from "@/features/github-analysis/api";
 import {
   connectGithub,
   getGithubRepositories
@@ -20,6 +22,7 @@ type RepositorySelection = {
 };
 
 export function GithubConnectionView() {
+  const router = useRouter();
   const [connection, setConnection] = useState<GithubConnectionResponse | null>(
     null
   );
@@ -29,7 +32,9 @@ export function GithubConnectionView() {
     selectedRepositoryIds: []
   });
   const [isConnecting, setIsConnecting] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
   const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
 
   async function handleConnectSubmit(event: FormEvent<HTMLFormElement>) {
@@ -56,6 +61,7 @@ export function GithubConnectionView() {
       setConnection(connected);
       setRepositories(repositoryList.repositories);
       setSelection({ coreRepositoryIds: [], selectedRepositoryIds: [] });
+      setAnalysisError(null);
       setConnectionMessage(
         `${connected.githubLogin} 계정의 저장소 ${repositoryList.repositories.length}개를 불러왔습니다.`
       );
@@ -63,6 +69,42 @@ export function GithubConnectionView() {
       setLoadError(getErrorMessage(error));
     } finally {
       setIsConnecting(false);
+    }
+  }
+
+  async function handleAnalysisCreate() {
+    if (!connection) {
+      setAnalysisError("GitHub 연결 후 분석을 실행해 주세요.");
+      return;
+    }
+
+    if (selection.selectedRepositoryIds.length === 0) {
+      setAnalysisError("분석 대상 저장소를 1개 이상 선택해 주세요.");
+      return;
+    }
+
+    if (selection.coreRepositoryIds.length === 0) {
+      setAnalysisError("핵심 repo를 1개 이상 선택해 주세요.");
+      return;
+    }
+
+    setIsAnalyzing(true);
+    setAnalysisError(null);
+
+    try {
+      const analysis = await createGithubAnalysis({
+        coreRepositoryIds: selection.coreRepositoryIds,
+        githubConnectionId: connection.githubConnectionId,
+        selectedRepositoryIds: selection.selectedRepositoryIds
+      });
+
+      router.push(
+        `/github/analysis?githubAnalysisId=${analysis.githubAnalysisId}`
+      );
+    } catch (error) {
+      setAnalysisError(getAnalysisErrorMessage(error));
+    } finally {
+      setIsAnalyzing(false);
     }
   }
 
@@ -180,12 +222,37 @@ export function GithubConnectionView() {
       ) : null}
 
       {repositories.length > 0 ? (
-        <RepositorySelectionPanel
-          onCoreToggle={toggleCoreRepository}
-          onSelectedToggle={toggleSelectedRepository}
-          repositories={repositories}
-          selection={selection}
-        />
+        <>
+          <RepositorySelectionPanel
+            onCoreToggle={toggleCoreRepository}
+            onSelectedToggle={toggleSelectedRepository}
+            repositories={repositories}
+            selection={selection}
+          />
+          <section className="panel github-analysis-start-panel">
+            <div>
+              <h2>분석 실행</h2>
+              <p>
+                분석 대상 {selection.selectedRepositoryIds.length}개, 핵심 repo{" "}
+                {selection.coreRepositoryIds.length}개를 선택했습니다.
+              </p>
+              {analysisError ? (
+                <p className="github-connection-error">{analysisError}</p>
+              ) : null}
+            </div>
+            <button
+              disabled={
+                isAnalyzing ||
+                selection.selectedRepositoryIds.length === 0 ||
+                selection.coreRepositoryIds.length === 0
+              }
+              onClick={handleAnalysisCreate}
+              type="button"
+            >
+              {isAnalyzing ? "분석 실행 중" : "GitHub 분석 실행"}
+            </button>
+          </section>
+        </>
       ) : null}
     </section>
   );
@@ -274,6 +341,14 @@ function getErrorMessage(error: unknown) {
   }
 
   return "GitHub 저장소를 불러오지 못했습니다.";
+}
+
+function getAnalysisErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "GitHub 분석을 실행하지 못했습니다.";
 }
 
 function formatDateTime(value: string) {

--- a/frontend/src/features/github-connection/types.ts
+++ b/frontend/src/features/github-connection/types.ts
@@ -1,0 +1,22 @@
+export type GithubConnectionRequest = {
+  authorizationCode: string;
+};
+
+export type GithubConnectionResponse = {
+  connectedAt: string;
+  githubConnectionId: string;
+  githubLogin: string;
+};
+
+export type GithubRepository = {
+  defaultBranch?: string | null;
+  primaryLanguage?: string | null;
+  repoFullName: string;
+  repoUrl: string;
+  repositoryId: string;
+};
+
+export type GithubRepositoryListResponse = {
+  githubConnectionId: string;
+  repositories: GithubRepository[];
+};


### PR DESCRIPTION
## 변경 요약
- `/github` 화면에서 authorization code로 GitHub 연결을 등록하도록 연결했습니다.
- 연결된 저장소 목록 조회와 분석 대상/핵심 repo 선택 UI를 추가했습니다.
- 선택한 저장소로 `POST /api/github-analyses`를 실행하고 성공 시 분석 결과 화면으로 이동하게 했습니다.

## 왜 필요한가
프로필 이후 GitHub 분석 단계가 화면에서 끊기지 않아야 v1 흐름을 브라우저에서 테스트할 수 있습니다.

## 테스트
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`

Closes #141