### PR TITLE
chore(repo): 포맷 기준 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.{java,kt,kts}]
+indent_size = 4
+
+[*.{ts,tsx,js,json,yml,yaml,md,sql}]
+indent_size = 2
+
+[*.bat]
+end_of_line = crlf
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+
+*.gif binary
+*.ico binary
+*.jpg binary
+*.jpeg binary
+*.pdf binary
+*.png binary
+*.webp binary
+*.zip binary


### PR DESCRIPTION
## 변경 요약
- `.editorconfig`로 에디터 저장 시 인코딩, 줄끝, 들여쓰기, trailing whitespace 기준을 추가했습니다.
- `.gitattributes`로 Git text 파일 LF 정규화와 `.bat` CRLF 유지 기준을 추가했습니다.
- 기존 파일 대량 renormalize는 하지 않았습니다.

## 왜 필요한가
OS/IDE 차이로 생기는 불필요한 공백/줄끝 diff를 줄이기 위해 필요합니다.

## 테스트
- `git diff --check`
- `git check-attr text eol -- README.md frontend/src/components/tag-list.tsx backend/src/main/java/com/back/coach/global/security/CookieManager.java backend/gradlew.bat`

Closes #153