### PR TITLE
refactor(frontend-ui): tag badge UI 공통화

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -191,6 +191,37 @@ a {
   font-weight: 700;
 }
 
+.tag-list {
+  display: grid;
+  gap: 8px;
+}
+
+.tag-list p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tag-list-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-pill {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
 .item-list {
   display: grid;
   gap: 10px;
@@ -607,36 +638,6 @@ a {
   margin: 0;
   color: var(--foreground);
   font-size: 14px;
-  font-weight: 700;
-}
-
-.dashboard-tag-group {
-  display: grid;
-  gap: 8px;
-}
-
-.dashboard-tag-group p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.dashboard-tag-group div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.dashboard-tag-group span {
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0 9px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  font-size: 12px;
   font-weight: 700;
 }
 
@@ -1066,25 +1067,6 @@ a {
   margin: 0;
 }
 
-.github-tag-group {
-  display: grid;
-  gap: 8px;
-}
-
-.github-tag-group p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.github-tag-group div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.github-tag-group span,
 .github-depth-badge,
 .github-evidence-list span {
   min-height: 28px;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -222,6 +222,42 @@ a {
   white-space: nowrap;
 }
 
+.status-badge {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.status-badge[data-tone="neutral"] {
+  background: #eef2f7;
+  color: #475467;
+}
+
+.status-badge[data-tone="info"] {
+  background: #e8f0ff;
+  color: #2563eb;
+}
+
+.status-badge[data-tone="success"] {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.status-badge[data-tone="warning"] {
+  background: #fff4e5;
+  color: #a15c00;
+}
+
+.status-badge[data-tone="danger"] {
+  background: #fff1f1;
+  color: #b42318;
+}
+
 .item-list {
   display: grid;
   gap: 10px;
@@ -303,37 +339,6 @@ a {
   margin: 0;
   font-size: 20px;
   line-height: 1.35;
-}
-
-.progress-badge {
-  min-height: 30px;
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0 10px;
-  font-size: 13px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.progress-badge[data-status="todo"] {
-  background: #eef2f7;
-  color: #475467;
-}
-
-.progress-badge[data-status="in-progress"] {
-  background: #e8f0ff;
-  color: #2563eb;
-}
-
-.progress-badge[data-status="done"] {
-  background: var(--success-soft);
-  color: var(--success);
-}
-
-.progress-badge[data-status="skipped"] {
-  background: #fff4e5;
-  color: #a15c00;
 }
 
 .roadmap-week-reason {
@@ -941,32 +946,6 @@ a {
   line-height: 1.55;
 }
 
-.diagnosis-severity-badge {
-  min-height: 30px;
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 0 10px;
-  font-size: 13px;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.diagnosis-severity-badge[data-severity="low"] {
-  background: #eef2f7;
-  color: #475467;
-}
-
-.diagnosis-severity-badge[data-severity="medium"] {
-  background: #fff4e5;
-  color: #a15c00;
-}
-
-.diagnosis-severity-badge[data-severity="high"] {
-  background: #fff1f1;
-  color: #b42318;
-}
-
 .diagnosis-result-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -1067,7 +1046,6 @@ a {
   margin: 0;
 }
 
-.github-depth-badge,
 .github-evidence-list span {
   min-height: 28px;
   display: inline-flex;
@@ -1150,26 +1128,6 @@ a {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-}
-
-.github-depth-badge[data-depth="intro"] {
-  background: #eef2f7;
-  color: #475467;
-}
-
-.github-depth-badge[data-depth="applied"] {
-  background: #e8f0ff;
-  color: #2563eb;
-}
-
-.github-depth-badge[data-depth="practical"] {
-  background: var(--success-soft);
-  color: var(--success);
-}
-
-.github-depth-badge[data-depth="deep"] {
-  background: #fff4e5;
-  color: #a15c00;
 }
 
 .github-evidence-list code {

--- a/frontend/src/components/status-badge.tsx
+++ b/frontend/src/components/status-badge.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+
+export type StatusBadgeTone =
+  | "danger"
+  | "info"
+  | "neutral"
+  | "success"
+  | "warning";
+
+type StatusBadgeProps = {
+  children: ReactNode;
+  className?: string;
+  tone: StatusBadgeTone;
+};
+
+export function StatusBadge({
+  children,
+  className,
+  tone
+}: StatusBadgeProps) {
+  const classes = ["status-badge", className].filter(Boolean).join(" ");
+
+  return (
+    <span className={classes} data-tone={tone}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/tag-list.tsx
+++ b/frontend/src/components/tag-list.tsx
@@ -1,0 +1,36 @@
+type TagListProps = {
+  className?: string;
+  emptyLabel?: string;
+  items: string[];
+  label: string;
+};
+
+export function TagList({
+  className,
+  emptyLabel,
+  items,
+  label
+}: TagListProps) {
+  if (items.length === 0 && !emptyLabel) {
+    return null;
+  }
+
+  const classes = ["tag-list", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes}>
+      <p>{label}</p>
+      {items.length > 0 ? (
+        <div className="tag-list-items">
+          {items.map((item) => (
+            <span className="tag-pill" key={item}>
+              {item}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <span className="tag-pill">{emptyLabel}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import { TagList } from "@/components/tag-list";
 import { getDashboard } from "@/features/dashboard/api";
 import { currentLevelLabels } from "@/features/dashboard/labels";
 import type {
@@ -239,23 +240,6 @@ function EmptySummary({
       <Link className="dashboard-card-link" href={actionHref}>
         {actionLabel}
       </Link>
-    </div>
-  );
-}
-
-function TagList({ items, label }: { items: string[]; label: string }) {
-  if (items.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="dashboard-tag-group">
-      <p>{label}</p>
-      <div>
-        {items.map((item) => (
-          <span key={item}>{item}</span>
-        ))}
-      </div>
     </div>
   );
 }

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -4,10 +4,13 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import {
+  StatusBadge,
+  type StatusBadgeTone
+} from "@/components/status-badge";
 import { getDiagnosis } from "@/features/diagnosis/api";
 import {
   currentLevelLabels,
-  diagnosisSeverityClassNames,
   diagnosisSeverityLabels
 } from "@/features/diagnosis/labels";
 import type { Diagnosis, MissingSkill } from "@/features/diagnosis/types";
@@ -183,14 +186,17 @@ function DiagnosisListSection({
 
 function SeverityBadge({ skill }: { skill: MissingSkill }) {
   return (
-    <span
-      className="diagnosis-severity-badge"
-      data-severity={diagnosisSeverityClassNames[skill.severity]}
-    >
+    <StatusBadge tone={diagnosisSeverityTones[skill.severity]}>
       {diagnosisSeverityLabels[skill.severity]}
-    </span>
+    </StatusBadge>
   );
 }
+
+const diagnosisSeverityTones: Record<MissingSkill["severity"], StatusBadgeTone> = {
+  HIGH: "danger",
+  LOW: "neutral",
+  MEDIUM: "warning"
+};
 
 function comparePriorityOrder(a: MissingSkill, b: MissingSkill) {
   return a.priorityOrder - b.priorityOrder;

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -5,6 +5,10 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import {
+  StatusBadge,
+  type StatusBadgeTone
+} from "@/components/status-badge";
 import { TagList } from "@/components/tag-list";
 import { getDashboard } from "@/features/dashboard/api";
 import { createDiagnosis } from "@/features/diagnosis/api";
@@ -13,13 +17,13 @@ import {
   saveGithubAnalysisCorrections
 } from "@/features/github-analysis/api";
 import {
-  githubDepthLevelClassNames,
   githubDepthLevelLabels,
   githubEvidenceTypeLabels
 } from "@/features/github-analysis/labels";
 import type {
   DepthEstimate,
   GithubAnalysis,
+  GithubDepthLevel,
   GithubUserCorrection
 } from "@/features/github-analysis/types";
 import { ApiError } from "@/lib/api";
@@ -519,14 +523,18 @@ function GithubCorrectionForm({
 
 function DepthBadge({ estimate }: { estimate: DepthEstimate }) {
   return (
-    <span
-      className="github-depth-badge"
-      data-depth={githubDepthLevelClassNames[estimate.level]}
-    >
+    <StatusBadge tone={githubDepthLevelTones[estimate.level]}>
       {githubDepthLevelLabels[estimate.level]}
-    </span>
+    </StatusBadge>
   );
 }
+
+const githubDepthLevelTones: Record<GithubDepthLevel, StatusBadgeTone> = {
+  APPLIED: "info",
+  DEEP: "warning",
+  INTRO: "neutral",
+  PRACTICAL: "success"
+};
 
 function normalizeOptionalId(value?: string | null) {
   if (!value) {

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import { TagList } from "@/components/tag-list";
 import { getDashboard } from "@/features/dashboard/api";
 import { createDiagnosis } from "@/features/diagnosis/api";
 import {
@@ -347,6 +348,7 @@ function StaticSignalsPanel({ analysis }: { analysis: GithubAnalysis }) {
         </div>
       </dl>
       <TagList
+        emptyLabel="없음"
         items={staticSignals.primaryLanguages.map(
           (language) => `${language.lang} ${formatRatio(language.ratio)}`
         )}
@@ -361,10 +363,15 @@ function FinalTechProfilePanel({ analysis }: { analysis: GithubAnalysis }) {
     <section className="panel github-analysis-section">
       <h2>최종 기술 프로필</h2>
       <TagList
+        emptyLabel="없음"
         items={analysis.finalTechProfile.confirmedSkills}
         label="확정 기술"
       />
-      <TagList items={analysis.finalTechProfile.focusAreas} label="집중 영역" />
+      <TagList
+        emptyLabel="없음"
+        items={analysis.finalTechProfile.focusAreas}
+        label="집중 영역"
+      />
     </section>
   );
 }
@@ -518,28 +525,6 @@ function DepthBadge({ estimate }: { estimate: DepthEstimate }) {
     >
       {githubDepthLevelLabels[estimate.level]}
     </span>
-  );
-}
-
-function TagList({ items, label }: { items: string[]; label: string }) {
-  if (items.length === 0) {
-    return (
-      <div className="github-tag-group">
-        <p>{label}</p>
-        <span>없음</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className="github-tag-group">
-      <p>{label}</p>
-      <div>
-        {items.map((item) => (
-          <span key={item}>{item}</span>
-        ))}
-      </div>
-    </div>
   );
 }
 

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -3,10 +3,13 @@
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
+import {
+  StatusBadge,
+  type StatusBadgeTone
+} from "@/components/status-badge";
 import { getRoadmap, saveRoadmapProgress } from "@/features/roadmap/api";
 import {
   materialTypeLabels,
-  progressStatusClassNames,
   progressStatusLabels,
   progressStatusOptions,
   taskTypeLabels
@@ -186,12 +189,9 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
                     <p className="roadmap-week-kicker">{week.weekNumber}주차</p>
                     <h2>{week.topic}</h2>
                   </div>
-                  <span
-                    className="progress-badge"
-                    data-status={progressStatusClassNames[progressStatus]}
-                  >
+                  <StatusBadge tone={progressStatusTones[progressStatus]}>
                     {progressStatusLabels[progressStatus]}
-                  </span>
+                  </StatusBadge>
                 </div>
 
                 <p className="roadmap-week-reason">{week.reason}</p>
@@ -313,6 +313,13 @@ function getErrorMessage(error: unknown, fallbackMessage: string) {
 
   return fallbackMessage;
 }
+
+const progressStatusTones: Record<ProgressStatus, StatusBadgeTone> = {
+  DONE: "success",
+  IN_PROGRESS: "info",
+  SKIPPED: "warning",
+  TODO: "neutral"
+};
 
 function isProgressStatus(
   value: FormDataEntryValue | null


### PR DESCRIPTION
## 변경 요약
- 공통 `TagList` 컴포넌트를 추가하고 dashboard/GitHub 분석 화면의 로컬 TagList를 교체했습니다.
- 공통 `StatusBadge` 컴포넌트를 추가하고 roadmap progress, diagnosis severity, GitHub depth badge를 교체했습니다.
- 중복 pill CSS를 `.tag-list`, `.tag-pill`, `.status-badge` 기준으로 정리했습니다.

## 왜 필요한가
반복되는 pill UI를 화면마다 복사하지 않고, 빈 값 처리와 상태 색상 기준을 한 곳에서 재사용하기 위해 필요합니다.

## 테스트
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`

Closes #148