### PR TITLE
chore(ci): 프론트엔드 검증 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,52 @@
+name: frontend-ci
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+concurrency:
+  group: frontend-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-check:
+    name: frontend-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint
+
+      - name: Run frontend build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Set-Content .env.local "NEXT_PUBLIC_API_BASE_URL=http://localhost:8080"
 
 ```powershell
 cd frontend
+npm ci
 npm run lint
 npm run build
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,16 @@ npm run dev
 `GITHUB_CLIENT_SECRET` 환경변수와 함께 띄워야 한다 (둘 다 미설정이면 OAuth2 빈이 등록되지
 않아 `/oauth2/authorization/github` 가 404).
 
+## PR 전 검증
+
+CI와 같은 순서로 의존성을 설치하고 lint/build를 확인한다.
+
+```bash
+npm ci
+npm run lint
+npm run build
+```
+
 ## 화면
 
 | 경로 | 용도 |


### PR DESCRIPTION
## 변경 요약
- frontend 변경 PR/push 대상 `frontend-ci` GitHub Actions workflow를 추가했습니다.
- CI에서 `npm ci`, `npm run lint`, `npm run build`를 실행하도록 했습니다.
- README에 프론트 검증 명령을 CI 기준과 맞춰 정리했습니다.

## 왜 필요한가
프론트 변경의 lint/build 실패를 리뷰 전에 자동으로 잡기 위해 필요합니다.

## 테스트
- `cd frontend && npm ci`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`

Closes #144