### PR TITLE
feat(backend): Decision Reversal Detection + OAuth 쿠키 수정 + e2e 테스트

### DIFF
--- a/backend/2026-05-02-002049-local-command-caveatcaveat-the-messages-below.txt
+++ b/backend/2026-05-02-002049-local-command-caveatcaveat-the-messages-below.txt
@@ -1,0 +1,3535 @@
+ ▐▛███▜▌   Claude Code v2.1.121
+▝▜█████▛▘  Opus 4.7 · Claude Pro
+  ▘▘ ▝▝    ~\IdeaProjects\INT6-Roadmap-Team06\backend
+
+✻ Conversation compacted (ctrl+o for history)
+
+
+> /compact                                                                      
+  ⎿  Compacted (ctrl+o to see full summary)
+     Tip: You have access to Opus 1M with 5x more context
+  ⎿  Read src\test\java\com\back\coach\global\security\oauth2\AuthFlowIntegrationTest.java (161 lines)
+  ⎿  Read src\main\java\com\back\coach\global\security\oauth2\OAuth2LoginSecurityConfig.java (50 lines)
+  ⎿  Read src\test\java\com\back\coach\global\security\SecurityConfigTest.java (156 lines)
+  ⎿  Read src\test\java\com\back\coach\api\auth\AuthControllerTest.java (117 lines)
+  ⎿  Read src\test\java\com\back\coach\global\security\oauth2\CoachOAuth2LoginSuccessHandlerTest.java (177 lines)
+  ⎿  Plan file referenced (~\.claude\plans\zesty-herding-pretzel.md)
+
+> 이전 깃허브 전략을 말해 줄게, ppt에서 가져온 내용이야(몇만 줄, 몇십만 줄이 될 
+   수도 있는 Github Repo의 분석을 하려면 토큰이 많이 들어가는 법입니다. 저희는  
+  input 토큰을 아끼기 위해,고품질 압축을 위해 저희는 특별한 전략을 수립했습니다 
+                                                                                
+  GitHub Repo 분석 파이프라인 전체 흐름을 설명드리겠습니다.                     
+  시작은 사용자의 기여 Repo 탐색입니다. GitHub GraphQL contributionsCollection  
+  API로 사용자가 실제로 커밋한 저장소 목록을 가져옵니다.                        
+  다음은 Significance Check입니다. 모든 Repo를 분석하면 비용과 시간이 너무 많이 
+   들기 때문에, GitHub Commits API로 최근 커밋 수와 활동량을 확인해 점수를      
+  계산합니다. 15점 미만이면 여기서 중단합니다.                                  
+  점수를 통과하면 blobless clone을 합니다. git clone --filter=blob:none         
+  옵션으로 파일 내용은 제외하고 이력과 트리 구조만 먼저 가져와 clone 속도를     
+  크게 줄였습니다.                                                              
+  clone 이후에는 세 가지 작업이 병렬로 진행됩니다. Static Analyzer는            
+  JavaParser로 AST를 파싱하고 Call Graph를 추출합니다. Contribution Extractor는 
+   git log에서 본인 커밋만 필터링합니다. Semantic Commit Processor는 노이즈     
+  커밋을 제거하고 ImpactScore를 계산해 시간대별로 Champion 후보를 선정합니다.   
+  선별된 Champion 커밋은 diff를 합축하고 패키지 구조와 함께 Token Budget        
+  Enforcer를 거칩니다. 토큰 예산을 초과하면 diff를 줄이거나 항목을 제거해 LLM   
+  입력 크기를 강제로 맞춥니다.                                                  
+  최종적으로 정제된 데이터를 XML batch_data 형태로 묶어 AI에 1회 호출로 전체    
+  저장소를 일괄 요약합니다. 결과는 RepoSummary로 저장되고, MergedSummary로      
+  집계되어 자소서와 면접 질문 생성의 컨텍스트가 됩니다.                         
+  전체 설계의 핵심은 "얼마나 고품질로 압축할 수 있느냐"입니다. clone도          
+  blobless로, 분석도 본인 기여 파일만, 커밋도 Top N만 추려서, AI 호출은 딱 한   
+  번으로 끝냅니다.파이프라인 핵심 로직을 단계별로 보겠습니다.                   
+  PHASE 1은 데이터 수집입니다. git clone으로 커밋 로그, sha, subject, body,     
+  diff, README, AST와 PageRank를 위한 구조 정보를 가져옵니다. GitHub            
+  GraphQL로는 Issue, PR, Review 상태도 함께 수집합니다.                         
+  PHASE 2는 Champion 선정입니다. 1단계로 merge 커밋, 포매팅, 테스트,            
+  auto-generated 커밋을 제거합니다. 2단계로 각 커밋에 점수를 계산합니다. fix는  
+  +3, body는 +5, 코드구조 세분화는 +10, 순삭제는 -10, 편집소재 동시성은 +8,     
+  DB설계는 +7, 구조중요도는 PageRank × 8 등입니다. 3단계로 시간 구간을 Early,   
+  Mid, Late 3분의 1씩 나눠 구간별 Top N을 선택합니다. 4단계로 LLM이 최종 6~9개  
+  Champion을 확정합니다.                                                        
+  PHASE 3는 상세 분석입니다. 선정된 Champion의 diff를 합축합니다. import-getter 
+   반들 제거와 포맷블록, 어노테이션을 제거해 유효 diff만 남기고, 10KB를         
+  초과하면 CodeIndex로 요약본을 대신 사용합니다. GitHub Metadata도 병합해       
+  Impact Score Top-N을 재산정합니다.                                            
+  PHASE 4는 AI 분석입니다. 전체를 XML batch_data로 묶어 1회 Batch 호출로        
+  저장소별 JSON을 받아옵니다. 절단이 발생하면 TruncatedJsonArrayRecovery로      
+  완성된 원소만 부분 저장합니다.                                                
+  이 구조 덕분에 AI 호출 횟수를 최소화하면서도 저장소별 컨텍스트가 명확하게     
+  분리된 고품질 요약을 얻을 수 있었습니다.실제 개발 중 마주친 문제들과 해결     
+  방법을 정리했습니다. GitHub API 429/403 반복은 Redis Dry-run과 피드백 루프로  
+  해결했습니다. 이 표와는 달리 지수 백오프는 지금 베거된 상태입니다. AI JSON    
+  절단 문제는 역방향으로 탐색해 유효한 배열을 복구하는                          
+  TruncatedJsonArrayRecovery로 대응했고, Virtual Thread 동시성 이슈는 Redis Lua 
+   Script 기반의 원자적 세마포어로 처리했습니다. 대형 외부 Repo 처리는 blobless 
+   clone과 본인 기여 파일에만 AST 분석을 제한하는 방식으로 해결했습니다.AI에    
+  전달하는 입력 포맷은 XML batch_data 구조입니다. Markdown 대신 XML을 쓴        
+  이유는, 여러 Repo를 묶으면 ## Section 경계가 모호해져 AI가 이전 Repo 내용을   
+  다음 Repo 분석에 혼용하는 Context Bleeding이 발생하기 때문입니다. XML 태그는  
+  시작과 끝 경계가 명확해 이 문제를 원천 차단합니다.                            
+                                                                                
+  출력은 per-repo JSON 배열 구조로, 각 저장소마다 역할, 기술 스택, 신호, 근거   
+  bullet, 챌린지, 기술 결정 사항이 포함됩니다. 이 결과가 자소서 생성과 면접     
+  질문의 컨텍스트로 직접 연결됩니다.)                                           
+
+● 좋아, 이전 전략 잘 정리됐어. 핵심을 다시 짚어보면:
+
+  이전 프로젝트가 한 일 (Gemini Flash 저토큰 환경 가정):
+  1. 수집: GraphQL contributionsCollection → 기여 repo 목록
+  2. Significance Check: 점수 < 15 → drop (비용 절감)
+  3. Blobless clone (--filter=blob:none) → 트리/이력만
+  4. 3-way 병렬: JavaParser AST + Call Graph PageRank, 본인 커밋 필터, Semantic
+  Commit Processor (노이즈 제거 + ImpactScore)
+  5. Champion 선정: 룰베이스 점수 → 시간 3구간 Top N → LLM이 6~9개 확정
+  6. Diff 압축: import/getter/포맷/어노테이션 제거, 10KB 초과 시 CodeIndex 대체
+  7. Token Budget Enforcer가 강제 캡
+  8. XML batch_data로 1회 호출 (Markdown은 Context Bleeding 발생)
+  9. JSON 절단 시 TruncatedJsonArrayRecovery로 부분 저장
+
+  이걸 Slice 2 계획에 어떻게 반영할지 — 결정이 필요한 지점:
+
+  이전 전략은 "Gemini Flash 저토큰 + 수십만 줄 OSS"에 최적화됐어. 우리는
+  Opus/Sonnet 컨텍스트가 훨씬 넉넉하지만, 고품질 압축 원칙은 그대로 가져갈 
+  가치가 있음. 다만 전부 한 슬라이스에 넣으면 Slice 2가 폭발해.
+
+  질문 드릴게요. 두 가지 큰 갈림길:
+
+  Q1. Slice 2의 야심 수준
+  - (A) MVP 얇게: github_projects pre-populated 가정 유지 + 본인 커밋 메시지/PR
+  + 단순 truncation diff. PageRank/AST/Significance/Champion 룰베이스 점수는
+  모두 후속 슬라이스. → 1주 안에 끝남.
+  - (B) 이전 전략 풀 포팅: blobless clone + JavaParser + PageRank + Champion
+  선정 룰 + Token Budget Enforcer + XML batch + JSON 복구. → 2~3주, 슬라이스 2가
+   사실상 "GitHub 분석 전체".
+  - (C) 하이브리드: MVP에 Champion 룰베이스 선정(시간 3구간 Top N) + XML batch
+  출력 포맷 + Token Budget Enforcer만 가져옴. AST/PageRank/blobless clone은
+  후속.
+
+  Q2. XML vs JSON 출력 포맷
+  - 이전 프로젝트는 Context Bleeding 때문에 XML batch_data를 썼는데, Opus 
+  4.7에서도 같은 문제가 발생할까? 내 판단으로는 멀티 repo를 한 호출에 묶을 때만
+  의미 있음. 우리가 (A)/(C) 처럼 per-repo 호출 + 1회 synthesis로 가면 Context
+  Bleeding 자체가 발생할 일이 없어서 JSON Schema validated 그대로 가도 됨. 풀
+  batch (B)로 가면 XML 채택 검토.
+
+  어떤 방향으로 갈지 알려주면 그에 맞춰 plan 파일 다시 씁니다. 개인적으로는 (C) 
+  하이브리드 추천 — Champion 룰베이스 선정과 Token Budget Enforcer는 LLM 호출
+  비용/품질에 직접 영향을 주는 핵심이고, AST/PageRank/clone은 별도 슬라이스로
+  떼도 시스템이 동작함.
+
+> 룰베이스 선정을 없애고 싶어. 솔직히 룰이 그닥 효과적으로 잘 짜기도 힘들고, 잘 
+   짠다고 해도, 사람이 커밋 메시지에 아무거나 쓰는 경우가 너무 많아. 차라리     
+  가벼운 llm 호출로 커밋 메시지 + diff size + 변경된 파일 이름을 보고 경량      
+  모델이 직접 champion을 선택하고 그다음에 본격 분석 들어가는 게 낫지 않아?     
+
+● 동의해. 룰베이스의 한계 정확히 짚었어 — 커밋 메시지 신뢰도가 낮고, ImpactScore
+   같은 휴리스틱은 짜는 비용 대비 정밀도가 떨어져. **2단계 LLM (triage → deep
+  analysis)**가 더 현대적이고 우리 환경(Opus/Sonnet 풀스택)에도 맞아.
+
+  제안하는 구조:
+
+  Stage 1: Triage (Haiku 4.5)
+    입력: 본인 커밋 메타만 — sha, subject, body 첫 200자, 변경 파일 경로 리스트,
+   +/- lines
+    (diff 본문 없음 — 토큰 매우 저렴)
+    출력: { championShas: [...], reasonPerSha: {...} } 6~9개
+
+  Stage 2: Per-Repo Summary (Sonnet/Opus)
+    입력: Champion 커밋들의 압축된 diff + repo 메타
+    출력: RepoSummary JSON (스키마 검증)
+
+  Stage 3: Synthesis (Sonnet/Opus)
+    입력: Static signals + per-repo summaries
+    출력: techTags / depthEstimates / evidences / finalTechProfile
+
+  잠가둘 결정 포인트 — 답해주면 plan에 박아넣을게:
+
+  1. Triage 입력 캡: repo당 최근 N개 커밋만 triage에 보냄. N = ?
+    - (a) 100 — 많지만 Haiku로는 여전히 싸고 (~10KB)
+    - (b) 300 — 장기 프로젝트도 커버, ~30KB
+    - (c) 전체 본인 커밋 — 캡 없음 (위험)
+  2. Triage 폴백: Haiku가 0개 선택하거나 스키마 위반하면?
+    - (a) 시간순 최신 6개로 fallback
+    - (b) +/- lines 절대값 큰 6개로 fallback
+    - (c) LLM_INVALID_RESPONSE 그대로 throw → 사용자가 재시도
+  3. Diff 전처리: Stage 2에 보내기 전에 import/getter/포맷 제거 (이전
+  프로젝트처럼)? 또는 단순 byte cap만?
+    - (a) 단순 byte cap (예: 커밋당 8KB, 초과 시 [...truncated]) — 구현 간단,
+  Opus가 노이즈 잘 견딤
+    - (b) 이전 프로젝트의 Java-aware 압축 (import/포맷 제거) — 품질↑, 구현 복잡,
+   Java 외 언어 미지원
+    - 내 추천: (a). 언어-aware 압축은 후속 슬라이스로.
+  4. Slicing: 이걸 한 슬라이스에 다 넣을지
+    - (A) Slice 2 = Triage + Stage 2 + Stage 3 모두, GitHub HTTP fetcher는
+  여전히 Slice 3로 분리 (테스트는 fixture로 커밋 데이터 주입)
+    - (B) Slice 2 = Stage 2 + Stage 3만, Triage는 Slice 2.5로 분리 (먼저
+  "사용자가 직접 champion 골랐다" 가정으로 동작)
+    - 내 추천: (A). Triage 빠지면 시스템이 의미가 없음. 어차피 fixture 기반
+  테스트라 LLM 호출 1번 더 늘어나는 정도.
+
+  답 주면 plan 파일 commit-based + 2-stage LLM 구조로 다시 씁니다.
+
+> 응, 그리고 참고로 깃허브 분석할 때 유저가 핵심리포를 몇개 직접 선정하는       
+  구조면 좋을 것 같아 체크박스 형태로, 그래서 per-repo마다 triage + selected    
+  champion commits based summary  가 들어가고, 이후에 synthesis 단계에서        
+  per-repo summary + static으로 overall repo analysis를 줌. 근데 triage가       
+  기왕이면 PR이랑 issue, github comment도 점수를 매겨줬으면 좋겠어, 그래서      
+  한정된 컨텍스트 안에서 commit diff, pr, issue comment 등이 전부 다 들어가는   
+  거지. 또                                                                      
+
+● 좋아, 정리되는 그림:
+
+  - 사용자 선택: 체크박스로 핵심 repo N개 직접 지정 (이미 plan의
+  coreRepositories)
+  - Per-repo triage: 커밋만이 아니라 PR + Issue + Issue/PR comment까지 후보 풀에
+   넣고 한 번에 점수 매김
+    - Triage 입력: {type: COMMIT|PR|ISSUE|COMMENT, id, title/subject, body 
+  excerpt, paths?, +/- lines?, authoredByMe}
+    - Triage 출력: champion 항목 6~9개 (혼합 타입 OK — PR 1개 + 커밋 5개 + Issue
+   1개 같은 식)
+  - Per-repo deep summary: 선정된 champion 항목들의 본문(diff/PR body/issue
+  thread)을 byte cap 안에 묶어서 1회 호출
+  - Synthesis: per-repo summary + static signals → 전체 분석
+
+  여기서 자연스럽게 따라오는 것:
+  - RepoContext가 champions: List<ChampionItem>을 가짐 (커밋/PR/이슈 union 타입)
+  - Stage 2 프롬프트가 타입별 섹션을 가짐 (<commits>, <pull_requests>, <issues>)
+  - Token budget이 항목 단위로 잘림 — 우선순위는 triage가 매긴 점수 순
+
+  "또" 다음에 뭐였어? 끊긴 것 같아서 — 마저 듣고 한 번에 plan 파일 다시 쓸게.
+
+> 만약 champion commit으로 예를 들면 'A 라이브러리를 B 방식으로 도입했다' 라는  
+  내용이 선정되는데, 알고 보면 다음에 내가 직접 'A 라이브러리를 B 방식으로 쓰는 
+   건 역시 잘못되어서 C 방식으로 바르게 고쳤다' 이런 커밋을 만들면 어떻게 될까? 
+
+● 좋은 질문 — 이게 commit-based 분석의 가장 큰 함정이야. "Decision Reversal 
+  Problem".
+
+  순진하게 짜면 LLM이 "이 사람은 A 라이브러리를 B 방식으로 도입할 줄 안다"라고
+  자신만만하게 평가하는데, 실제로는 그게 틀린 방식이었고 본인이 직접 폐기한
+  케이스. 이력서/면접에서 거짓말하게 만드는 거니까 치명적.
+
+  대응 방안 3개:
+
+  (1) Triage에 전체 타임라인 시야 주기 (필수)
+  Triage 입력에 본인 커밋 전체 메타데이터를 시간순으로 줌 (subject + paths +
+  size 만이라 토큰 싸다). 프롬프트에:
+
+  ▎ "후속 커밋이 이전 결정을 번복/수정하는 경우, 두 커밋을 arc로 묶어서 함께 
+  ▎ champion으로 선정하라. 단일 결정만 보지 말 것."
+
+  → Triage 출력이 단순 SHA 리스트가 아니라 {championShas, arcs: [{introSha, 
+  revisionShas, claim}]} 구조.
+
+  (2) Stage 2에 "후속 변경" 컨텍스트 강제 주입
+  Champion으로 선정된 커밋이 건드린 파일들에 대해, 그 후 시점의 모든 커밋 
+  subject를 추가로 넣음 (diff 없이 메타만). 프롬프트:
+
+  ▎ "champion 커밋 이후 동일 파일을 수정한 커밋 목록이 함께 제공된다. 이 목록이 
+  ▎ champion의 결정을 번복하는지 평가하고, 번복된 경우 currentStatus: REVERSED 
+  ▎ 또는 EVOLVED로 마킹하라."
+
+  (3) Output schema에 상태 필드 추가
+  RepoSummary.highlights[]가 단순 문자열이 아니라:
+  {
+    "claim": "A 라이브러리를 B 방식으로 도입",
+    "currentStatus": "REVERSED",  // ADOPTED | EVOLVED | REVERSED
+    "evolution": "이후 C 방식으로 재구성됨 (sha abc123)"
+  }
+
+  → Synthesis가 REVERSED 항목은 depthEstimates에서 제외하거나, **"오답을
+  인지하고 수정한 능력"**이라는 별개 신호로 활용.
+
+  더 나가면 (옵션):
+  (4) HEAD 파일 상태 샘플링 — champion이 건드린 키 파일들을 HEAD 시점에서 읽어서
+   Stage 2에 포함. "도입 시점 + 현재 상태"를 둘 다 보여줌. 가장 정확하지만
+  토큰/구현 비용 큼. 후속 슬라이스로 미루는 거 추천.
+
+  ---
+  내 추천: (1)+(2)+(3)을 Slice 2 기본 스펙에 박아넣기. (4)는 명시적 후속
+  슬라이스. 이렇게 하면 "Reversal 문제 인지하고 설계했다"가 면접에서도 자체로
+  자랑 포인트가 됨.
+
+  이대로 plan에 반영할까? 아니면 (4)까지 욕심낼지, 또는 다른 엣지 케이스 더
+  있는지?
+
+> 1234를 아예 후속 슬라이스로 만들어 줘. 처음부터 너무 복잡하게 깃허브 분석을   
+  만들려고 하기보단 일단 분석본이 나오는 걸 보고, 그 이후에 방식을 바꾸고       
+  고도화하는 게 좋을 거 같아.                                                   
+
+● 좋아, Slice 2는 가장 단순한 end-to-end 흐름으로 가고 reversal/arc/HEAD-state는
+   모두 후속으로 뺄게. 플랜 파일 다시 쓴다.
+
+● Updated plan
+  ⎿  Error writing file
+
+  Read 1 file (ctrl+o to expand)
+
+● Updated plan
+  ⎿  /plan to preview
+  ⎿  Tool use rejected
+
+● 좋은 추가 정보. GLM 사용 + 폴백/캡 튜닝은 TODO는 plan에 박을 거고, diff 전처리
+   질문에 먼저 답하면:
+
+  Diff 전처리 옵션 (난이도 순):
+
+  (a) 전처리 없음 — byte cap만 (8KB/item)
+  - 가장 단순. LLM이 노이즈 알아서 무시한다고 믿음.
+  - 위험: lockfile 1개가 50KB라 cap에 걸려서 진짜 코드 변경이 잘림.
+
+  (b) 파일 경로 블랙리스트 (강추)
+  - Diff에서 다음 파일 경로의 hunk를 통째로 drop:
+    - Lockfiles: package-lock.json, yarn.lock, pnpm-lock.yaml, Cargo.lock,
+  Gemfile.lock, go.sum, poetry.lock, gradle.lockfile
+    - Generated/binary: *.min.js, *.min.css, *.map, dist/, build/, *.snap,
+  *.png/*.jpg 등 바이너리 (어차피 텍스트 diff 없음)
+    - Vendored: vendor/, node_modules/ (보통 ignored지만 가끔 들어감)
+  - 언어 불가지론적, 구현 30줄, 효과 큼 (lockfile은 거의 항상 노이즈).
+
+  (c) Hunk 단위 cleanup (언어 불가지론적)
+  - import-only / use-only / require-only hunk drop (라인이 모두
+  import|from|use|require|include로 시작)
+  - whitespace-only hunk drop
+  - generated 마커 hunk drop (@generated, DO NOT EDIT, Code generated by)
+  - 효과 중간, 구현 80줄.
+
+  (d) Java/언어별 AST 파싱 — 이전 프로젝트 수준. Slice 2 범위 밖.
+
+  ---
+  내 추천: (a) + (b) for Slice 2.
+  - (b)가 비용 대비 효과가 압도적 (lockfile 한 번 안 잘리는 것만으로 win).
+  - (c)는 매력적이지만 패턴 매칭 false positive 디버깅이 슬라이스를 늘림. TODO로
+   후속 슬라이스 (Slice 4 품질 강화)에 포함.
+  - (d)는 명시적 out-of-scope.
+
+  이걸로 plan 업데이트하고 ExitPlanMode 갈까? 아니면 (c)도 Slice 2에 넣을까?
+> /export                                                                       
+  ⎿  Conversation exported to: C:\Users\lozy9\IdeaProjects\INT6-Roadmap-Team06\ba
+     ckend\2026-04-28-164531-local-command-caveatcaveat-the-messages-below.txt
+
+> 일단 ab로 slice 2 가고, 대신 나중에 다른 기존 opensource 찾아서 참고하자 일단 
+   내가 예전에 조사해놨던 오픈소스 프로젝트와 전략이야. 일단 이것도 줄게.       
+  github-repo-analyzer (Python) — LangChain + OpenAI로 GitHub repo의 기술적     
+  복잡도를 분석하는 도구야. 아키텍처 참고용                                     
+  PyDriller (Python) — Git 커밋, diff, 개발자 정보를 분석하는 프레임워크.       
+  분석까지 안 함.                                                               
+  gitinspector — 저장소별 작성자 통계 분석 도구. 기여도 추적용이라 목적이 다름. 
+   스택 추출 특화 — 가장 직접적으로 쓸 수 있는 것:                              
+  specfy/stack-analyser — 700개 이상의 기술을 자동 감지해. 언어, SaaS,          
+  클라우드, 인프라, 의존성, 서비스까지 추출. 이게 이 프로젝트 목적에 가장       
+  가까워. 의존성 파일(pom.xml, build.gradle, package.json)뿐 아니라 Dockerfile, 
+   CI 설정, 클라우드 설정까지 스캔해서 기술 스택을 뽑아줘. TypeScript로 되어    
+  있긴 한데, 결과를 참고하거나 로직을 이식할 수 있어. GitHub                    
+  로컬 코드베이스 분석 (정적 분석 + 구조 파악):                                 
+  RepoLens Community Edition — 오픈소스 로컬 분석 엔진. 스택 감지, AST 파싱,    
+  모듈 추출, API 엔드포인트 추출, 의존성 그래프, 아키텍처 요약까지 해. CLI      
+  버전(asharirfan/repo-lens)은 GitHub URL이나 로컬 폴더를 넣으면 스택 감지 →    
+  의존성 파싱 → 아키텍처 요약 → JSON/Markdown 출력을 해줘.                      
+  Node/Python/Go/Rust/Docker 분석기가 플러그인 형태로 되어 있어서 구조를        
+  참고하기 좋아. GitHubGitHub                                                   
+  LLM + 정적 분석 결합:                                                         
+  OpenBMB/RepoAgent — AST로 코드 구조를 독립적으로 분석하고, LLM으로 문서를     
+  생성하는 구조. 정적 분석과 LLM의 역할 분리를 잘 해놨어. 코드 구조는 AST로     
+  결정론적으로 뽑고, 해석/요약은 LLM에 맡기는 패턴이 이 프로젝트의 "1단계 정적  
+  스캔 + 2단계 LLM 요약"이랑 정확히 같은 구조야. GitHub                         
+  haxllo/repolens — Tree-sitter로 AST 파싱하고 Gemini 2.0으로 AI 분석하는 구조. 
+   NestJS 게이트웨이 → BullMQ/Redis 큐 → Python 분석 워커 → Tree-sitter 파서 +  
+  LLM 조합. 아키텍처 참고용으로 좋아. GitHub                                    
+  Repo를 LLM에 먹이기 위한 전처리:                                              
+  Repomix — 전체 repo를 AI 친화적인 단일 파일로 패킹하는 도구. Tree-sitter로    
+  코드 압축해서 토큰 수를 줄이면서 구조는 유지해. 2단계에서 선택된 repo를 LLM에 
+   넣을 때 전처리 도구로 쓸 수 있어. GitHub                                     
+  RepoToTextForLLMs — 비슷한 목적. README 추출, 구조 매핑, 비바이너리 파일 내용 
+   추출해서 LLM 분석용으로 포맷팅. GitHub                                       
+                                                                                
+  현실적 추천:                                                                  
+  1단계(전체 스캔)에는 specfy/stack-analyser의 감지 로직을 참고해서             
+  hub4j/github-api 위에 스택 감지를 구현하면 돼. 700개 기술의 감지 패턴을       
+  처음부터 만들 필요 없이 specfy의 규칙을 참고할 수 있어.                       
+  2단계(LLM 심층 분석)에는 Repomix 스타일로 선택된 repo를 압축 → LLM에 넘겨서   
+  요약하는 게 가장 실용적이야. RepoAgent의 "AST는 정적으로, 해석은 LLM으로"     
+  역할 분리 패턴도 참고할 만하고.                                               
+  다만 이것들이 대부분 TypeScript/Python이라 Java/Spring Boot 프로젝트에 직접   
+  가져다 쓸 수는 없고, 로직과 패턴을 참고해서 Java로 구현하는 방향이야.         
+  specfy/stack-analyser의 감지 규칙 JSON 같은 건 언어 상관없이 재사용 가능하고. 
+
+● 알았어. (a)+(b) 확정하고, OSS 리서치는 메모리에 저장해서 Slice 3/4에서 다시
+  꺼내쓸게.
+
+  Searched for 1 pattern, listed 1 directory, recalled 1 memory, wrote 2 memories (ctrl+o to expand)
+
+● 이제 plan 파일에 (a)+(b) diff 전처리, GLM, fallback/cap TODO 반영.
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● User approved Claude's plan
+  ⎿  Plan saved to: ~\.claude\plans\zesty-herding-pretzel.md · /plan to edit
+     Plan — Slice 2: GitHub 분석 (Commit-based, 2-stage LLM, TDD)
+
+     Context
+
+     Slice 1 (GitHub OAuth login) 완료/머지됨. 이번 슬라이스는 v1 첫 AI 기능인
+     GitHub 분석의 가장 얇은 end-to-end 흐름을 먼저 통과시킨다. 사용자가 핵심
+     repo를 체크박스로 선정하면, repo별로 본인 커밋 + PR + Issue/Comment를
+     입력으로 경량 LLM이 champion 항목들을 triage하고, 그 champion만 본격 분석에
+      들어간다. 마지막으로 synthesis 단계에서 per-repo 요약 + static signals를
+     합쳐 analysis_payload JSONB를 만든다.
+
+     분석 파이프라인의 고도화(번복/진화 처리, HEAD 파일 상태 샘플링, decision
+     arc, AST/PageRank, blobless clone 등)는 모두 후속 슬라이스로 명시적으로 
+     미룬다. "분석본이 한 번 끝까지 흐르는 것"을 먼저 보고 그다음에 품질을
+     올리자는 결정.
+
+     Scope (locked in):
+     - Full vertical: domain + service + controller + DTOs + integration tests
+     (POST/GET만, PATCH /corrections 별도 슬라이스).
+     - 사용자가 체크박스로 핵심 repo 직접 선정 (DTO: selectedRepositoryIds +
+     coreRepositoryIds).
+     - Stage 1 (Triage): Haiku 4.5. 입력은 본인 커밋/PR/Issue/Comment의
+     메타데이터만 (subject/title, body 발췌, 변경 파일 경로, +/- lines). 출력은
+     champion 6~9개.
+     - Stage 2 (Per-repo Summary): Sonnet/Opus. champion 항목들의 본문(diff/PR
+     body/issue thread)을 byte cap 안에 묶어 1회 호출. 출력은 schema-validated
+     RepoSummary JSON.
+     - Stage 3 (Synthesis): Sonnet/Opus. static signals + 모든 per-repo summary
+     → techTags/depthEstimates/evidences/finalTechProfile.
+     - github_projects + 커밋/PR/Issue 데이터는 fixture로 pre-populated 가정.
+     GitHub HTTP fetcher는 Slice 3.
+     - 룰베이스 점수/PageRank/AST 일체 없음.
+
+     Reference patterns (from NBE8-10-final-Team02/backend)
+
+     Borrow:
+     - Schema-validated LLM 응답: src/main/resources/ai/schema/*.json을
+     JsonSchemaValidator (com.networknt)로 검증.
+     - 프롬프트 템플릿 = classpath resource:
+     src/main/resources/ai/templates/*.v1.txt + ${var} 치환.
+     - 단일 orchestrator 패턴: load → static signals → triage → per-repo deep →
+     synthesis → persist.
+     - Champion 후보를 정밀 선별한다는 발상 자체.
+
+     Drop (이전 프로젝트가 했지만 우리는 안 함):
+     - 룰베이스 ImpactScore (커밋 메시지 신뢰도가 낮아 효과 대비 복잡도가 큼).
+     대신 Stage 1 triage LLM에 위임.
+     - Significance Check 점수 컷. 사용자가 직접 핵심 repo를 고르므로 불필요.
+     - Blobless clone + JavaParser AST + Call Graph PageRank. Slice 2 범위 밖.
+     - Java-aware diff 압축 (import/getter/포맷 제거). Stage 2는 단순 byte
+     cap만.
+     - XML batch_data 출력 포맷. 우리는 per-repo 호출 + per-repo JSON 응답이라
+     Context Bleeding이 발생할 구조가 아님.
+     - @Async + Redis 상태 추적 + 멀티 프로바이더 라우팅. v1 동기 호출 (docs
+     §6.5).
+
+     What already exists (reuse)
+
+     - domain/github/entity/GithubAnalysis.java — analysis_payload JSONB는
+     @JdbcTypeCode(SqlTypes.JSON)로 String 매핑됨. Jackson으로 직렬화한 String을
+      그대로 저장.
+     - domain/github/entity/GithubProject.java — userId, githubConnectionId,
+     repoNodeId, repoFullName, repoUrl, primaryLanguage, defaultBranch,
+     selected, coreRepo, metadataPayload (JSONB).
+     - domain/github/entity/GithubConnection.java — Slice 1에서 추가한
+     accessToken. Slice 2에서는 fixture 가정이라 직접 안 씀 (Slice 3 HTTP
+     fetcher가 사용).
+     - domain/github/repository/GithubAnalysisRepository.java —
+     findMaxVersionByUserId, findTopByUserIdOrderByVersionDescCreatedAtDesc,
+     findByIdAndUserId. 새 메서드 추가 금지.
+     - domain/github/repository/GithubProjectRepository.java —
+     findByUserIdAndGithubConnectionId, findByIdAndUserId. 필요시
+     findAllByIdInAndUserId(List<Long>, Long) 추가 가능.
+     - domain/github/repository/GithubConnectionRepository.java —
+     findByIdAndUserId, existsByIdAndUserId 이미 존재.
+     - external/llm/LlmClient.java — orchestrator는 이 인터페이스에만 의존.
+     AiGatewayLlmClient가 timeout/rate-limit/invalid-response를
+     ServiceException으로 매핑.
+     - global/security/AuthenticatedUser.java, global/exception/ErrorCode.java,
+     global/response/ApiResponse.java.
+     - 테스트 인프라: @IntegrationTest, ApiTestBase,
+     TestcontainersConfiguration, WireMock 3.12.1.
+
+     ErrorCode 신규 추가 필요: LLM_TRIAGE_FAILED (triage가 0개 선정/스키마
+     위반/타임아웃 시).
+
+     데이터 모델 가정 (Slice 2 범위)
+
+     github_projects.metadata_payload JSONB가 다음 형태로 pre-populated 되어
+     있다고 가정 (Slice 3에서 GitHub API로 채울 예정):
+
+     {
+       "commits": [
+         { "sha": "...", "subject": "...", "bodyExcerpt": "...", "paths": [...],
+      "additions": 0, "deletions": 0, "diffExcerpt": "..." }
+       ],
+       "pullRequests": [
+         { "number": 0, "title": "...", "bodyExcerpt": "...", "state": "MERGED",
+      "additions": 0, "deletions": 0 }
+       ],
+       "issues": [
+         { "number": 0, "title": "...", "bodyExcerpt": "...", "state": "CLOSED",
+      "commentExcerpts": [...] }
+       ]
+     }
+
+     → Slice 2 테스트는 이 JSONB를 직접 fixture로 넣어 흐름을 검증. Slice 3가
+     실제 채움.
+
+     Triage / Deep / Synthesis 컨텍스트 캡
+
+     모든 캡은 builder 클래스의 public static final 상수 — 한 곳에서 튜닝.
+
+     Stage 1 (Triage) 입력
+     - repo당 최근 본인 커밋 100개 + PR 50개 + Issue 50개 메타데이터.
+     - 각 항목 표현은 1~3줄 (subject + paths 일부 + size). diff 본문 없음.
+     - 전체 프롬프트 ≤ 20KB. 초과 시 가장 오래된 항목부터 drop, WARN 로그.
+     - 출력 schema: { champions: [{ kind: COMMIT|PR|ISSUE, ref: <sha or number>,
+      reason: <한 줄> }] } 6~9개.
+
+     Stage 2 (Per-repo Summary) 입력
+     - Triage가 고른 champion들의 본문 — 커밋이면 diff, PR이면 body + 핵심
+     review comment, Issue면 thread 발췌.
+     - Diff 전처리 (Slice 2 범위): byte cap + 파일 경로 블랙리스트만.
+       - Blacklist (hunk 통째로 drop): lockfiles (package-lock.json, yarn.lock,
+     pnpm-lock.yaml, Cargo.lock, Gemfile.lock, go.sum, poetry.lock,
+     gradle.lockfile), 생성/번들 (*.min.js, *.min.css, *.map, dist/, build/,
+     *.snap), 바이너리 확장자 (*.png, *.jpg, *.gif, *.ico, *.pdf), vendored
+     (vendor/, node_modules/).
+       - 블랙리스트 통과한 diff에 byte cap 적용.
+       - TODO(slice-4): Hunk 단위 cleanup (import-only / whitespace-only /
+     @generated 마커 hunk drop). Java AST 압축은 더 후속.
+     - 항목당 본문 ≤ 8KB (초과 시 […truncated] 마커). Stage 2 프롬프트 전체 ≤
+     24KB.
+     - 출력 schema: RepoSummary { repoId, repoName, summary, highlights[] }.
+
+     Stage 3 (Synthesis) 입력
+     - Static signals + 모든 per-repo RepoSummary (최대 N=핵심 repo 수).
+     - 프롬프트 전체 ≤ 16KB. 초과 시 각 RepoSummary의 highlights를 앞 3개로
+     압축.
+     - 출력 schema: { techTags[], depthEstimates[], evidences[], 
+     finalTechProfile }.
+
+     Champion Triage 폴백
+
+     Triage가 0개 선정 / 스키마 위반 / 타임아웃 → 시간순 최신 본인 커밋 6개를
+     champion으로 fallback. WARN 로그 + analysis_payload.meta.triageFallback = 
+     true 기록 (디버깅용).
+
+     → 이렇게 해야 LLM 일시 장애로 분석 자체가 죽지 않음. Reversal/품질 이슈는
+     어차피 후속 슬라이스가 다룰 영역.
+
+     Critical files to create
+
+     Production code
+
+     - service/github/AnalysisPayload.java 및 nested records — JSONB top-level +
+      모든 하위 record:
+       - StaticSignals, PrimaryLanguage, RepoSummary, TechTag,
+     DepthEstimate(skillName, GithubDepthLevel level, reason),
+     Evidence(repoName, GithubEvidenceType type, source, summary),
+     UserCorrection, FinalTechProfile, AnalysisMeta(boolean triageFallback).
+       - GithubDepthLevel / GithubEvidenceType 기존 enum 재사용.
+     - service/github/AnalysisPayloadJson.java — Jackson ObjectMapper 한
+     인스턴스로 직렬화/역직렬화. NON_NULL, FAIL_ON_UNKNOWN_PROPERTIES=false.
+     - service/github/RepoMetadata.java 및 nested — metadata_payload JSONB
+     역직렬화 record (CommitItem, PullRequestItem, IssueItem).
+     - service/github/StaticSignalAggregator.java — @Component.
+     aggregate(List<GithubProject>) → StaticSignals. 언어 비율 + activeRepos
+     계산. commitFrequency/contributionPattern은 "WEEKLY"/"CONSISTENT" 하드코딩
+     + TODO(slice-3).
+     - service/github/triage/ChampionTriagePromptBuilder.java — public 상수
+     MAX_PROMPT_BYTES = 20 * 1024, MAX_COMMITS = 100, MAX_PRS = 50, MAX_ISSUES =
+      50. 가장 오래된 항목부터 drop.
+     - service/github/triage/ChampionTriageResponseParser.java —
+     ai/schema/champion-triage.schema.json 검증. champion 개수 < 1 또는 > 9 →
+     스키마 위반.
+     - service/github/triage/ChampionTriageService.java — triage(RepoMetadata, 
+     repoId, repoName) → List<Champion>. 폴백 로직 포함.
+     - service/github/Champion.java — record (Kind kind, String ref, String 
+     reason), enum Kind { COMMIT, PR, ISSUE }.
+     - service/github/summary/DiffPreprocessor.java — public 메서드 String 
+     clean(String unifiedDiff). 파일 경로 블랙리스트 hunk drop. 블랙리스트는
+     public 상수 BLACKLISTED_PATH_PATTERNS.
+     - service/github/summary/RepoSummaryPromptBuilder.java — public 상수
+     MAX_ITEM_BYTES = 8 * 1024, MAX_PROMPT_BYTES = 24 * 1024. 항목 단위로
+     truncate. diff는 DiffPreprocessor.clean() 적용 후 cap.
+     - service/github/summary/RepoSummaryResponseParser.java —
+     ai/schema/repo-summary.schema.json 검증.
+     - service/github/synthesis/SynthesisPromptBuilder.java — public 상수
+     MAX_PROMPT_BYTES = 16 * 1024. overflow 시 highlights 앞 3개로 압축.
+     - service/github/synthesis/SynthesisResponseParser.java —
+     ai/schema/synthesis.schema.json 검증.
+     - service/github/GithubAnalysisService.java — orchestrator:
+     @Transactional
+     public GithubAnalysisResult run(Long userId, Long githubConnectionId,
+                                     List<Long> selectedRepoIds, List<Long>
+     coreRepoIds);
+     - 순서: 연결 소유권 확인 → projects load + selected/core 필터 →
+     StaticSignalAggregator → 각 core repo: ChampionTriageService →
+     RepoSummaryPromptBuilder + LlmClient + parser → 모든 summary 모이면
+     SynthesisPromptBuilder + LlmClient + parser → AnalysisPayload 조립 →
+     version = findMaxVersionByUserId().orElse(0) + 1 → persist → return.
+     - api/github/GithubAnalysisController.java —
+     @RequestMapping("/api/github-analyses"). POST + GET /{id}.
+     - api/github/dto/GithubAnalysisRequest.java — (Long githubConnectionId, 
+     List<Long> selectedRepositoryIds, List<Long> coreRepositoryIds).
+     validation: 핵심 repo는 selected의 부분집합.
+     - api/github/dto/GithubAnalysisResponse.java — API spec §3.3.1 형태.
+     from(GithubAnalysis, AnalysisPayload) 정적 팩토리.
+
+     Resources
+
+     - src/main/resources/ai/templates/champion-triage.v1.txt — Haiku 대상.
+     "본인이 작성한 commit/PR/issue 메타데이터를 보고 기술적으로 가장 의미 있는
+     6~9개를 골라라". 변수: {repoName}, {repoUrl}, {itemsBlock}.
+     - src/main/resources/ai/templates/repo-summary.v1.txt — 변수: {repoName},
+     {primaryLanguage}, {championsBlock}.
+     - src/main/resources/ai/templates/synthesis.v1.txt —
+     GithubDepthLevel/GithubEvidenceType enum 값 인라인.
+     - src/main/resources/ai/schema/champion-triage.schema.json — { champions: 
+     [{kind, ref, reason}] }, kind enum 강제, 길이 1~9.
+     - src/main/resources/ai/schema/repo-summary.schema.json — { repoId, 
+     repoName, summary, highlights[] } required.
+     - src/main/resources/ai/schema/synthesis.schema.json — { techTags[], 
+     depthEstimates[], evidences[], finalTechProfile } required, depth/evidence
+     enum 강제.
+
+     Test code
+
+     - service/github/AnalysisPayloadJsonTest.java — round-trip + unknown field
+     tolerance. ~3.
+     - service/github/RepoMetadataJsonTest.java — JSONB → record 역직렬화. ~2.
+     - service/github/StaticSignalAggregatorTest.java — table-driven. ~4.
+     - service/github/triage/ChampionTriagePromptBuilderTest.java — 캡
+     enforcement, drop 우선순위, 항목 표현 검증. ~4.
+     - service/github/triage/ChampionTriageResponseParserTest.java — happy +
+     스키마 위반 3종. ~4.
+     - service/github/triage/ChampionTriageServiceTest.java — Mockito. happy /
+     0개 선정 → fallback / LLM_TIMEOUT → fallback / 스키마 위반 → fallback. ~4.
+     - service/github/summary/DiffPreprocessorTest.java — 블랙리스트별 hunk
+     drop, 블랙리스트 외 hunk 보존, 빈 diff. ~4.
+     - service/github/summary/RepoSummaryPromptBuilderTest.java — champion
+     종류별 섹션 + 캡 + truncate marker + DiffPreprocessor 호출됨. ~4.
+     - service/github/summary/RepoSummaryResponseParserTest.java — happy +
+     스키마 위반 3종. ~4.
+     - service/github/synthesis/SynthesisPromptBuilderTest.java — 모든
+     RepoSummary embed + overflow → highlights 압축. ~3.
+     - service/github/synthesis/SynthesisResponseParserTest.java — happy +
+     잘못된 enum + 필수 필드 누락. ~4.
+     - service/github/GithubAnalysisServiceTest.java — Mockito. ~6:
+       - 첫 분석 → version=1.
+       - 두 번째 분석 → version=N+1.
+       - 연결 소유권 실패 → FORBIDDEN.
+       - Triage가 모두 fallback → analysis_payload.meta.triageFallback = true로
+     저장됨.
+       - Stage 2 LLM 에러 (LLM_TIMEOUT) → 그대로 surface.
+       - Stage 3 LLM 에러 → 그대로 surface.
+     - api/github/GithubAnalysisControllerTest.java — ApiTestBase + @MockitoBean
+      GithubAnalysisService. ~5:
+       - POST happy / 401 / 빈 selected → 400 / core가 selected 부분집합 아님 →
+     400 / GET happy / GET 404.
+     - service/github/GithubAnalysisFlowIntegrationTest.java — @IntegrationTest
+     + WireMock. AI Gateway 스텁이 triage / per-repo / synthesis 각 단계의
+     canned JSON 반환. 실제 User + GithubConnection + GithubProject
+     (metadata_payload fixture) 삽입 → 서비스 호출 → github_analyses row 검증.
+     ~2.
+
+     TDD sequence
+
+     각 단계: failing test → minimal impl → green → refactor.
+
+     1. AnalysisPayload records + AnalysisPayloadJson round-trip.
+     2. RepoMetadata records + 역직렬화.
+     3. StaticSignalAggregator.
+     4. ChampionTriagePromptBuilder (캡 + drop 우선순위).
+     5. ChampionTriageResponseParser + schema (실패 케이스가 스키마를 끌어냄).
+     6. ChampionTriageService (LlmClient mock + fallback).
+     7. RepoSummaryPromptBuilder (champion 종류별 섹션 + 캡).
+     8. RepoSummaryResponseParser + schema.
+     9. SynthesisPromptBuilder (overflow 압축).
+     10. SynthesisResponseParser + schema.
+     11. GithubAnalysisService (Mockito orchestration).
+     12. GithubAnalysisController + DTOs.
+     13. GithubAnalysisFlowIntegrationTest (WireMock 3-stage 스텁).
+
+     Decisions locked in
+
+     - 개발 중 LLM 프로바이더 = GLM (무료 지원). AiGatewayLlmClient가
+     추상화하므로 application.yml 모델 키만 GLM으로 두면 됨. TODO: 멀티
+     프로바이더 라우팅 (Anthropic/OpenAI fallback)은 별도 슬라이스. 단계별 모델
+     (triage = 경량 모델, deep/synthesis = 상위 모델)도 GLM 라인업 안에서
+     properties로 지정.
+     - Triage 입력 캡: 최근 commits 100 + PRs 50 + issues 50, 프롬프트 ≤ 20KB.
+     TODO: 실제 데이터로 튜닝 (Slice 3 후).
+     - Triage 폴백: 시간순 최신 6개 본인 커밋 + meta.triageFallback=true. TODO:
+     더 똑똑한 폴백 (Slice 4 품질 강화에서 재검토).
+     - Stage 2 캡 + 전처리: diff에 파일경로 블랙리스트 적용 후 항목당 8KB,
+     프롬프트 24KB. Java-aware 압축은 후속.
+     - Stage 3 캡: 16KB. overflow 시 highlights 앞 3개만.
+     - per-repo 호출 + per-repo JSON 응답 구조라 XML batch 불필요. JSON Schema
+     validated.
+     - Synchronous endpoint (docs §6.5).
+     - Version: 같은 트랜잭션에서 max+1. DataIntegrityViolationException →
+     ANALYSIS_FAILED. retry 없음.
+     - Authorization: 모든 read/write가 userId 필터링. 연결 소유권은
+     existsByIdAndUserId로 확인 후 FORBIDDEN (NOT_FOUND 아님 — ID leak 방지).
+     - userCorrections는 생성 시 빈 배열. POST는 corrections 안 받음.
+     - JSON 저장: Jackson 직렬화 String → analysis_payload 컬럼
+     (@JdbcTypeCode(SqlTypes.JSON)로 jsonb 캐스팅).
+     - 신규 ErrorCode: LLM_TRIAGE_FAILED (triage가 fallback조차 실패하는 극단
+     케이스에 한해 surface).
+
+     Verification
+
+     End of slice should pass:
+     1. ./gradlew test — 신규 단위 테스트 모두 green (~45개).
+     2. ./gradlew integrationTest — GithubAnalysisFlowIntegrationTest
+     Testcontainers Postgres + WireMock 위에서 통과. 기존
+     AuthFlowIntegrationTest 등 그대로 green.
+     3. POST → GET round-trip이 stubbed LLM 응답으로 동작하고, 저장된 JSONB가
+     contract appendix shape와 일치.
+     4. Triage fallback 경로가 통합 테스트로 한 번 명시적으로 커버됨
+     (meta.triageFallback=true assertion).
+
+     Out of scope (queued — 명시적 후속 슬라이스)
+
+     - Slice 2.5: PATCH /api/github-analyses/{id}/corrections.
+     - Slice 3 (GitHub HTTP fetcher): GraphQL contributionsCollection + REST
+     commits/PRs/issues로 github_projects.metadata_payload를 실제로 채움.
+     accessToken (Slice 1) 사용. Rate limit 처리 (Redis dry-run + 피드백 루프
+     또는 token bucket).
+     - Slice 4 (Decision Reversal & Quality): 순서대로 (1) Triage에 전체
+     타임라인 시야 + arc 묶기, (2) Stage 2에 후속 커밋 subject 컨텍스트 주입,
+     (3) RepoSummary.highlights[].currentStatus = ADOPTED|EVOLVED|REVERSED, (4)
+     HEAD 시점 키 파일 샘플링, (5) Hunk 단위 diff cleanup (import-only /
+     whitespace-only / @generated), (6) 멀티 프로바이더 라우팅 + 더 똑똑한
+     triage 폴백, (7) 실데이터 기반 캡 튜닝. 단계별로 별도 슬라이스 가능. OSS
+     참고: specfy/stack-analyser, RepoAgent, Repomix (memory
+     github_analysis_oss_references.md 참고).
+     - Slice 5: 역량 진단 (analysis_payload.finalTechProfile 소비).
+     - Slice 6: 학습 로드맵.
+     - 비동기 잡 모델, 멀티 프로바이더 라우팅, 실
+     commitFrequency/contributionPattern 추출, blobless clone, JavaParser AST,
+     Call Graph PageRank, Java-aware diff 압축, XML batch_data,
+     TruncatedJsonArrayRecovery.
+
+● Plan 승인됨. TDD Step 1부터 시작 — AnalysisPayload records + round-trip test.
+  먼저 기존 enum/구조 확인하고 실패 테스트 작성할게.
+
+> 그리고 정적 분석은 어떻게 할 예정이야?repo.getFileContent("pom.xml")으로 의존성이랑,  repo.listLanguages()로 언어 비율을 뽑아오는 거 맞지? 그리고 readme도 triage에 포함해 줘. 
+
+● 좋은 추가야. 답하고 plan/구현에 반영할게.
+
+  1. 정적 분석 방식 — 거의 맞고 좀 더 디테일:
+
+  // Slice 3 fetcher가 metadata_payload에 채울 것:
+  GHRepository repo = github.getRepository(fullName);
+
+  // (a) 언어 바이트 비율 — primary_language보다 정확
+  Map<String, Long> languages = repo.listLanguages();
+  // → {"Java": 12345, "TypeScript": 6789} byte 단위
+
+  // (b) 의존성 파일 — 멀티 언어 대응
+  String[] depFiles = {
+      "pom.xml", "build.gradle", "build.gradle.kts",
+      "package.json", "requirements.txt", "pyproject.toml",
+      "Cargo.toml", "go.mod", "Gemfile"
+  };
+  // 각 파일은 try { repo.getFileContent(path).getContent() } catch 
+  (FileNotFoundException) { skip }
+
+  // (c) README — triage용
+  GHContent readme = repo.getReadme();  // 자동 탐색 (README.md / README.rst 등)
+
+  → 의존성 파싱(pom.xml → groupId:artifactId 추출)은 Slice 3에서
+  specfy/stack-analyser 규칙 참고. Slice 2는 raw content excerpt만 metadata에 
+  들어 있다고 가정하고 fixture로 박음.
+
+  2. README in triage — 추가하지만 후보가 아니라 컨텍스트로:
+
+  README는 "champion 후보"가 아니라 repo 자체의 framing임. Triage 프롬프트의
+  header 섹션에 박아서 LLM이 "이 repo가 뭐 하는 프로젝트인지" 알고
+  commit/PR/issue를 평가하게.
+
+  ## Repository: my-cool-app
+  URL: https://github.com/u/my-cool-app
+  README excerpt:
+  {readme excerpt — 1KB cap}
+
+  ## Candidates (pick 6-9)
+  COMMIT abc123: "feat: add auth middleware" | paths: [src/auth/...] | +120 -10
+  ...
+
+  → RepoMetadata에 readmeExcerpt 추가, Triage 프롬프트 빌더가 header에 포함.
+  README도 Stage 2 deep summary 입력에 포함하면 좋겠지만, 거기는 champion
+  본문만으로 이미 빡빡하니까 Slice 2는 triage에만.
+
+  ---
+  plan 파일 + 구현에 반영할 변경:
+
+  - RepoMetadata 필드 추가: readmeExcerpt: String, languageBytes: Map<String, 
+  Long>, dependencyFiles: List<DependencyFile{path, contentExcerpt}>
+  - StaticSignalAggregator가 primary_language 카운트 대신 languageBytes 합산으로
+   비율 계산 (더 정확). 모든 selected repo의 languageBytes를 더해서 비율.
+  - ChampionTriagePromptBuilder가 header 섹션에 readmeExcerpt 포함, README
+  excerpt cap 1KB.
+  - Slice 3 TODO에 "README/listLanguages/dependency 파일 fetch" 명시.
+
+  plan 파일 빠르게 패치하고 Step 1 (AnalysisPayload + RepoMetadata records)
+  시작할게.
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● Updated plan
+  ⎿  /plan to preview
+
+● 이제 Step 1 시작 — 기존 enum/엔티티 확인 후 AnalysisPayload records 작성.
+  Searched for 3 patterns, read 2 files (ctrl+o to expand)
+
+● 좋아, enum 확인됨. 이제 Step 1의 RED 테스트부터 작성.
+  AnalysisPayloadJsonTest로 round-trip + unknown-field 관용성 검증.
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Tasks 등록 완료. Plan 수정도 다 반영했고 (README 1KB cap,
+  languageBytes/dependencyFiles, RepoMetadata 필드 확장, StaticSignalAggregator
+  시그니처).
+
+  다음 메시지에서 Step 1 시작 — AnalysisPayload records +
+  AnalysisPayloadJsonTest (RED → GREEN → 다음 단계)로 들어갈게. 지금은
+  plan/tasks 정리만 마무리하고 멈춤.
+
+  질문 둘 다 답 정리:
+  - 정적 분석: repo.listLanguages() (byte 단위 정확) + repo.getFileContent()
+  (의존성 파일들, 멀티 언어). Slice 3 fetcher가 실 호출, Slice 2는 fixture 가정.
+  - README in triage: header framing으로 추가 (1KB cap). champion 후보 아님.
+
+> 근데 claude code 같은 llm이 "summarize this repo" 라는 명령을 받으면 뭐부터   
+  하는데? 내 summarizer도 클로드 코드의 방식을 보고 그런 방식으로 할 수는 없나? 
+
+● 엄청 좋은 메타 질문이야. 솔직히 답하면:
+
+  Claude Code가 "summarize this repo" 받으면 하는 것 (관찰 기반):
+
+  1. ls / Glob * — 루트 구조 파악
+  2. README 먼저 읽음 — 가장 빠른 intent 신호
+  3. pom.xml/package.json 읽음 — 스택 파악
+  4. Application.java/index.ts 같은 entry point 샘플링
+  5. 디렉토리 네이밍 보고 대표 파일 몇 개 골라 읽음
+  6. 필요하면 Grep으로 특정 패턴 추격 (라우트, TODO, 핵심 클래스명)
+  7. 반복: 가설 세우고 → 불확실하면 더 파봄
+
+  핵심은 agentic tool-use loop — 단일 프롬프트 요약이 아니라 read/grep을 도구로
+  가진 LLM이 스스로 탐색.
+
+  ---
+  우리 케이스에 가져올 수 있나? 정직한 답: 절반만.
+
+  Agentic이 좋은 점:
+  - 적응적 — 단순 repo 빨리 끝, 복잡한 repo 깊이 파봄
+  - pre-digest 없이도 동작
+  - 시니어 엔지니어가 repo 평가하는 방식 그대로
+
+  우리 v1에서 안 좋은 점:
+
+  1. 비용/지연: 한 repo summary에 tool call 20~50번. 사용자 100명 × repo 5개 =
+  수만 콜. 우리 2-stage 프롬프트는 repo당 2콜.
+  2. 동기 API: docs §6.5 동기. Agentic은 30초~2분이 흔함. 사용자가 기다림.
+  3. 결정적 핵심 미스매치: Claude Code는 HEAD 시점 코드를 읽음. 우리는 "이 
+  사용자가 시간에 걸쳐 무엇을 기여했는지"가 핵심. agentic이 git log 
+  --author=me로 일일이 파봐야 하는데, 그건 우리 pre-digest가 이미 해주는 일.
+  4. GLM tool-use 신뢰도 미지수. Anthropic/OpenAI는 안정적이지만 비용↑.
+  5. Schema validation 어려움. 비결정적 출력.
+
+  ---
+  현실적 절충안 (Slice 4 후보):
+
+  deep-dive(Stage 2) 단계만 bounded agentic loop로 바꿈:
+
+  Triage가 champion 6~9개 고름 (현 구조 유지)
+    ↓
+  Stage 2 = LLM + 작은 툴킷 + 10 iteration cap:
+    - read_file(path)        // 우리가 미리 fetch한 파일만
+    - grep(pattern)           // 같은 풀에서
+    - read_commit_diff(sha)   // champion 외에도 on-demand
+    - list_paths(prefix)
+    ↓
+  LLM이 스스로 탐색 후 RepoSummary JSON 출력 (schema 검증)
+
+  이러면:
+  - Pre-fetch는 "tool이 빠르게 응답하는 캐시" 역할
+  - Iteration cap이 비용/지연 상한 보장
+  - Author-by 데이터는 여전히 우리가 채워줘야 함 (agentic이 GitHub API 직접 치면
+   rate limit 폭사)
+  - README/static 신호는 그대로 활용
+
+  ---
+  결론 추천:
+  - Slice 2는 현재 pre-digest 방식 유지 — 결정적, 스키마 검증, 비용 상한.
+  - Slice 4 (품질 강화)에 "Stage 2 bounded agentic" 옵션 추가 — pre-digest와
+  비교 실험. 데이터 기반으로 둘 중 하나 선택.
+
+  이걸 plan의 Slice 4 후속 항목에 추가할까? 아니면 Slice 2부터 agentic으로
+  가볼래? 후자라면 일정/비용 리스크가 꽤 커지니까 권하진 않아.
+
+> 근데 claude code 같은 llm이 "summarize this repo" 라는 명령을 받으면 뭐부터   
+  하는데? 내 summarizer도 클로드 코드의 방식을 보고 비슷한 방식으로 할 수는     
+  없나?                                                                         
+
+● 다시 질문해줘서 다행. 지난 답이 너무 "안 됨" 위주였어. 좀 더 구체적으로,
+  실제로 Claude Code가 뭘 하는지 단계별로 풀어보고 우리가 따라할 구조도 짤 수
+  있는 만큼 구체화해볼게.
+
+  ---
+  Claude Code가 "summarize this repo" 받으면 (실제 관찰)
+
+  보통 6~10번의 tool call로 끝남 (내가 어제 20~50이라고 한 건 과장이었어):
+
+  1. Glob("**/*.md") → README 위치 파악
+  2. Read("README.md") → intent/도메인 파악
+  3. Read("package.json"|"pom.xml"|"build.gradle") → 스택
+  4. Glob("src/**/*.java") with head_limit → 파일 수/네이밍 감
+  5. Read("Application.java"|"main entry") → wire-up
+  6. Glob("**/*Controller.java"), Glob("**/*Service.java") → 도메인 shape
+  7. Read 대표 컨트롤러/서비스 2~3개 → 패턴 파악
+  8. Glob("**/migration/*.sql") → 데이터 모델
+  9. Grep("@Configuration|@Bean") → 인프라 결정
+  10. 최종 요약 JSON
+
+  핵심: Read 안 한 파일은 모름. 토큰 예산 안에서 무엇을 안 읽고도 결론 낼지 
+  LLM이 스스로 판단.
+
+  ---
+  우리 summarizer를 이 구조로 옮긴다면
+
+  For each core repo:
+    agentic loop (max 10 iterations, 모델 = Sonnet):
+      LLM에게 주는 toolkit:
+        - read_file(path)              // 캐시된 파일만
+        - grep(pattern, path_glob)     // 캐시된 파일만
+        - list_files(prefix)           // repo 전체 트리 (메타만, 가벼움)
+        - read_commit_diff(sha)        // 본인 커밋 풀에서
+        - list_my_commits(limit, since)// 본인 커밋만
+      LLM 응답 = tool call → 실행 → 다음 iteration
+                  or = 최종 RepoSummary JSON → schema validate → 끝
+
+  이 구조의 장점 (지난번에 안 짚은 것):
+  - pre-digest 코드 양 대폭 감소: ChampionTriageService 통째로 사라짐. LLM이
+  스스로 "어떤 커밋이 중요한지" 탐색.
+  - 시니어 엔지니어처럼 평가: README → 스택 → 본인 핵심 커밋 → 테스트/CI 식의
+  자연스러운 깊이 드릴
+  - "이 사용자가 무엇을 했는가"에 맞춘 toolkit (list_my_commits,
+  read_commit_diff)이라 author 신호 살아있음
+
+  진짜 비용 (수정):
+  - repo당 6~10 LLM 호출 × Sonnet ≈ per-repo 비용은 우리 2-stage(2콜)보다 3~5배
+  - 동기 응답 시간: repo당 20~40초. 3개 repo → 1~2분.
+  - GLM 무료 tier에선 부담 적음. 운영 가서 Sonnet 쓰면 비용↑.
+
+  진짜 약점 (수정):
+  - Tool-use API 안정성: GLM이 receipts good enough인지 검증 필요
+  - 테스트: WireMock으로 tool-result도 stub해야 함. 가능하지만 cassette 작성이
+  fixture보다 훨씬 큼
+  - Iteration이 stochastic — 같은 입력에 다른 path. 테스트는 "최종 JSON이 schema
+   만족"만 보고, 내부 path는 안 봄.
+
+  ---
+  솔직한 권고 (이번엔 반대 방향도 진지하게)
+
+  옵션 A — 내 원래 권고: Slice 2 = pre-digest, Slice 4에서 agentic 옵션
+  비교실험.
+
+  옵션 B (지금 진지하게 생각해볼 것): Slice 2를 agentic으로 바로 가기.
+  - 사실 우리가 pre-digest로 짜는 코드(triage prompt, response parser, fallback,
+   summary prompt builder)가 만만찮게 큼. agentic으로 가면 toolkit 5개만
+  구현하면 끝.
+  - 문제는 GLM의 tool-use 안정성을 모른다는 것 하나.
+  - 만약 GLM이 tool use를 깔끔히 한다면 → agentic이 더 작은 코드 + 더 똑똑한
+  결과.
+  - 만약 GLM이 tool use를 못한다면 → 망함.
+
+  중간 지점 — 실용적: 먼저 GLM으로 작은 PoC(repo 1개를 agentic loop로
+  summarize)를 30분 안에 짜본다. 잘 되면 Slice 2를 agentic으로 갈아엎고, 안 되면
+   원래 plan대로.
+
+  이거 하고 싶어? 진짜 30분짜리 PoC라 손해 안 봄. Slice 2 코드 시작 전에
+  이거부터 하면 방향이 확실해짐.
+> 근데 agentic이 더 토큰 사용량이 많은 거 맞지? pre-digest가 더 static해서 더   
+  저렴하고.                                                                     
+
+● 맞아. 확실히 더 많이 써. 거친 숫자로 비교하면:
+
+  Pre-digest (우리 2-stage):
+  - Triage (per repo): ~6K in + 1K out
+  - Stage 2 summary (per repo): ~7K in + 2K out
+  - Stage 3 synthesis (1회): ~5K in + 2K out
+  - 3개 repo 전체: ~44K in + 11K out
+
+  Agentic (10 iteration loop per repo):
+  - iteration마다 이전 대화 전체 + 새 tool result가 누적
+  - iter 1: 1K, iter 5: ~20K, iter 10: ~40~50K
+  - per repo 누적 input ≈ 150~250K (prompt cache 없으면)
+  - prompt cache 들어가면 50~80K로 뚝 떨어짐 (시스템/초반 메시지 hit)
+  - 3개 repo 전체: ~500K~750K in (캐시 없음) / 150~240K (캐시 있음)
+
+  대략 비율:
+  - 캐시 없이: agentic이 10~17배 더 비쌈
+  - 캐시 적극 활용: agentic이 3~5배 더 비쌈
+  - output token도 agentic이 매 iteration마다 응답하니까 더 많음 (tool call JSON
+   + reasoning)
+
+  현실 적용:
+  - GLM 개발용 = 무료니까 비용은 0. 시간/안정성만 신경 쓰면 됨.
+  - 운영 가서 유료 모델 (Sonnet/Opus) = 차이가 진짜로 돈으로 나옴. 사용자 1명
+  분석에 $0.05 vs $0.50 차이 가능.
+
+  그래서 트레이드오프 정리:
+
+  ┌────────┬─────────────────────────────────────┬────────────────────────┐
+  │        │             Pre-digest              │        Agentic         │
+  ├────────┼─────────────────────────────────────┼────────────────────────┤
+  │ 토큰   │ 1x                                  │ 3~17x                  │
+  ├────────┼─────────────────────────────────────┼────────────────────────┤
+  │ 코드량 │ 많음 (parser, builder, schema 다수) │ 적음 (toolkit + loop)  │
+  ├────────┼─────────────────────────────────────┼────────────────────────┤
+  │ 결정성 │ 높음 (테스트 쉬움)                  │ 낮음 (cassette 필요)   │
+  ├────────┼─────────────────────────────────────┼────────────────────────┤
+  │ 적응성 │ 고정                                │ 높음 (시니어처럼 탐색) │
+  ├────────┼─────────────────────────────────────┼────────────────────────┤
+  │ 지연   │ repo당 5~10초                       │ repo당 20~40초         │
+  └────────┴─────────────────────────────────────┴────────────────────────┘
+
+  내 솔직한 권고 (다시):
+  - 운영 비용 신경 쓰면 pre-digest로 Slice 2 가는 게 정답. 결과 품질 차이는
+  가설일 뿐, 실측 전엔 모름.
+  - agentic은 "Slice 4 품질 강화" 때 A/B로 비교 실험 정도가 안전.
+  - 단, 품질 직감이 강하게 agentic 쪽이고 GLM tool-use가 안정적이면 → 갈아엎어도
+   됨.
+
+  그냥 plan대로 pre-digest로 Slice 2 갈까?
+
+> 그러면 일단 pre-digest로 하고, agentic은 나중에 또 따로 만들자.               
+
+● 좋아. plan에 한 줄 추가하고 Step 1 RED 테스트 들어갈게.
+
+● Updated plan
+  ⎿  /plan to preview
+
+● 이제 Step 1 RED — AnalysisPayloadJsonTest 먼저. 테스트 인프라 확인.
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Bash(mkdir -p backend/src/main/java/com/back/coach/service/github
+      backend/src/test/java/com/back/coach/service/github)
+  ⎿  Done
+
+● RED 테스트 작성:
+
+● Write(src\test\java\com\back\coach\service\github\AnalysisPayloadJsonTest.java
+       )
+  ⎿  Wrote 81 lines to src\test\java\com\back\coach\service\github\Analysis
+     PayloadJsonTest.java
+       1 package com.back.coach.service.github;
+       2 
+       3 import com.back.coach.global.code.GithubDepthLevel;
+       4 import com.back.coach.global.code.GithubEvidenceType;
+       5 import org.junit.jupiter.api.DisplayName;
+       6 import org.junit.jupiter.api.Test;
+       7 
+       8 import java.util.List;
+       9 
+      10 import static org.assertj.core.api.Assertions.assertThat;
+     … +87 lines (ctrl+o to expand)
+
+● 이제 GREEN — AnalysisPayload records + AnalysisPayloadJson helper.
+
+● Write(src\main\java\com\back\coach\service\github\AnalysisPayload.java)
+  ⎿  Wrote 45 lines to
+     src\main\java\com\back\coach\service\github\AnalysisPayload.java
+       1 package com.back.coach.service.github;
+       2 
+       3 import com.back.coach.global.code.GithubDepthLevel;
+       4 import com.back.coach.global.code.GithubEvidenceType;
+       5 
+       6 import java.util.List;
+       7 
+       8 public record AnalysisPayload(
+       9         StaticSignals staticSignals,
+      10         List<RepoSummary> repoSummaries,
+     … +39 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\AnalysisPayloadJson.java)
+  ⎿  Wrote 31 lines to
+     src\main\java\com\back\coach\service\github\AnalysisPayloadJson.java
+       1 package com.back.coach.service.github;
+       2 
+       3 import com.fasterxml.jackson.annotation.JsonInclude;
+       4 import com.fasterxml.jackson.core.JsonProcessingException;
+       5 import com.fasterxml.jackson.databind.DeserializationFeature;
+       6 import com.fasterxml.jackson.databind.ObjectMapper;
+       7 import org.springframework.stereotype.Component;
+       8 
+       9 @Component
+      10 public class AnalysisPayloadJson {
+     … +24 lines (ctrl+o to expand)
+
+● 테스트 실행:
+
+● Bash(cd backend && ./gradlew test --tests
+      "com.back.coach.service.github.AnalysisPayloadJsonTest" -q 2>&1 | tail
+      -40)
+  ⎿  /usr/bin/bash: ./gradlew: No such file or directory
+
+  Searched for 1 pattern, listed 2 directories (ctrl+o to expand)
+
+● Bash(cd .. && ./gradlew :backend:test --tests
+      "com.back.coach.service.github.AnalysisPayloadJsonTest" -q 2>&1 | tail
+      -50)
+  ⎿  FAILURE: Build failed with an exception.
+
+     * What went wrong:
+     … +15 lines (ctrl+o to expand)
+
+  Read 1 file (ctrl+o to expand)
+
+● Bash(cd .. && ls *.gradle.kts settings.gradle.kts 2>&1; cat
+      settings.gradle.kts 2>&1 | head -20)
+  ⎿  ls: cannot access '*.gradle.kts': No such file or directory
+     ls: cannot access 'settings.gradle.kts': No such file or directory
+     cat: settings.gradle.kts: No such file or directory
+
+● Bash(pwd; ls -la)
+  ⎿  /c/Users/lozy9/IdeaProjects/INT6-Roadmap-Team06
+     total 782
+     drwxr-xr-x 1 lozy9 197609      0 Apr 28 09:52 .
+     … +16 lines (ctrl+o to expand)
+
+  Listed 3 directories (ctrl+o to expand)
+● cd ..가 working dir을 영구히 옮겼네. 잘못 만든 파일을 올바른 위치로 옮기고
+  정리.
+
+● Bash(cd backend && find ../backend/backend -type f 2>&1; echo "---"; mv
+      backend/backend/src/main/java/com/back/coach/service/github/*
+      backend/src/main/java/com/back/…)
+  ⎿  Error: Exit code 1
+     ---
+     mv: cannot stat 
+     'backend/backend/src/main/java/com/back/coach/service/github/*': No such 
+     file or directory
+     mv: cannot stat 
+     'backend/backend/src/main/java/com/back/coach/service/github/*': No such 
+     file or directory
+
+> also, note any changes in architecture in document, excluding the document 10. 
+
+● 알겠어, 파일 정리하고 테스트 통과시킨 후에 docs 업데이트할게.
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● 파일은 올바른 위치에 있네. 그냥 테스트 실행:
+
+● Bash(cd /c/Users/lozy9/IdeaProjects/INT6-Roadmap-Team06/backend && ./gradlew
+      test --tests "com.back.coach.service.github.AnalysisPayloadJsonTest" -q
+      2>&1 | tail -30)
+  ⎿  WARNING: A terminally deprecated method in sun.misc.Unsafe has been ca
+     lled
+     WARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.
+     … +9 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.AnalysisPayloadJsonTest" 2>&1 | tail -15)
+  ⎿  > Task :compileJava UP-TO-DATE
+     > Task :processResources UP-TO-DATE
+     > Task :classes UP-TO-DATE
+     … +10 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.AnalysisPayloadJsonTest" --rerun-tasks 2>&1
+       | tail -20)
+  ⎿  WARNING: Please consider reporting this to the maintainers of class lo
+     mbok.permit.Permit
+     WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a futur
+     … +22 lines (ctrl+o to expand)
+
+● Step 1 GREEN. 3개 테스트 통과 (round-trip + null omit + unknown-field
+  tolerance).
+
+● 이제 user 요청 — docs 업데이트. 먼저 docs 구조 파악.
+
+  Searched for 3 patterns, read 1 file, listed 1 directory (ctrl+o to expand)
+
+> 아니 파일 위치만이 아니라, 마크다운 파일을 작성하라고 문서정리용 subagent를 실행하던가 해서. 또 이미 있는 파일 추가 외에 새로 local doc을 추가해도 돼 
+
+● 알았어, session-chronicler subagent를 띄울게.
+
+● session-chronicler(Document Slice 2 architecture decisions)
+  ⎿  Done (14 tool uses · 63.7k tokens · 2m 25s)
+  (ctrl+o to expand)
+
+● 문서 정리 완료. session-chronicler가 한 일:
+
+  - 새 문서: docs/11_github_analysis_pipeline.md — Slice 2 파이프라인 아키텍처
+  전부 (3-stage IO 테이블, byte-cap 상수, JSONB shape, diff 블랙리스트, triage
+  fallback, decision reversal 설명, 거부한 대안들의 근거, Slice 2~6 경계 테이블)
+  - 포인터 추가: 04 (function spec), 05 (architecture) — 짧은 blockquote로 doc
+  11 가리킴, 본문은 안 건드림
+  - 인덱스 갱신: 00_bundle_index.md에 doc 11 추가
+  - doc 10은 손 안 댐
+
+  Step 1 (AnalysisPayload + JSON helper)는 이미 GREEN 상태로 끝났고, 다음 Step
+  2부터는 별도 메시지로 가자. 지금은 여기서 멈춤.
+
+> slice 1이 뭔지도 적어야지,                                                    
+
+※ recap: Slice 2 GitHub 분석 파이프라인을 TDD로 구현 중. Step 1 (AnalysisPayload records + Jackson round-trip)은 GREEN, 문서도 docs/11에 정리됨. 다음은 Step 2 — RepoMetadata records + JSONB 역직렬화 테스트 작성. (disable recaps in /config)
+
+> ok do the step 2, but remember to run the session chronicler when             
+  needed(prefer making new documents instead of editing the core 00-10          
+  documents), keep doing the tdd, add brief comments when needed                
+
+● RED 테스트 — RepoMetadata JSONB 역직렬화. 우리가 Slice 3 fetcher에서 채울
+  shape를 정확히 표현하는지 검증.
+
+● Write(src\test\java\com\back\coach\service\github\RepoMetadataJsonTest.java)
+  ⎿  Wrote 79 lines to
+     src\test\java\com\back\coach\service\github\RepoMetadataJsonTest.java
+      1 package com.back.coach.service.github;
+      2 
+      3 import com.fasterxml.jackson.databind.ObjectMapper;
+      4 import org.junit.jupiter.api.DisplayName;
+      5 import org.junit.jupiter.api.Test;
+      6 
+      7 import static org.assertj.core.api.Assertions.assertThat;
+      8 
+      9 class RepoMetadataJsonTest {
+     … +90 lines (ctrl+o to expand)
+● 이제 GREEN — RepoMetadata records.
+
+● Write(src\main\java\com\back\coach\service\github\RepoMetadata.java)
+  ⎿  Wrote 44 lines to
+     src\main\java\com\back\coach\service\github\RepoMetadata.java
+       2 package com.back.coach.service.github;
+       3 import java.util.List;
+       4 import java.util.Map;
+       5 
+       6 // Slice 3 fetcher가 채우는 github_projects.metadata_payload JSO
+         NB의 역직렬화 record.
+       7 // 모든 컬렉션 필드는 누락 가능 (fetcher가 일부만 채울 수 있음).
+       8 public record RepoMetadata(
+       9         String readmeExcerpt,
+      10         Map<String, Long> languageBytes,
+     … +36 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.RepoMetadataJsonTest" --rerun-tasks 2>&1 |
+      tail -15)
+  ⎿  Note: Recompile with -Xlint:deprecation for details.
+
+     > Task :processResources
+     … +15 lines (ctrl+o to expand)
+
+● Step 2 GREEN. 두 테스트 통과 (full payload + 누락 필드 관용).
+
+● Step 2 끝. RepoMetadata (+ 4개 nested records) 추가됨, 아키텍처 변경 없음 (doc
+   11에 이미 shape 명시되어 있어서 chronicler 호출 불필요). 다음 Step 3는 별도
+  메시지로.
+
+> next                                                                          
+
+  Searched for 1 pattern, read 1 file (ctrl+o to expand)
+
+● aggregator를 entity 없이 테스트 가능하게 작은 input record로 받게 함. RED
+  테스트 먼저:
+
+● Write(src\test\java\com\back\coach\service\github\StaticSignalAggregatorTest.j
+       ava)
+  ⎿  Wrote 78 lines to src\test\java\com\back\coach\service\github\StaticSi
+     gnalAggregatorTest.java
+       1 package com.back.coach.service.github;
+       2 
+       3 import org.junit.jupiter.api.DisplayName;
+       4 import org.junit.jupiter.api.Test;
+       5 
+       6 import java.util.List;
+       7 import java.util.Map;
+       8 
+       9 import static org.assertj.core.api.Assertions.assertThat;
+      10 import static org.assertj.core.api.Assertions.within;
+     … +94 lines (ctrl+o to expand)
+
+● GREEN 구현:
+
+● Write(src\main\java\com\back\coach\service\github\StaticSignalAggregator.java)
+  ⎿  Wrote 58 lines to src\main\java\com\back\coach\service\github\StaticSi
+     gnalAggregator.java
+       1 package com.back.coach.service.github;
+       2 
+       3 import org.springframework.stereotype.Component;
+       4 
+       5 import java.util.Comparator;
+       6 import java.util.LinkedHashMap;
+       7 import java.util.List;
+       8 import java.util.Map;
+       9 
+      10 @Component
+     … +63 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.StaticSignalAggregatorTest" --rerun-tasks
+      2>&1 | tail -15)
+  ⎿  Note: Recompile with -Xlint:deprecation for details.
+
+     > Task :processResources
+     … +15 lines (ctrl+o to expand)
+
+● Step 3 GREEN. 4개 테스트 통과 (multi-repo byte ratio + single repo +
+  primary_language fallback + placeholder activity fields).
+
+● 노트할 작은 architecture 변경: aggregator 시그니처가 plan의
+  aggregate(List<GithubProject>, List<RepoMetadata>) 대신
+  aggregate(List<RepoSignalInput>)로 단순화됨 (entity 의존성 제거 → pure unit
+  test). doc 11 한 줄만 짧게 정정할 가치가 있는지 — 음, 호출자(orchestrator)가
+  entity → input 변환 어댑터만 추가하면 되는 거라 doc 11에 명시된 외부 동작은 안
+   바뀜. chronicler 호출 불필요.
+
+  다음 Step 4는 별도 메시지로.
+
+※ recap: Building Slice 2 GitHub 분석 pipeline via TDD; Steps 1-3 (AnalysisPayload, RepoMetadata, StaticSignalAggregator) are GREEN. Next: Step 4, ChampionTriagePromptBuilder with header/candidates sections and byte caps.
+
+> ok continue                                                                   
+
+● Write(src\test\java\com\back\coach\service\github\triage\ChampionTriagePromptB
+       uilderTest.java)
+  ⎿  Wrote 97 lines to src\test\java\com\back\coach\service\github\triage\C
+     hampionTriagePromptBuilderTest.java
+      1 package com.back.coach.service.github.triage;
+      2 
+      3 import com.back.coach.service.github.RepoMetadata;
+      4 import org.junit.jupiter.api.DisplayName;
+      5 import org.junit.jupiter.api.Test;
+      6 
+      7 import java.util.List;
+      8 import java.util.Map;
+      9 import java.util.stream.IntStream;
+     … +115 lines (ctrl+o to expand)
+
+● GREEN 구현:
+
+● Bash(mkdir -p backend/src/main/java/com/back/coach/service/github/triage)
+  ⎿  Done
+● Write(src\main\java\com\back\coach\service\github\triage\ChampionTriagePromptB
+       uilder.java)
+  ⎿  Wrote 116 lines to src\main\java\com\back\coach\service\github\triage\
+     ChampionTriagePromptBuilder.java
+      1 package com.back.coach.service.github.triage;
+      2 
+      3 import com.back.coach.service.github.RepoMetadata;
+      4 import org.slf4j.Logger;
+      5 import org.slf4j.LoggerFactory;
+      6 import org.springframework.stereotype.Component;
+      7 
+      8 import java.util.ArrayList;
+      9 import java.util.List;
+     … +131 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.triage.ChampionTriagePromptBuilderTest"
+      --rerun-tasks 2>&1 | tail -30)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +17 lines (ctrl+o to expand)
+
+● Step 4 GREEN. 4개 테스트 통과 (header+kinds + README truncate + cap byte
+  enforcement + per-kind absolute caps).
+
+● 한 가지 architectural 노트: builder가 "list 끝 = 최신" 가정을 함.
+  fetcher/orchestrator가 시간 역순(오래된 순) 보장 책임 있음. 이건 doc 11에
+  명시할 가치가 있는 작은 invariant인데, 큰 변경은 아니라 다음 chronicler 호출
+  때 같이 묶어서 추가할게. 다음 Step 5는 별도 메시지로.
+
+> continue                                                                      
+
+  Listed 1 directory (ctrl+o to expand)
+
+● Bash(pwd; grep -n "json-schema\|networknt" build.gradle.kts 2>&1; ls
+      src/main/resources/ai 2>&1)
+  ⎿  Error: Exit code 2
+     /c/Users/lozy9/IdeaProjects/INT6-Roadmap-Team06/backend
+     57:  implementation("com.networknt:json-schema-validator:1.5.6")
+     ls: cannot access 'src/main/resources/ai': No such file or directory
+
+● Bash(mkdir -p src/main/resources/ai/schema src/main/resources/ai/templates
+      src/main/java/com/back/coach/service/github/triage
+      src/test/java/com/back/coach/service/gi…)
+  ⎿  Done
+
+● Champion record + Kind enum 먼저:
+
+● Write(src\main\java\com\back\coach\service\github\Champion.java)
+  ⎿  Wrote 7 lines to
+     src\main\java\com\back\coach\service\github\Champion.java
+      1 package com.back.coach.service.github;
+      2 
+      3 // Triage가 고른 champion 후보 1개. ref는 commit이면 sha, PR/issu
+        e면 number string.
+      4 public record Champion(Kind kind, String ref, String reason) {
+      5 
+      6     public enum Kind { COMMIT, PR, ISSUE }
+      7 }
+
+● RED 테스트:
+
+● Write(src\test\java\com\back\coach\service\github\triage\ChampionTriageRespons
+       eParserTest.java)
+  ⎿  Wrote 88 lines to src\test\java\com\back\coach\service\github\triage\C
+     hampionTriageResponseParserTest.java
+      1 package com.back.coach.service.github.triage;
+      2 
+      3 import com.back.coach.global.exception.ErrorCode;
+      4 import com.back.coach.global.exception.ServiceException;
+      5 import com.back.coach.service.github.Champion;
+      6 import org.junit.jupiter.api.DisplayName;
+      7 import org.junit.jupiter.api.Test;
+      8 
+      9 import java.util.List;
+     … +95 lines (ctrl+o to expand)
+
+● Schema 파일 + parser 구현. 먼저 ServiceException/ErrorCode 시그니처 확인.
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Write(src\main\resources\ai\schema\champion-triage.schema.json)
+  ⎿  Wrote 24 lines to
+     src\main\resources\ai\schema\champion-triage.schema.json
+       1 {
+       2   "$schema": "https://json-schema.org/draft/2020-12/schema",
+       3   "title": "ChampionTriageResponse",
+       4   "type": "object",
+       5   "required": ["champions"],
+       6   "additionalProperties": false,
+       7   "properties": {
+       8     "champions": {
+       9       "type": "array",
+      10       "minItems": 1,
+     … +15 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\triage\ChampionTriageRespons
+       eParser.java)
+  ⎿  Wrote 68 lines to src\main\java\com\back\coach\service\github\triage\C
+     hampionTriageResponseParser.java
+       1 package com.back.coach.service.github.triage;
+       2 
+       3 import com.back.coach.global.exception.ErrorCode;
+       4 import com.back.coach.global.exception.ServiceException;
+       5 import com.back.coach.service.github.Champion;
+       6 import com.fasterxml.jackson.databind.JsonNode;
+       7 import com.fasterxml.jackson.databind.ObjectMapper;
+       8 import com.networknt.schema.JsonSchema;
+       9 import com.networknt.schema.JsonSchemaFactory;
+      10 import com.networknt.schema.SpecVersion;
+     … +68 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.triage.ChampionTriageResponseParserTest"
+      --rerun-tasks 2>&1 | tail -25)
+  ⎿          String json = """{"champions": []}""";
+                                          ^
+     C:\Users\lozy9\IdeaProjects\INT6-Roadmap-Team06\backend\src\test\java\
+     … +18 lines (ctrl+o to expand)
+
+● Text block 문법 수정 (개행 필수):
+
+● Update(src\test\java\com\back\coach\service\github\triage\ChampionTriageRespon
+        seParserTest.java)
+  ⎿  Added 1 line, removed 1 line
+      40      @Test
+      41      @DisplayName("champion이 0개면 LLM_INVALID_RESPONSE를 던진
+          다 (minItems=1)")
+      42      void parse_emptyChampions_throws() {
+      43 -        String json = """{"champions": []}""";                 
+      43 +        String json = "{\"champions\": []}";                   
+      44  
+      45          assertThatThrownBy(() -> parser.parse(json))
+      46                  .isInstanceOf(ServiceException.class)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.triage.ChampionTriageResponseParserTest"
+      --rerun-tasks 2>&1 | tail -20)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +17 lines (ctrl+o to expand)
+
+● Step 5 GREEN. 5개 테스트 통과 (valid + empty + too many + invalid kind +
+  missing field).
+● Step 5 끝. Schema 파일 추가됨 (ai/schema/champion-triage.schema.json), parser
+  통과. 다음 Step 6 (ChampionTriageService w/ fallback)는 별도 메시지로.
+
+> continue                                                                      
+
+  Searched for 1 pattern, read 1 file (ctrl+o to expand)
+
+● Write(src\test\java\com\back\coach\service\github\triage\ChampionTriageService
+       Test.java)
+  ⎿  Wrote 116 lines to src\test\java\com\back\coach\service\github\triage\
+     ChampionTriageServiceTest.java
+       1 package com.back.coach.service.github.triage;
+       2 
+       3 import com.back.coach.external.llm.LlmClient;
+       4 import com.back.coach.global.exception.ErrorCode;
+       5 import com.back.coach.global.exception.ServiceException;
+       6 import com.back.coach.service.github.Champion;
+       7 import com.back.coach.service.github.RepoMetadata;
+       8 import org.junit.jupiter.api.BeforeEach;
+       9 import org.junit.jupiter.api.DisplayName;
+      10 import org.junit.jupiter.api.Test;
+     … +125 lines (ctrl+o to expand)
+
+● ErrorCode에 LLM_TRIAGE_FAILED 추가 필요 — 확인:
+
+  Searched for 1 pattern, read 1 file (ctrl+o to expand)
+
+● Update(src\main\java\com\back\coach\global\exception\ErrorCode.java)
+  ⎿  Added 3 lines, removed 1 line
+      30      // LLM 내부 코드 — 호출 지점에서 ANALYSIS_FAILED / ROADMAP_
+          GENERATION_FAILED / RATE_LIMIT_EXCEEDED 로 매핑
+      31      LLM_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "LLM 응답 시간이 초
+          과되었습니다."),
+      32      LLM_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "LLM 호출 제
+          한에 도달했습니다."),
+      33 -    LLM_INVALID_RESPONSE(HttpStatus.BAD_GATEWAY, "LLM 응답을 해
+         -석할 수 없습니다.");                                           
+      33 +    LLM_INVALID_RESPONSE(HttpStatus.BAD_GATEWAY, "LLM 응답을 해
+         +석할 수 없습니다."),                                           
+      34 +    // Triage가 0개 선정/스키마 위반/타임아웃이고 fallback (최 
+         +신 commit 6개)도 불가능할 때만.                                
+      35 +    LLM_TRIAGE_FAILED(HttpStatus.BAD_GATEWAY, "GitHub 분석을 시
+         +작할 활동이 부족합니다.");                                     
+      36  
+      37      private final HttpStatus status;
+      38      private final String defaultMessage;
+
+● 이제 ChampionTriageService 구현:
+
+● Write(src\main\java\com\back\coach\service\github\triage\ChampionTriageService
+       .java)
+  ⎿  Wrote 64 lines to src\main\java\com\back\coach\service\github\triage\C
+     hampionTriageService.java
+       1 package com.back.coach.service.github.triage;
+       2 
+       3 import com.back.coach.external.llm.LlmClient;
+       4 import com.back.coach.global.exception.ErrorCode;
+       5 import com.back.coach.global.exception.ServiceException;
+       6 import com.back.coach.service.github.Champion;
+       7 import com.back.coach.service.github.RepoMetadata;
+       8 import org.slf4j.Logger;
+       9 import org.slf4j.LoggerFactory;
+      10 import org.springframework.stereotype.Service;
+     … +65 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.triage.ChampionTriageServiceTest"
+      --rerun-tasks 2>&1 | tail -20)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +19 lines (ctrl+o to expand)
+
+● Step 6 GREEN. 5개 테스트 통과 (정상 / timeout fallback / 스키마 위반 fallback
+  / commit 6개 미만 / commit 0개면 LLM_TRIAGE_FAILED).
+
+● Architecture 노트 (다음 chronicler 호출 때 doc 11에 묶어 반영할 작은 것들):
+  - ChampionTriageService.triage()가 List<Champion>이 아니라
+  TriageResult(champions, fallback) 반환 — orchestrator가 meta.triageFallback
+  필드 채우려면 이 정보가 필요해서.
+  - 신규 LLM_TRIAGE_FAILED ErrorCode 추가됨 (commit 0개 + LLM 실패 극단 케이스).
+
+  다음 Step 7 (DiffPreprocessor + RepoSummaryPromptBuilder)는 별도 메시지로.
+
+> continue                                                                      
+
+● 먼저 DiffPreprocessor RED 테스트:
+
+● Bash(mkdir -p src/main/java/com/back/coach/service/github/summary
+      src/test/java/com/back/coach/service/github/summary)
+  ⎿  Done
+
+● Write(src\test\java\com\back\coach\service\github\summary\DiffPreprocessorTest
+       .java)
+  ⎿  Wrote 92 lines to src\test\java\com\back\coach\service\github\summary\
+     DiffPreprocessorTest.java
+       2 package com.back.coach.service.github.summary;
+       3 import org.junit.jupiter.api.DisplayName;
+       4 import org.junit.jupiter.api.Test;
+       5 
+       6 import static org.assertj.core.api.Assertions.assertThat;
+       7 
+       8 class DiffPreprocessorTest {
+       9 
+      10     private final DiffPreprocessor preprocessor = new DiffPrepro
+         cessor();
+     … +89 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\summary\DiffPreprocessor.jav
+       a)
+  ⎿  Wrote 86 lines to src\main\java\com\back\coach\service\github\summary\
+     DiffPreprocessor.java
+       2 package com.back.coach.service.github.summary;
+       3 import org.springframework.stereotype.Component;
+       4 
+       5 import java.util.List;
+       6 import java.util.function.Predicate;
+       7 import java.util.regex.Matcher;
+       8 import java.util.regex.Pattern;
+       9 
+      10 // Stage 2 입력 전처리. unified diff에서 노이즈 파일(lockfile/ge
+         nerated/binary/vendored)의 hunk를 통째로 drop.
+     … +86 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.summary.DiffPreprocessorTest" --rerun-tasks
+       2>&1 | tail -25)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +17 lines (ctrl+o to expand)
+
+● DiffPreprocessor GREEN. 이제 RepoSummaryPromptBuilder. 먼저 ResolvedChampion
+  타입 정의 (orchestrator가 RepoMetadata에서 champion ref → body 매칭 결과):
+● Write(src\main\java\com\back\coach\service\github\summary\ResolvedChampion.jav
+       a)
+  ⎿  Wrote 12 lines to src\main\java\com\back\coach\service\github\summary\
+     ResolvedChampion.java
+       2 package com.back.coach.service.github.summary;
+       3 import com.back.coach.service.github.Champion;
+       4 
+       5 // Orchestrator가 Champion (kind+ref) → 실제 본문(diff/PR body/i
+         ssue thread)을 RepoMetadata에서 lookup해 만든 결과.
+       7 public record ResolvedChampion(umb하게 렌더링한다.
+       8         Champion.Kind kind,
+       9         String ref,
+      10         String headline,  // commit subject / PR title / issue t
+         itle
+     … +4 lines (ctrl+o to expand)
+
+● RepoSummaryPromptBuilder 테스트:
+
+● Write(src\test\java\com\back\coach\service\github\summary\RepoSummaryPromptBui
+       lderTest.java)
+  ⎿  Wrote 74 lines to src\test\java\com\back\coach\service\github\summary\
+     RepoSummaryPromptBuilderTest.java
+       1 package com.back.coach.service.github.summary;
+       2 
+       3 import com.back.coach.service.github.Champion;
+       4 import org.junit.jupiter.api.DisplayName;
+       5 import org.junit.jupiter.api.Test;
+       6 
+       7 import java.util.List;
+       8 import java.util.stream.IntStream;
+       9 
+      10 import static org.assertj.core.api.Assertions.assertThat;
+     … +83 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\summary\RepoSummaryPromptBui
+       lder.java)
+  ⎿  Wrote 79 lines to src\main\java\com\back\coach\service\github\summary\
+     RepoSummaryPromptBuilder.java
+      1 package com.back.coach.service.github.summary;
+      2 
+      3 import com.back.coach.service.github.Champion;
+      4 import org.slf4j.Logger;
+      5 import org.slf4j.LoggerFactory;
+      6 import org.springframework.stereotype.Component;
+      7 
+      8 import java.util.List;
+      9 import java.util.Map;
+     … +82 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests "com.back.coach.service.github.summary.*"
+      --rerun-tasks 2>&1 | tail -25)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +17 lines (ctrl+o to expand)
+
+● Step 7 GREEN. 8개 테스트 통과 (DiffPreprocessor 4 + RepoSummaryPromptBuilder
+  4).
+
+● Architecture 노트 (chronicler 호출용 누적):
+  - 새 ResolvedChampion(kind, ref, headline, body) 도입 — orchestrator가
+  Champion (메타) → 본문 매칭 결과를 builder에 넘기는 dumb DTO. Builder가
+  RepoMetadata에 직접 의존하지 않음 = pure renderer.
+  - Champion 우선순위 invariant: triage 반환 순서가 priority. cap 초과 시
+  뒤(낮은 우선순위)부터 drop.
+
+  다음 Step 8 (RepoSummaryResponseParser + schema)는 별도 메시지로.
+
+※ recap: Slice 2 GitHub 분석 파이프라인을 TDD로 구현 중. Step 7까지 GREEN (DiffPreprocessor + RepoSummaryPromptBuilder 완료). 다음은 Step 8 — `RepoSummaryResponseParser` + JSON schema 작성.
+
+> continue                                                                      
+
+● RED 테스트:
+
+● Write(src\test\java\com\back\coach\service\github\summary\RepoSummaryResponseP
+       arserTest.java)
+  ⎿  Wrote 84 lines to src\test\java\com\back\coach\service\github\summary\
+     RepoSummaryResponseParserTest.java
+       2 package com.back.coach.service.github.summary;
+       3 import com.back.coach.global.exception.ErrorCode;
+       4 import com.back.coach.global.exception.ServiceException;
+       5 import com.back.coach.service.github.AnalysisPayload;
+       6 import org.junit.jupiter.api.DisplayName;
+       7 import org.junit.jupiter.api.Test;
+       8 
+       9 import static org.assertj.core.api.Assertions.assertThat;
+      10 import static org.assertj.core.api.Assertions.assertThatThrownBy
+         ;
+     … +83 lines (ctrl+o to expand)
+
+● Write(src\main\resources\ai\schema\repo-summary.schema.json)
+  ⎿  Wrote 17 lines to
+     src\main\resources\ai\schema\repo-summary.schema.json
+       1 {
+       2   "$schema": "https://json-schema.org/draft/2020-12/schema",
+       3   "title": "RepoSummaryResponse",
+       4   "type": "object",
+       5   "required": ["repoId", "repoName", "summary", "highlights"],
+       6   "additionalProperties": false,
+       7   "properties": {
+       8     "repoId": { "type": "string", "minLength": 1 },
+       9     "repoName": { "type": "string", "minLength": 1 },
+      10     "summary": { "type": "string", "minLength": 1 },
+     … +7 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\summary\RepoSummaryResponseP
+       arser.java)
+  ⎿  Wrote 66 lines to src\main\java\com\back\coach\service\github\summary\
+     RepoSummaryResponseParser.java
+       1 package com.back.coach.service.github.summary;
+       2 
+       3 import com.back.coach.global.exception.ErrorCode;
+       4 import com.back.coach.global.exception.ServiceException;
+       5 import com.back.coach.service.github.AnalysisPayload;
+       6 import com.fasterxml.jackson.databind.JsonNode;
+       7 import com.fasterxml.jackson.databind.ObjectMapper;
+       8 import com.networknt.schema.JsonSchema;
+       9 import com.networknt.schema.JsonSchemaFactory;
+      10 import com.networknt.schema.SpecVersion;
+     … +65 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.summary.RepoSummaryResponseParserTest"
+      --rerun-tasks 2>&1 | tail -15)
+  ⎿  Note: Recompile with -Xlint:deprecation for details.
+
+     > Task :processResources
+     … +15 lines (ctrl+o to expand)
+
+● Step 8 GREEN. 4개 통과 (valid + missing summary + empty highlights + wrong
+  type).
+
+● Step 8 끝. Schema + parser 통과, AnalysisPayload.RepoSummary 직접 반환. 다음
+  Step 9 (SynthesisPromptBuilder)는 별도 메시지로.
+
+> continue for rest of the step unless there are problems in the way            
+
+● 알겠어, Step 9 → 13 일괄로 진행. 각 단계 RED→GREEN.
+
+● Step 9: SynthesisPromptBuilder
+
+● Bash(mkdir -p src/main/java/com/back/coach/service/github/synthesis
+      src/test/java/com/back/coach/service/github/synthesis)  ⎿  Done
+
+● Write(src\test\java\com\back\coach\service\github\synthesis\SynthesisPromptBui
+       lderTest.java)
+  ⎿  Wrote 75 lines to src\test\java\com\back\coach\service\github\synthesi
+     s\SynthesisPromptBuilderTest.java
+       1 package com.back.coach.service.github.synthesis;
+       2 
+       3 import com.back.coach.service.github.AnalysisPayload;
+       4 import org.junit.jupiter.api.DisplayName;
+       5 import org.junit.jupiter.api.Test;
+       6 
+       7 import java.util.List;
+       8 import java.util.stream.IntStream;
+       9 
+      10 import static org.assertj.core.api.Assertions.assertThat;
+     … +87 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\synthesis\SynthesisPromptBui
+       lder.java)
+  ⎿  Wrote 65 lines to src\main\java\com\back\coach\service\github\synthesi
+     s\SynthesisPromptBuilder.java
+       1 package com.back.coach.service.github.synthesis;
+       2 
+       3 import com.back.coach.global.code.GithubDepthLevel;
+       4 import com.back.coach.global.code.GithubEvidenceType;
+       5 import com.back.coach.service.github.AnalysisPayload;
+       6 import org.slf4j.Logger;
+       7 import org.slf4j.LoggerFactory;
+       8 import org.springframework.stereotype.Component;
+       9 
+      10 import java.util.Arrays;
+     … +74 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.synthesis.SynthesisPromptBuilderTest"
+      --rerun-tasks 2>&1 | tail -15)
+  ⎿  Note: Recompile with -Xlint:deprecation for details.
+
+     > Task :processResources
+     … +15 lines (ctrl+o to expand)
+
+● Step 9 GREEN.
+
+● Step 10: SynthesisResponseParser + schema
+
+● Write(src\main\resources\ai\schema\synthesis.schema.json)
+  ⎿  Wrote 57 lines to src\main\resources\ai\schema\synthesis.schema.json
+       2   "$schema": "https://json-schema.org/draft/2020-12/schema",
+       3   "title": "SynthesisResponse",
+       4   "type": "object",
+       5   "required": ["techTags", "depthEstimates", "evidences", "final
+         TechProfile"],
+       6   "additionalProperties": false,
+       7   "properties": {
+       8     "techTags": {
+       9       "type": "array",
+      10       "items": {
+     … +52 lines (ctrl+o to expand)
+
+● Write(src\test\java\com\back\coach\service\github\synthesis\SynthesisResponseP
+       arserTest.java)
+  ⎿  Wrote 86 lines to src\test\java\com\back\coach\service\github\synthesi
+     s\SynthesisResponseParserTest.java
+       1 package com.back.coach.service.github.synthesis;
+       2 
+       3 import com.back.coach.global.code.GithubDepthLevel;
+       4 import com.back.coach.global.code.GithubEvidenceType;
+       5 import com.back.coach.global.exception.ErrorCode;
+       6 import com.back.coach.global.exception.ServiceException;
+       7 import org.junit.jupiter.api.DisplayName;
+       8 import org.junit.jupiter.api.Test;
+       9 
+      10 import static org.assertj.core.api.Assertions.assertThat;
+     … +96 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\service\github\synthesis\SynthesisResponseP
+       arser.java)
+  ⎿  Wrote 89 lines to src\main\java\com\back\coach\service\github\synthesi
+     s\SynthesisResponseParser.java
+       1 package com.back.coach.service.github.synthesis;
+       2 
+       3 import com.back.coach.global.code.GithubDepthLevel;
+       4 import com.back.coach.global.code.GithubEvidenceType;
+       5 import com.back.coach.global.exception.ErrorCode;
+       6 import com.back.coach.global.exception.ServiceException;
+       7 import com.back.coach.service.github.AnalysisPayload;
+       8 import com.fasterxml.jackson.databind.JsonNode;
+       9 import com.fasterxml.jackson.databind.ObjectMapper;
+      10 import com.networknt.schema.JsonSchema;
+     … +96 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests "com.back.coach.service.github.synthesis.*"
+      --rerun-tasks 2>&1 | tail -15)
+  ⎿  Note: Recompile with -Xlint:deprecation for details.
+
+     > Task :processResources
+     … +15 lines (ctrl+o to expand)
+
+● Step 10 GREEN.
+
+● Step 11: GithubAnalysisService orchestrator
+
+  먼저 기존 entity 구조 + repository 파악:
+
+  Read 3 files (ctrl+o to expand)
+
+● 먼저 GithubAnalysis에 factory 추가:
+
+● Update(src\main\java\com\back\coach\domain\github\entity\GithubAnalysis.java)
+  ⎿  Added 17 lines
+      41      @CreatedDate
+      42      @Column(name = "created_at", nullable = false, updatable = 
+          false)
+      43      private Instant createdAt;
+      44 +                                                               
+      45 +    public static GithubAnalysis create(Long userId, Long githu
+         +bConnectionId,                                                 
+      46 +                                        int version, String sum
+         +mary, String analysisPayload) {                                
+      47 +        if (userId == null || githubConnectionId == null) {    
+      48 +            throw new IllegalArgumentException("userId/githubCo
+         +nnectionId 는 필수입니다.");                                   
+      49 +        }                                                      
+      50 +        if (version < 1) {                                     
+      51 +            throw new IllegalArgumentException("version 은 1 이
+         +상이어야 합니다.");                                            
+      52 +        }                                                      
+      53 +        GithubAnalysis g = new GithubAnalysis();               
+      54 +        g.userId = userId;                                     
+      55 +        g.githubConnectionId = githubConnectionId;             
+      56 +        g.version = version;                                   
+      57 +        g.summary = summary == null ? "" : summary;            
+      58 +        g.analysisPayload = analysisPayload;                   
+      59 +        return g;                                              
+      60 +    }                                                          
+      61  }
+
+● Orchestrator 테스트 작성:
+
+● Write(src\test\java\com\back\coach\service\github\GithubAnalysisServiceTest.ja
+       va)
+  ⎿  Wrote 205 lines to src\test\java\com\back\coach\service\github\GithubA
+     nalysisServiceTest.java
+       2 package com.back.coach.service.github;
+       3 import com.back.coach.domain.github.entity.GithubAnalysis;
+       4 import com.back.coach.domain.github.entity.GithubProject;
+         ository;om.back.coach.domain.github.repository.GithubAnalysisRep
+       6 import com.back.coach.domain.github.repository.GithubConnectionR
+         epository;
+         sitory;com.back.coach.domain.github.repository.GithubProjectRepo
+       8 import com.back.coach.external.llm.LlmClient;
+       9 import com.back.coach.global.exception.ErrorCode;
+      10 import com.back.coach.global.exception.ServiceException;
+     … +248 lines (ctrl+o to expand)
+
+● ErrorCode에 FORBIDDEN/INVALID_INPUT 있는지 확인:
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● 이제 orchestrator 구현:
+
+● Write(src\main\java\com\back\coach\service\github\GithubAnalysisService.java)  ⎿  Wrote 239 lines to
+     src\main\java\com\back\coach\service\github\GithubAnalysisService.java
+       2 package com.back.coach.service.github;
+       3 import com.back.coach.domain.github.entity.GithubAnalysis;
+       4 import com.back.coach.domain.github.entity.GithubProject;
+         ository;om.back.coach.domain.github.repository.GithubAnalysisRep
+       6 import com.back.coach.domain.github.repository.GithubConnectionR
+         epository;
+         sitory;com.back.coach.domain.github.repository.GithubProjectRepo
+       8 import com.back.coach.external.llm.LlmClient;
+       9 import com.back.coach.global.exception.ErrorCode;
+      10 import com.back.coach.global.exception.ServiceException;
+     … +308 lines (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.GithubAnalysisServiceTest" --rerun-tasks
+      2>&1 | tail -40)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +23 lines (ctrl+o to expand)
+
+● Update(src\test\java\com\back\coach\service\github\GithubAnalysisServiceTest.j
+        ava)
+  ⎿  Added 8 lines, removed 1 line
+      185      }
+      186  
+      187      private static GithubProject makeProject(Long id, String f
+           ullName, String lang, String metadataJson) {
+      188 -        GithubProject p = new GithubProject();                
+      188 +        GithubProject p;                                      
+      189 +        try {                                                 
+      190 +            var ctor = GithubProject.class.getDeclaredConstruc
+          +tor();                                                        
+      191 +            ctor.setAccessible(true);                         
+      192 +            p = ctor.newInstance();                           
+      193 +        } catch (Exception e) {                               
+      194 +            throw new RuntimeException(e);                    
+      195 +        }                                                     
+      196          ReflectionTestUtils.setField(p, "id", id);
+      197          ReflectionTestUtils.setField(p, "userId", USER_ID);
+      198          ReflectionTestUtils.setField(p, "githubConnectionId", 
+           CONNECTION_ID);
+
+● Bash(./gradlew test --tests
+      "com.back.coach.service.github.GithubAnalysisServiceTest" --rerun-tasks
+      2>&1 | tail -40)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +19 lines (ctrl+o to expand)
+
+● Step 11 GREEN. 6개 테스트 통과 (FORBIDDEN, version=1, version=N+1, triage
+  fallback flag, Stage 2 LLM error 전파, core⊄selected).
+
+● Step 12: GithubAnalysisController + DTOs
+
+  Searched for 2 patterns, read 3 files (ctrl+o to expand)
+
+● DTOs + controller + 테스트 작성. 먼저 테스트:
+
+● Bash(mkdir -p src/main/java/com/back/coach/api/github/dto
+      src/test/java/com/back/coach/api/github)
+  ⎿  Done
+
+● Write(src\test\java\com\back\coach\api\github\GithubAnalysisControllerTest.jav
+       a)
+  ⎿  Wrote 157 lines to src\test\java\com\back\coach\api\github\GithubAnaly
+     sisControllerTest.java
+       2 package com.back.coach.api.github;
+       3 import com.back.coach.domain.github.entity.GithubAnalysis;
+       4 import com.back.coach.domain.github.repository.GithubAnalysisRep
+         ository;
+       5 import com.back.coach.domain.user.entity.User;
+       6 import com.back.coach.domain.user.repository.UserRepository;
+       7 import com.back.coach.global.code.AuthProvider;
+       8 import com.back.coach.global.exception.ErrorCode;
+       9 import com.back.coach.global.exception.ServiceException;
+      10 import com.back.coach.global.security.JwtTokenProvider;
+     … +192 lines (ctrl+o to expand)
+
+● DTOs + controller:
+
+● Write(src\main\java\com\back\coach\api\github\dto\GithubAnalysisRequest.java)
+  ⎿  Wrote 13 lines to
+     src\main\java\com\back\coach\api\github\dto\GithubAnalysisRequest.java
+       1 package com.back.coach.api.github.dto;
+       2 
+       3 import jakarta.validation.constraints.NotEmpty;
+       4 import jakarta.validation.constraints.NotNull;
+       5 
+       6 import java.util.List;
+       7 
+       8 public record GithubAnalysisRequest(
+       9         @NotNull Long githubConnectionId,
+      10         @NotEmpty List<Long> selectedRepositoryIds,
+     … +5 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\api\github\dto\GithubAnalysisResponse.java)
+  ⎿  Wrote 45 lines to src\main\java\com\back\coach\api\github\dto\GithubAn
+     alysisResponse.java
+       2 package com.back.coach.api.github.dto;
+       3 import com.back.coach.domain.github.entity.GithubAnalysis;
+       4 import com.back.coach.service.github.AnalysisPayload;
+       5 import com.back.coach.service.github.GithubAnalysisService;
+       6 
+       7 import java.time.Instant;
+       8 import java.util.List;
+       9 
+      10 // API spec §3.3.1 응답 형태. AnalysisPayload의 모든 필드를 평탄
+         화해 반환.
+     … +41 lines (ctrl+o to expand)
+
+● Write(src\main\java\com\back\coach\api\github\GithubAnalysisController.java)
+  ⎿  Wrote 64 lines to
+     src\main\java\com\back\coach\api\github\GithubAnalysisController.java
+       2 package com.back.coach.api.github;
+       3 import com.back.coach.api.github.dto.GithubAnalysisRequest;
+       4 import com.back.coach.api.github.dto.GithubAnalysisResponse;
+       5 import com.back.coach.domain.github.entity.GithubAnalysis;
+       6 import com.back.coach.domain.github.repository.GithubAnalysisRep
+         ository;
+       7 import com.back.coach.global.exception.ErrorCode;
+       8 import com.back.coach.global.exception.ServiceException;
+       9 import com.back.coach.global.response.ApiResponse;
+      10 import com.back.coach.global.security.AuthenticatedUser;
+     … +65 lines (ctrl+o to expand)
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Bash(./gradlew test --tests
+      "com.back.coach.api.github.GithubAnalysisControllerTest" --rerun-tasks
+      2>&1 | tail -40)
+  ⎿  > Task :compileJava
+     Note: Some input files use or override a deprecated API.
+     Note: Recompile with -Xlint:deprecation for details.
+     … +25 lines (ctrl+o to expand)
+
+  Searched for 2 patterns, read 1 file (ctrl+o to expand)
+
+● Bash(./gradlew integrationTest --tests
+      "com.back.coach.api.github.GithubAnalysisControllerTest" 2>&1 | tail -50)
+  ⎿  Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --sta
+     tus for details
+     WARNING: A terminally deprecated method in sun.misc.Unsafe has been ca
+     … +27 lines (ctrl+o to expand)
+
+> I just 'git pull'ed on the dev branch, DO check to make sure the merge/rebase was okay. 
+
+● Step 12 GREEN. 이제 git pull 상태 확인:
+● Bash(git status && echo "---LOG---" && git log --oneline -10)
+  ⎿  On branch dev
+     Your branch is ahead of 'origin/dev' by 4 commits.
+       (use "git push" to publish your local commits)
+     … +20 lines (ctrl+o to expand)
+
+● Bash(git log --oneline b424f56^2 ^b424f56^1 2>&1 | head -20; echo "---FILES
+      MERGED IN---"; git diff --name-only b424f56^1 b424f56 | head -30)
+  ⎿  e48ae04 Merge pull request #74 from Programmers-Intern-Program/chore/l
+     ocal-only-agents-md
+     7a5d215 chore(repo): AGENTS.md 로컬 전용 처리
+     … +48 lines (ctrl+o to expand)
+
+● Merge가 깔끔히 됐어 — 내 작업 영역 (service/github/*, api/github/*,
+  ai/schema/*)은 안 건드림. 충돌 가능성 있는 modified 파일 확인:
+
+● Bash(git log --oneline origin/dev --
+      src/main/java/com/back/coach/global/exception/ErrorCode.java
+      src/main/java/com/back/coach/domain/github/entity/GithubAnalysis.ja…)
+  ⎿  55553cc feat(domain): 결과 이력 저장 엔티티 추가
+     31450f1  Test: 테스트 인프라 셋업 + LLM 클라이언트 골격만   - ErrorCod
+     e Enum -> docs/03_api_spec_aligned.md 어휘에 맞춤 + 해당 마크다운에 없
+     … +6 lines (ctrl+o to expand)
+
+● 내 수정 파일들은 origin 최근 커밋이 안 건드림. 전체 테스트로 회귀 확인:
+
+● Bash(./gradlew test --rerun-tasks 2>&1 | tail -10)
+  ⎿  2026-04-29T09:27:43.833+09:00 INFO  [SpringApplicationShutdownHook] tr
+     aceId=none o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JP
+     A EntityManagerFactory for persistence unit 'default'
+     … +16 lines (ctrl+o to expand)
+
+● Unit tests 전체 GREEN. Step 13 (integration test)으로 진행:
+
+  Step 13: GithubAnalysisFlowIntegrationTest
+
+  Searched for 3 patterns, read 2 files (ctrl+o to expand)
+
+● Write(src\test\java\com\back\coach\service\github\GithubAnalysisFlowIntegratio
+       nTest.java)
+  ⎿  Wrote 129 lines to src\test\java\com\back\coach\service\github\GithubA
+     nalysisFlowIntegrationTest.java
+       2 package com.back.coach.service.github;
+       3 import com.back.coach.domain.github.entity.GithubAnalysis;
+       4 import com.back.coach.domain.github.entity.GithubConnection;
+         ository;om.back.coach.domain.github.repository.GithubAnalysisRep
+       6 import com.back.coach.domain.github.repository.GithubConnectionR
+         epository;
+         sitory;com.back.coach.domain.github.repository.GithubProjectRepo
+       8 import com.back.coach.domain.user.entity.User;
+       9 import com.back.coach.domain.user.repository.UserRepository;
+      10 import com.back.coach.global.code.AuthProvider;
+     … +171 lines (ctrl+o to expand)
+
+● Bash(./gradlew integrationTest --tests
+      "com.back.coach.service.github.GithubAnalysisFlowIntegrationTest" 2>&1 |
+      tail -60)
+  ⎿  > Task :compileJava UP-TO-DATE
+     > Task :processResources UP-TO-DATE
+     > Task :classes UP-TO-DATE
+     … +11 lines (ctrl+o to expand)
+
+● Step 13 GREEN. 통합 테스트 한 번에 통과 (3-stage WireMock 흐름 + DB 영속화 +
+  payload round-trip).
+
+● 마지막으로 전체 테스트 suite (unit + integration) 한 번 더:
+
+● Bash(./gradlew test integrationTest 2>&1 | tail -15)
+  ⎿  > Task :integrationTest
+
+     2026-04-29T09:31:57.253+09:00 INFO  [SpringApplicationShutdownHook] tr
+     … +23 lines (ctrl+o to expand)
+
+● 전체 GREEN. 이제 누적된 architecture 변경을 chronicler에 한 번에 정리해서 새
+  문서로 추가:
+
+● session-chronicler(Document Slice 2 implementation deltas)
+  ⎿  Done (4 tool uses · 35.6k tokens · 1m 58s)
+  (ctrl+o to expand)
+
+● Slice 2 완료 요약
+
+  TDD 13 step 모두 GREEN, 신규 unit test ~36개 + integration test 1개 추가, 기존
+   테스트 회귀 없음.
+
+  구조 (service/github/):
+  - AnalysisPayload (8개 nested record) + AnalysisPayloadJson (Jackson helper)
+  - RepoMetadata (4개 nested) — Slice 3 fetcher가 채울 JSONB shape
+  - StaticSignalAggregator — listLanguages 합산 + primary_language fallback
+  - triage/ — ChampionTriagePromptBuilder + ChampionTriageResponseParser +
+  schema + ChampionTriageService (with fallback)
+  - summary/ — DiffPreprocessor (path 블랙리스트) + RepoSummaryPromptBuilder +
+  parser + ResolvedChampion DTO
+  - synthesis/ — SynthesisPromptBuilder (overflow → highlights 3개 압축) +
+  parser
+  - GithubAnalysisService — orchestrator
+  - api/github/ — GithubAnalysisController + DTOs
+
+  리소스:
+  - ai/schema/champion-triage.schema.json, repo-summary.schema.json,
+  synthesis.schema.json
+
+  기타:
+  - GithubAnalysis.create(...) 팩토리 추가
+  - LLM_TRIAGE_FAILED ErrorCode 추가
+  - git pull 머지 깨끗 (충돌 없음)
+
+  문서:
+  - docs/11_github_analysis_pipeline.md (이전 세션) — 파이프라인 설계
+  - docs/12_github_analysis_implementation_notes.md (이번) — 설계→실구현 deltas
+  12건
+  - docs/00_bundle_index.md 갱신
+
+  이제 다음은 Slice 2.5 (PATCH /corrections) 또는 Slice 3 (GitHub HTTP fetcher)
+  중 하나로 가면 됨.
+
+※ recap: Slice 2 (GitHub 분석 파이프라인 — commit-based, 2-stage LLM, TDD)는 13 step 모두 GREEN으로 끝났고 unit + integration 테스트 다 통과 중이야. 다음은 Slice 2.5 (PATCH /corrections) 또는 Slice 3 (GitHub HTTP fetcher) 중 하나 골라서 시작.
+
+> 이것도 해줘.  이제 내일 멘토링을 하는데 간단하게 적어줘. 피드백 받고 싶은     
+  부분은 없으면 안 적어줘도 돼.멘토링 전 준비사항                               
+    필수 준비                                                                   
+    이번 주 진행 상황 요약 (무엇을 했는지)                                      
+    현재 이슈 및 블로킹 사항 (무엇이 막혀있는지)                                
+    멘토에게 받고 싶은 피드백 항목 (무엇을 물어볼 것인지)                       
+    다음 주 목표 초안                                                           
+                                                                                
+  ● 멘토링 준비 (이번 주)                                                       
+                                                                                
+    1. 이번 주 진행 상황                                                        
+                                                                                
+    - Slice 1 — GitHub OAuth 로그인 + JWT 발급 완료                             
+      - User / github_connections 업서트, JWT access/refresh 토큰을 HttpOnly    
+  쿠키로 발급                                                                   
+      - V3 마이그레이션으로 github_connections.access_token 컬럼 추가 (이후     
+  슬라이스의 GitHub API 호출용)                                                 
+      - 단위/슬라이스/통합 테스트 77개 통과                                     
+    - Slice 1.5 — 인증 보강 완료                                                
+      - 이전 프로젝트(NBE8-10-final-Team02)에서 운영 중 발견된 결함을 사전 차단 
+      - CookieManager(SameSite=Lax, HttpOnly), OAuth state                      
+  라운드트립(redirectUrl 보존), HMAC-서명 쿠키 기반 STATELESS OAuth             
+    저장소(직렬화 RCE 차단), 실패 핸들러, CORS allowCredentials(true)           
+    - 프런트엔드 스모크 테스트 환경 구축                                        
+      - Next.js 15 (App Router, TS) 최소 구성. UI/UX 디자인은 미고려, 인증 흐름 
+   검증 전용                                                                    
+      - 로그인 → /me → 토큰 갱신 → 로그아웃 → 실패 리다이렉트까지 실 브라우저로 
+   확인                                                                         
+    - 문서 정합성                                                               
+      - 03_api_spec_aligned.md 인증 섹션을 실제 동작과 일치시킴 (HttpOnly 쿠키  
+  + Bearer 둘 다 허용)                                                          
+      - 11_github_analysis_pipeline.md 에 Slice 1 / 1.5 선행 슬라이스 요약 +    
+  슬라이스 경계 표 갱신                                                         
+                                                                                
+    2. 현재 이슈 / 블로킹                                                       
+                                                                                
+    - 막혀 있는 항목은 없음. Slice 2 (GitHub 분석 파이프라인) 설계가 마무리되어 
+   구현 진입 단계.                                                              
+    - 의식적으로 미룬 항목:                                                     
+      - 토큰 무효화 (Redis 기반 denylist) — 별도 보안 슬라이스                  
+      - github_connections.access_token 평문 저장 → 암호화 (별도 슬라이스,      
+  TODO(security) 주석 표시)                                                     
+                                                                                
+    3. 멘토에게 받고 싶은 피드백                                                
+                                                                                
+    - OAuth 스코프 시점 결정. 현재 read:user, user:email 만 사용. Slice 2 의    
+  분석에서 private repo 까지 보려면 repo 스코프가 필요한데,                     
+    지금 미리 추가해 첫 로그인부터 동의받을지 / Slice 2 머지 시점에 추가하고    
+  기존 사용자에게 재동의를 요구할지 — 운영 관점에서 권장하는                    
+    시점이 있는지.                                                              
+    - 3-Stage LLM 파이프라인 비용 설계. Stage 1 Triage 는 Haiku 급, Stage 2/3   
+  은 Sonnet 급으로 분리하고 입력 byte cap (1KB / 8KB / 16KB                     
+    / 24KB) 을 단계별로 둠. 사용자 1명당 분석 1회 기준으로 합리적인 수준인지,   
+  혹은 추가로 가드해야 할 지점이 있는지.                                        
+    - Decision Reversal 문제 이연 결정. 사용자가 커밋 A 의 결정을 이후 커밋 B   
+  에서 번복한 경우 잘못된 크레딧이 발생할 수 있다. Slice 2                      
+    에서는 의식적으로 무시하고 Slice 4 의 품질 강화 단계로 미뤘는데, 이         
+  우선순위가 타당한지.                                                          
+                                                                                
+    4. 다음 주 목표 초안                                                        
+                                                                                
+    - Slice 2 — GitHub 분석 파이프라인 구현 완료                                
+      - StaticSignalAggregator, Champion Triage, Per-repo Summary, Synthesis    
+  4단계                                                                         
+      - analysis_payload JSONB 영속화 + version 증가 규칙                       
+      - POST /api/v1/github-analyses / GET /api/v1/github-analyses/{id}         
+  엔드포인트                                                                    
+      - fixture 기반 (실제 GitHub HTTP fetch 는 Slice 3 으로 분리)              
+    - (여유 시) Slice 2.5 시작 — PATCH /corrections 로 사용자 보정값 반영       
+    - 프런트엔드 — Slice 2 응답을 표시할 최소 화면 추가 (여전히 디자인 미고려,  
+  데이터 검증용)                                                                
+
+● 멘토링 준비 (이번 주)
+
+  1. 이번 주 진행 상황
+
+  - Slice 1 — GitHub OAuth 로그인 + JWT 발급 완료
+    - User / github_connections 업서트, JWT access/refresh 토큰을 HttpOnly
+  쿠키로 발급
+    - V3 마이그레이션으로 github_connections.access_token 컬럼 추가
+  - Slice 1.5 — 인증 보강 완료
+    - CookieManager(SameSite=Lax, HttpOnly), OAuth state 라운드트립, HMAC-서명
+  쿠키 기반 STATELESS OAuth 저장소, 실패 핸들러, CORS allowCredentials(true)
+  - 프런트엔드 스모크 테스트 환경 구축
+    - Next.js 15 최소 구성, 실 브라우저로 로그인 → /me → 갱신 → 로그아웃 흐름
+  확인
+  - Slice 2 — GitHub 분석 파이프라인 구현 완료 (이번 주 추가 진행)
+    - 3-Stage LLM 흐름: Stage 1 Triage (Haiku급, commit/PR/issue 메타만 + README
+   framing) → Stage 2 Per-repo Summary → Stage 3 Synthesis
+    - StaticSignalAggregator, ChampionTriageService(폴백 포함),
+  DiffPreprocessor(파일 경로 블랙리스트), 3개 schema-validated parser,
+  GithubAnalysisService orchestrator
+    - POST /api/github-analyses + GET /{id}, analysis_payload JSONB 영속화 +
+  version=N+1
+    - 단위 테스트 ~36개 + WireMock 통합 테스트 1개, 모두 GREEN. fixture 기반 (실
+   GitHub HTTP fetch는 Slice 3으로 분리)
+  - 문서 정합성
+    - docs/11_github_analysis_pipeline.md (설계),
+  docs/12_github_analysis_implementation_notes.md (설계→구현 deltas 12건) 추가
+
+  2. 현재 이슈 / 블로킹
+
+  - 막혀 있는 항목은 없음. Slice 3 (GitHub HTTP fetcher) 진입 단계.
+  - 의식적으로 미룬 항목:
+    - 토큰 무효화 (Redis denylist) — 별도 보안 슬라이스
+    - github_connections.access_token 평문 저장 → 암호화 (TODO(security) 주석
+  표시)
+    - Decision Reversal 처리 (커밋 A의 결정을 B에서 번복한 경우) → Slice 4 품질
+  강화
+
+  3. 멘토에게 받고 싶은 피드백
+
+  - OAuth 스코프 시점 결정. 현재 read:user, user:email만 사용. Slice 3 fetcher가
+   private repo까지 보려면 repo 스코프 필요. 지금 미리 추가해 첫 로그인부터
+  동의받을지 / Slice 3 머지 시점에 기존 사용자 재동의를 요구할지 — 운영 관점
+  권장.
+  - GitHub API rate limit 전략. Slice 3 fetcher가 사용자당 5 repo × ~50 commits
+  → 분석 1회에 GitHub REST 호출 ~250건. 5000 req/hr 한도 내에서 GraphQL
+  contributionsCollection + REST commits 조합 + 캐싱 방향이 적절한지, 동시
+  사용자 수가 늘면 어떤 가드를 둘지.
+  - 3-Stage LLM 비용 설계. Stage 1 (~6K in)·Stage 2 (~7K in/repo)·Stage 3 (~5K
+  in) 캡으로 사용자 1명/repo 3개 기준 약 30~45K in token. GLM 무료 단계는 부담
+  없지만 운영 모델 전환 시 합리적인 수준인지.
+
+  4. 다음 주 목표 초안
+
+  - Slice 3 — GitHub HTTP fetcher 구현
+    - GraphQL contributionsCollection + REST commits/PRs/issues로
+  github_projects.metadata_payload 실데이터 채움
+    - repo.listLanguages() (언어 비율), 의존성 파일(pom.xml/package.json/...),
+  README 수집
+    - Rate limit 처리 (token bucket 또는 Redis 기반 dry-run)
+  - (여유 시) Slice 2.5 — PATCH /api/github-analyses/{id}/corrections
+  - 프런트엔드 — Slice 2 응답을 표시할 최소 화면 (디자인 미고려, 데이터 검증용)
+> 다음 주 목표를 좀 더 나중 슬라이스로 하고, 다른 피드백. 예를 들면 Decision    
+  Reversal과 Agentic vs Digest 방식 비교, 그리고 나중 슬라이스로 미뤄둔 결정    
+  사항을 피드백 받고 싶어. 또 JWT-in-cookie가 나을지도 고민했었잖아.            
+
+● 멘토링 준비 (이번 주)
+
+  1. 이번 주 진행 상황
+
+  - Slice 1 — GitHub OAuth 로그인 + JWT 발급 완료
+    - User / github_connections 업서트, JWT access/refresh 토큰을 HttpOnly
+  쿠키로 발급
+    - V3 마이그레이션으로 github_connections.access_token 컬럼 추가
+  - Slice 1.5 — 인증 보강 완료
+    - CookieManager(SameSite=Lax, HttpOnly), OAuth state 라운드트립, HMAC-서명
+  쿠키 기반 STATELESS OAuth 저장소, 실패 핸들러, CORS allowCredentials(true)
+  - 프런트엔드 스모크 테스트 환경 구축
+    - Next.js 15 최소 구성, 실 브라우저로 로그인 → /me → 갱신 → 로그아웃 흐름
+  확인
+  - Slice 2 — GitHub 분석 파이프라인 구현 완료 (이번 주)
+    - 3-Stage LLM 흐름: Triage(Haiku급, commit/PR/issue 메타 + README framing) →
+   Per-repo Summary → Synthesis
+    - StaticSignalAggregator, ChampionTriageService(폴백 포함),
+  DiffPreprocessor(파일 경로 블랙리스트), 3개 schema-validated parser,
+  GithubAnalysisService orchestrator
+    - POST /api/github-analyses + GET /{id}, analysis_payload JSONB 영속화 +
+  version=N+1
+    - 단위 테스트 ~36개 + WireMock 통합 테스트 1개 GREEN. fixture 기반 (실
+  GitHub HTTP fetch는 Slice 3으로 분리)
+  - 문서 정합성
+    - docs/11_github_analysis_pipeline.md (설계),
+  docs/12_github_analysis_implementation_notes.md (설계→구현 deltas 12건)
+
+  2. 현재 이슈 / 블로킹
+
+  - 막혀 있는 항목은 없음.
+  - 의식적으로 미룬 항목:
+    - 토큰 무효화 (Redis denylist), access_token 암호화 — 보안 슬라이스
+    - Decision Reversal 처리 — Slice 4 품질 강화
+    - Hunk 단위 diff cleanup, agentic Stage 2 비교 실험 — Slice 4
+    - 실제 commitFrequency / contributionPattern 추출 — Slice 3 fetcher
+
+  3. 멘토에게 받고 싶은 피드백
+
+  - Decision Reversal 이연 결정. Champion으로 뽑힌 commit "A 라이브러리를 B
+  방식으로 도입"이 후속 commit "B 잘못이라 C로 수정"으로 번복되는 경우, 현재
+  파이프라인은 잘못된 크레딧을 줄 수 있음. 의식적으로 Slice 4(타임라인 시야 +
+  arc 묶기 + currentStatus = ADOPTED|EVOLVED|REVERSED 필드)로 미뤘는데, MVP 데모
+   시점에서 이 한계를 드러내도 괜찮은지 / 미리 가드를 둬야 하는지.
+  - Agentic vs Pre-digest 방향성. Stage 2 Per-repo Summary를 두 가지 방식으로 짤
+   수 있었음:
+    - (선택한 방식) Pre-digest: triage가 champion 6~9개 미리 선정 → 본문을 byte
+  cap 안에 묶어 1회 호출. 결정적, 스키마 검증 쉬움, 토큰 1x.
+    - (이연) Agentic: LLM에게 read_file/grep/list_files/read_commit_diff toolkit
+   주고 10 iteration 안에 스스로 탐색. Claude Code 방식. 토큰 3~17x, 동기 응답
+  30~60초/repo, 결정성↓.
+
+  GLM 무료 tier에서는 둘 다 가능. 운영 비용/품질 관점에서 pre-digest로 굳히는 게
+   맞는지, 아니면 Slice 4에서 A/B 비교 실험이 가치 있는지.
+  - JWT 전달 방식 — Cookie-only vs Bearer 병행. 현재 accessToken HttpOnly 쿠키 +
+   Authorization 헤더 둘 다 받음. 이전 프로젝트 운영 중 토큰 분실/XSS 우려를
+  봐서 쿠키 쪽이 안전하다고 판단했지만, Bearer 헤더 호환을 남긴 게 mobile/SDK
+  확장성 + 디버깅 편의 vs 공격 표면 확대 사이 트레이드오프. v1에서 헤더 경로를
+  닫는 게 나을지.
+  - 이연 결정들의 우선순위. v1 데모 전에 처리할 것 / v2로 미룰 것 분리:
+    - 토큰 denylist (logout 후 토큰 즉시 무효화 안 됨)
+    - access_token 평문 저장 (DB 노출 시 GitHub API 토큰 유출)
+    - 멀티 프로바이더 라우팅 (GLM 장애 시 fallback 없음)
+    - 비동기 잡 모델 (Slice 2~3 분석이 30초+ 걸리면 사용자 대기)
+    - GitHub API rate limit 강제 (Slice 3 fetcher 도입 시)
+
+  데모 시점 기준 어디까지 v1에 포함하는 게 합리적인지.
+
+  4. 다음 주 목표 초안
+
+  - Slice 5 — 역량 진단 구현 시작
+    - capability_diagnoses 엔티티 + service. 입력은 사용자 프로필 +
+  analysis_payload.finalTechProfile + 직무 기준표
+    - Slice 2의 fixture 데이터로 end-to-end 검증 가능 (Slice 3 fetcher 없이도
+  진행)
+    - 출력 JSONB schema + version 규칙은 Slice 2 패턴 재사용
+  - (병행) Slice 3 — GitHub HTTP fetcher 는 별도 트랙으로 천천히 진행 가능 —
+  분석 정확성과 직결되지만 v1 데모는 fixture로도 흐름 시연 가능
+  - 프런트엔드 — Slice 2 응답을 표시할 최소 화면 (디자인 미고려)
+
+> 조금 더 친절하게  아에 모르는 사람도 처음부터 자세히 알 수 있도록...          
+
+● 멘토링 준비 (이번 주)
+
+  0. 프로젝트 한 줄 소개
+
+  AI Developer Growth Coach — 개발자가 자신의 GitHub 활동을 분석해 (1) 실제 사용
+   기술 프로파일을 만들고, (2) 목표 직무 대비 부족한 역량을 진단받고, (3) 학습
+  로드맵을 받는 서비스. Spring Boot 4 / Java 25 / PostgreSQL 16 모노리스. v1은
+  동기 흐름 + GitHub 중심.
+
+  작업 단위는 슬라이스(Slice) — 한 사용자 흐름이 위(컨트롤러)부터 아래(DB)까지
+  동작하는 최소 단위로 나눠 TDD로 구현. 슬라이스 1 = 로그인, 슬라이스 2 = 분석,
+  식.
+
+  ---
+  1. 이번 주 진행 상황
+
+  Slice 1 — GitHub OAuth 로그인 + JWT 발급 (완료)
+
+  사용자가 "GitHub로 로그인" 클릭 → GitHub 동의 → 우리 서버가 사용자 식별/저장 +
+   자체 JWT(access/refresh) 발급해 HttpOnly 쿠키로 응답. JWT는 이후 모든 보호된
+  API 호출에 사용.
+  - User / github_connections 테이블 업서트
+  - DB 마이그레이션(V3)으로 github_connections.access_token 컬럼 추가 — 향후
+  GitHub API 호출용
+
+  Slice 1.5 — 인증 보강 (완료)
+
+  이전 팀 프로젝트 운영 중 발견된 보안/UX 결함 사전 차단.
+  CookieManager(SameSite=Lax, HttpOnly 강제), OAuth state 파라미터로 redirect
+  URL 라운드트립(로그인 후 원래 가려던 페이지로 복귀), HMAC 서명된 쿠키 기반
+  STATELESS OAuth 저장소(직렬화 RCE 방지), 실패 핸들러, CORS allowCredentials.
+
+  프런트엔드 스모크 테스트 환경 (완료)
+
+  Next.js 15 최소 구성. UI는 일부러 무시, 인증 흐름이 실 브라우저에서 끝까지 
+  동작하는지만 확인용. 로그인 → /me → 토큰 갱신 → 로그아웃 → 실패 리다이렉트
+  모두 통과.
+
+  Slice 2 — GitHub 분석 파이프라인 (이번 주 완료)
+
+  이게 이번 주의 메인 작업. 사용자가 분석할 핵심 repo를 체크박스로 고르면
+  시스템이 그 repo들의 본인 commit/PR/issue를 LLM에 넘겨 "이 사용자가 실제로
+  잘하는 기술 + 깊이"를 추출. 결과는 analysis_payload JSONB 컬럼에 영속화.
+
+  핵심 설계: 3-Stage LLM 파이프라인.
+  1. Triage (경량 모델, Haiku급) — 메타데이터(commit subject + 변경 파일 + +/-
+  lines, README 발췌 등)만 보고 "기술적으로 의미 있는 후보 6~9개" 골라줌. diff
+  본문은 안 보냄 → 토큰 저렴.
+  2. Per-repo Summary (상위 모델) — Triage가 고른 후보의 본문(diff/PR body/issue
+   thread)만 묶어서 1회 호출 → repo별 요약 JSON.
+  3. Synthesis (상위 모델) — 모든 repo 요약 + 정적 신호(언어 비율 등) 합쳐서
+  최종 기술 태그/깊이 추정/근거 생성.
+
+  각 단계마다 byte cap(20KB / 24KB / 16KB)을 두고 초과 시 우선순위 낮은 항목부터
+   drop. 모든 LLM 응답은 JSON Schema로 
+  검증(com.networknt:json-schema-validator). Triage가 0개 선정/타임아웃 시 최신
+  commit 6개로 폴백 + meta.triageFallback=true 플래그 기록.
+
+  테스트: 단위 ~36개 + WireMock 통합 1개 통과. 실제 GitHub API 호출은 Slice 3로
+  분리, Slice 2는 fixture(직접 넣은 JSONB)로 검증.
+
+  문서 정합성
+
+  docs/11_github_analysis_pipeline.md(설계),
+  docs/12_github_analysis_implementation_notes.md(설계→실구현 deltas 12건) 신규
+  작성. 00_bundle_index.md 업데이트.
+
+  ---
+  2. 현재 이슈 / 블로킹
+
+  막혀 있는 항목 없음. 다음 슬라이스 진입 가능.
+
+  의식적으로 미뤄둔 항목 (지금은 안 하기로 결정한 것들):
+  - 토큰 무효화 — 로그아웃해도 만료 전까지 JWT가 유효함. Redis denylist 도입
+  별도 보안 슬라이스.
+  - github_connections.access_token 평문 저장 — DB 노출 시 GitHub API 토큰 유출.
+   암호화 별도 슬라이스.
+  - Decision Reversal 처리 — Slice 4(품질 강화).
+  - Hunk 단위 diff cleanup, agentic Stage 2 비교 실험 — Slice 4.
+  - 실제 commit 빈도/패턴 추출 — 지금은 "WEEKLY"/"CONSISTENT" 하드코딩 stub.
+  Slice 3 fetcher에서 진짜 값.
+
+  ---
+  3. 멘토에게 받고 싶은 피드백
+
+  (A) Decision Reversal 문제를 Slice 4로 미룬 결정
+
+  상황 설명: Triage가 champion으로 commit "A 라이브러리를 B 방식으로 도입"을
+  골라서 Stage 2가 "이 사용자는 A를 B 방식으로 쓸 줄 안다"라고 평가했다고 하자.
+  그런데 사용자가 그 후 "B 방식이 잘못이라 C로 수정"이라는 commit을 만들었으면?
+  현재 파이프라인은 후속 commit을 안 보고 첫 commit만 본다. 결과적으로 사용자가 
+  폐기한 잘못된 접근법을 "할 줄 안다"고 평가해 버림. 면접/이력서 출력에서
+  거짓말이 됨.
+
+  Slice 4에서 계획한 해결: Triage에 전체 타임라인 시야 주기, 같은 파일 건드린
+  후속 commit subject를 Stage 2에 함께 넣기,
+  RepoSummary.highlights[].currentStatus = ADOPTED|EVOLVED|REVERSED 필드 추가,
+  HEAD 시점 키 파일 샘플링.
+
+  질문: 이 문제를 알면서 v1 데모에 안 넣고 가는 게 합리적인가? 아니면 데모 전에
+  최소한의 가드(예: champion 본문에 "이 결정은 후속 N개 commit에서 변경됐을 수
+  있음" 경고 메시지 정도)를 두는 게 나은가?
+
+  (B) Agentic vs Pre-digest 방향성
+
+  용어 설명:
+  - Pre-digest (현 구조): 우리가 미리 데이터 정제(triage로 후보 선정, byte cap,
+  blacklist) 후 LLM에 1회 통째 호출. 결정적, 스키마 검증 쉬움, 토큰 1배.
+  - Agentic: Claude Code가 "이 repo summarize해줘"를 받으면 하는 것. LLM에게
+  read_file/grep/list_files/read_commit_diff 같은 tool을 주고 10번 정도
+  iteration 돌리며 스스로 탐색. 시니어 엔지니어가 repo 평가하듯. 토큰 3~17배,
+  repo당 응답 30~60초, 결정성↓.
+
+  처음에는 agentic에 끌렸지만 (1) 비용 (2) 동기 API 응답 시간 (3) Claude Code는
+  HEAD 코드를 읽지 우리처럼 "사용자가 무엇을 했는지" 시간축 분석은 잘 못함,
+  이유로 pre-digest로 결정.
+
+  질문: 이 결정이 장기적으로도 옳은지. Slice 4에서 agentic 옵션을 A/B
+  실험으로라도 만들어 비교할 가치가 있는지, 아니면 pre-digest 한 방향으로 굳히는
+   게 나은지.
+
+  (C) JWT 전달 방식 — Cookie-only vs Bearer 헤더 병행
+
+  현재 동작: accessToken을 HttpOnly 쿠키로 발급하고, JWT 인증 필터는 쿠키 또는 
+  Authorization 헤더 둘 다 받음. 이전 팀 프로젝트에서 LocalStorage 기반 토큰
+  저장이 XSS 표적이 됐던 경험 때문에 쿠키 쪽이 더 안전하다고 판단해 발급 경로를
+  쿠키로 단일화했음. 다만 헤더 경로를 남긴 건 모바일/외부 SDK/디버깅 편의 가능성
+   때문.
+
+  트레이드오프:
+  - 쿠키 단일: CSRF 위험 (SameSite=Lax로 일부 완화), 모바일/SDK 확장성↓
+  - 헤더 병행: 공격 표면 ↑, 두 경로 동시 유지로 인지 비용 ↑
+
+  질문: v1에서 헤더 경로를 닫는 게 나은지, 아니면 일단 둘 다 열어두고 운영
+  데이터 보고 정리하는 게 나은지.
+
+  (D) 의식적으로 미뤄둔 항목들의 v1 데모 우선순위
+
+  v1 데모 (잠재적 사용자/투자자/팀에게 시연하는 시점) 전에 어디까지 처리하는 게
+  합리적인지:
+
+  ┌─────────────────────┬───────────────────────────────┬────────────────────┐
+  │        항목         │        미처리 시 위험         │     작업 비용      │
+  ├─────────────────────┼───────────────────────────────┼────────────────────┤
+  │ 토큰 denylist       │ 로그아웃해도 토큰 만료 전까지 │ 중 (Redis + 필터)  │
+  │                     │  유효                         │                    │
+  ├─────────────────────┼───────────────────────────────┼────────────────────┤
+  │ access_token 암호화 │ DB 유출 시 GitHub API 토큰    │ 중 (KMS or 환경키) │
+  │                     │ 노출                          │                    │
+  ├─────────────────────┼───────────────────────────────┼────────────────────┤
+  │ 멀티 프로바이더     │ GLM 장애 = 분석 기능 전체     │ 상 (LlmClient      │
+  │ 라우팅              │ 정지                          │ 추상화 확장)       │
+  ├─────────────────────┼───────────────────────────────┼────────────────────┤
+  │ 비동기 잡 모델      │ Slice 2/3 분석이 30초+ 걸리면 │ 상 (큐 + 폴링 API) │
+  │                     │  사용자 화면 멈춤             │                    │
+  ├─────────────────────┼───────────────────────────────┼────────────────────┤
+  │ GitHub API rate     │ Slice 3 fetcher 도입 시 5000  │ 중 (token bucket)  │
+  │ limit 강제          │ req/hr 초과 가능              │                    │
+  └─────────────────────┴───────────────────────────────┴────────────────────┘
+
+  데모 청중/시점에 따라 "보여주기엔 멋있지만 위험 큰" 것 vs "지루하지만 안 하면
+  사고 날" 것 균형이 어디인지.
+
+  ---
+  4. 다음 주 목표 초안
+
+  Slice 5 — 역량 진단 구현 시작. Slice 2가 만든
+  analysis_payload.finalTechProfile + 사용자 프로필 + 직무 기준표를 입력으로 "이
+   사람이 목표 직무 대비 부족한 기술과 우선순위"를 LLM이 진단.
+  capability_diagnoses 엔티티 + service + JSONB 영속화 + version 규칙은 Slice 2
+  패턴 재사용. Slice 2 fixture 데이터로 end-to-end 검증 가능 — Slice 3 fetcher가
+   없어도 진행에 문제 없음.
+
+  (병행) Slice 3 — GitHub HTTP fetcher 는 백그라운드로 천천히 진행. 분석
+  정확성과 직결되지만 v1 데모 흐름 시연은 fixture만으로도 가능해 일정 의존성을
+  끊음.
+
+  프런트엔드 — Slice 2 분석 결과를 표시할 최소 화면 추가 (디자인 미고려, 데이터
+  흐름 검증용).
+
+※ recap: Slice 2 GitHub 분석 파이프라인 (3-Stage LLM)을 구현 완료했고 멘토링 준비 문서를 작성 중입니다. 다음 액션은 사용자가 추가 수정 요청할 부분을 받아 문서 다듬기입니다.
+
+> 더 더 이해하기 쉽게, 아예 기획서 안 읽어도 이해하기 쉽게 해 줘.               
+
+● 멘토링 준비 (이번 주)
+
+  0. 우리 서비스가 뭔지
+
+  개발자가 자기 GitHub 활동을 분석받고, 부족한 기술을 진단받고, 학습 로드맵을
+  받는 AI 코칭 서비스예요.
+
+  사용자 흐름은 이렇게 됩니다:
+  1. GitHub 로그인 → 우리 서버가 사용자 정보를 받아 계정을 만든다
+  2. 분석할 repo를 체크박스로 고른다 → 사용자가 "이게 내 핵심 작업이다" 표시
+  3. 시스템이 그 repo에서 본인이 한 commit/PR/issue를 LLM에 보내 "이 사람이
+  실제로 잘하는 기술이 뭔지" 추출 → DB에 저장
+  4. (다음 슬라이스) 그 결과 + 목표 직무 비교 → "이 기술이 부족하다" 진단
+  5. (그 다음) 진단 기반으로 학습 로드맵 생성
+
+  기술 스택: Spring Boot 4 / Java 25 / PostgreSQL 16. 우리 팀이 작업하는 단위는
+  "슬라이스(Slice)" — 위(API)부터 아래(DB)까지 한 흐름이 동작하는 최소 단위.
+  슬라이스 1 = 로그인, 슬라이스 2 = 분석, 이런 식. 한 슬라이스를 끝내고 다음으로
+   가요.
+
+  ---
+  1. 이번 주에 한 일
+
+  Slice 1 — GitHub 로그인 (완료)
+
+  사용자가 "GitHub로 로그인" 누르면 GitHub에서 동의받고, 우리 서버가 사용자
+  정보를 받아서 계정을 만들고, 우리 서비스용 토큰(JWT)을 만들어 브라우저 쿠키에
+  넣어줘요. 이 토큰이 있어야 이후 API를 부를 수 있어요.
+
+  Slice 1.5 — 로그인 보안 강화 (완료)
+
+  이전 팀 프로젝트 운영하면서 봤던 보안 결함을 미리 막았어요:
+  - 쿠키를 HttpOnly로 (JavaScript에서 못 읽게 → XSS 공격 차단)
+  - SameSite=Lax로 (CSRF 일부 차단)
+  - 로그인 후 원래 가려던 페이지로 복귀하는 기능 (state 파라미터 라운드트립)
+  - OAuth 진행 중 임시 데이터를 쿠키에 서명해서 저장 (서버 메모리 안 씀 =
+  stateless)
+
+  프런트엔드 스모크 테스트 (완료)
+
+  "진짜 브라우저에서 로그인이 끝까지 되나?" 만 확인하는 최소 Next.js 앱.
+  디자인은 신경 안 썼고, 흐름이 깨지지 않는지만 봤어요. 로그인 → 내 정보 조회 →
+  토큰 갱신 → 로그아웃까지 OK.
+
+  Slice 2 — GitHub 분석 (이번 주 메인)
+
+  문제: 사용자의 repo를 LLM에게 통째로 던지면 토큰이 폭발하고(repo 하나가 수십만
+   줄일 수 있음), 결과도 노이즈투성이가 돼요. 그러니 고품질 압축이 핵심.
+
+  우리가 만든 구조 — 3단계 LLM 파이프라인:
+
+  ▎ 1단계: Triage (선별, 싸고 가벼운 모델)
+  ▎ 사용자가 한 commit/PR/issue를 100~200개씩 모아서, 본문 없이 
+  ▎ 메타데이터만(commit 제목, 변경된 파일 이름, +/- 라인 수, README 발췌 등) 
+  ▎ LLM에게 보여주고 묻는다 → "이 중에서 기술적으로 가장 의미 있는 거 6~9개 
+  ▎ 골라줘". diff 본문이 없으니 토큰 매우 저렴.
+  ▎
+  ▎ 2단계: Per-repo Summary (요약, 상위 모델)
+  ▎ Triage가 고른 6~9개의 본문(diff 코드, PR 토론, issue thread)만 묶어서 한 번 
+  ▎ 호출 → "이 사용자가 이 repo에서 뭘 했는지" repo별 요약 JSON 생성.
+  ▎
+  ▎ 3단계: Synthesis (종합, 상위 모델)
+  ▎ 모든 repo 요약 + 정적 신호(언어 비율 등)를 합쳐서 → "이 사용자의 최종 기술 
+  ▎ 프로필" 생성.
+
+  안전장치:
+  - 각 단계마다 입력 크기 상한 (20KB / 24KB / 16KB). 넘으면 우선순위 낮은
+  항목부터 잘라냄.
+  - LLM이 돌려준 JSON은 JSON Schema로 검증 (필드 누락, enum 외 값 → 거부).
+  - Triage가 0개 골라주거나 LLM 타임아웃 → 자동 폴백 (시간순 최신 commit 6개로
+  대체) + "폴백으로 처리됨" 플래그를 결과에 같이 저장.
+  - diff에서 lockfile/번들/이미지/vendored 디렉토리는 블랙리스트로 통째 drop
+  (노이즈 제거).
+
+  API: POST /api/github-analyses (분석 실행) / GET /api/github-analyses/{id}
+  (조회).
+
+  테스트: 단위 ~36개 + WireMock으로 LLM 흉내낸 통합 테스트 1개, 모두 통과. 실제 
+  GitHub API 호출은 다음 슬라이스(3)로 분리 — 이번 슬라이스는 fixture(테스트용
+  가짜 데이터)로 검증.
+
+  문서
+
+  설계 문서 (11_github_analysis_pipeline.md)와 "설계 vs 실제 구현 차이 12건"
+  정리 문서 (12_github_analysis_implementation_notes.md) 작성.
+
+  ---
+  2. 막힌 거
+
+  없어요. 다음 슬라이스로 갈 수 있어요.
+
+  일부러 안 한 것들:
+  - 로그아웃해도 토큰이 만료 전까진 유효함 (서버에서 즉시 무효화 못 함) — Redis
+  denylist 별도 슬라이스
+  - DB의 GitHub access token이 평문 — 암호화 별도 슬라이스
+  - "Decision Reversal" 문제 (아래 (A)에서 설명) — Slice 4 품질 강화
+  - diff에서 import 라인/공백만 있는 hunk 같은 자잘한 정제 — Slice 4
+  - "Agentic" 방식 비교 실험 (아래 (B)에서 설명) — Slice 4
+  - commit 빈도/패턴 진짜 계산 — 지금은 "WEEKLY"/"CONSISTENT" 임시값, Slice 3
+  fetcher에서 진짜 값
+
+  ---
+  3. 멘토에게 묻고 싶은 것
+
+  (A) "Decision Reversal" 문제 — Slice 4로 미뤄도 되나?
+
+  구체적인 시나리오로 설명할게요:
+  - 사용자가 작년 3월에 commit을 만든다: "Spring Security를 세션 기반으로
+  도입했음"
+  - Triage가 이 commit을 champion으로 뽑는다
+  - Stage 2 LLM이 본문 보고 "이 사용자는 Spring Security 세션 인증을 잘
+  다룸"이라고 평가
+  - 그런데 작년 4월에 사용자가 또 commit을 만든다: "세션 방식이 모바일이랑 안
+  맞아서 JWT로 갈아엎음"
+  - 우리 파이프라인은 이 두 번째 commit을 안 본다 → 결과적으로 사용자가 이미 
+  폐기한 잘못된 결정을 "할 줄 안다"고 평가
+
+  이게 면접 답변이나 이력서로 출력되면 거짓말이 돼요. 치명적.
+
+  Slice 4에서 해결할 계획: Triage가 같은 파일 건드린 후속 commit까지 보게 하기,
+  "이 결정은 이후 번복됨/진화됨/유지됨" 상태 필드 추가, HEAD 시점 코드도 같이
+  샘플링.
+
+  질문: 이 문제를 알면서 v1 데모에 안 넣고 가는 게 OK인가? 아니면 임시
+  가드라도(예: 결과에 "이 평가는 과거 시점이며 현재 코드와 다를 수 있음" 면책
+  문구) 넣어야 하나?
+
+  (B) "Agentic" 방식 vs 우리가 선택한 "Pre-digest" 방식
+
+  용어부터:
+  - Pre-digest (우리가 선택한 방식) — 우리 서버 코드가 미리 데이터를 
+  정제해서(triage로 후보 선별, byte cap, blacklist) LLM에 한 번 통째로 호출.
+  결과가 결정적(같은 입력 → 같은 출력에 가깝다), 스키마 검증 쉬움, 토큰 1배.
+  - Agentic — Claude Code가 "이 repo summarize해줘"를 받았을 때 하는 그 방식.
+  LLM에게 read_file/grep/list_files/read_commit_diff 같은 도구를 주고, "스스로 
+  10번 정도 호출하면서 필요한 거 찾아봐" 시킨다. 시니어 엔지니어가 repo를
+  평가하는 자연스러운 방식. 더 똑똑할 수 있음. 하지만 토큰 3~17배, repo 하나당 
+  응답 30~60초, 결과가 매번 조금 다름.
+
+  처음엔 agentic이 멋있어 보였지만 안 한 이유:
+  1. 비용 — GLM 무료 tier는 OK지만 운영 모델로 가면 사용자 1명 분석에 $0.05 vs
+  $0.50 차이
+  2. 응답 시간 — 우리 v1은 동기 API. agentic은 사용자가 1~2분 멍하니 기다림
+  3. 핵심 차이 — Claude Code는 **현재 코드(HEAD)**를 읽음. 우리는 "이 사용자가 
+  시간에 걸쳐 무엇을 기여했는지"가 핵심. agentic은 author 필터를 매번 도구
+  호출로 해야 해서 비효율적
+
+  그래서 pre-digest로 결정했어요.
+
+  질문: 이 결정이 장기적으로도 옳은지? Slice 4에서 agentic 옵션을 만들어 A/B
+  비교해볼 가치가 있는지, 아니면 pre-digest 한 방향으로 굳히는 게 나은지?
+
+  (C) JWT를 쿠키에만 둘지, Authorization 헤더도 받을지
+
+  현재 상태: JWT 토큰을 발급할 때 HttpOnly 쿠키로만 내려주지만, 인증 필터는 쿠키
+   + Authorization 헤더 둘 다 받아요.
+
+  둘 다 받게 한 이유:
+  - 모바일 앱이나 외부 SDK가 나중에 붙을 수 있음 (그쪽은 헤더가 더 자연스러움)
+  - API 디버깅 시 curl/Postman에서 헤더가 편함
+
+  둘 다 열어둔 위험:
+  - 공격 표면이 두 배
+  - "어느 경로로 들어왔는지" 헷갈림
+  - 한쪽 보안 정책 바꿀 때 다른 쪽도 같이 챙겨야 함
+
+  이전 팀 프로젝트 경험: LocalStorage에 토큰 저장하다가 XSS로 토큰 유출된 적
+  있어서 발급은 쿠키로만 했어요.
+
+  질문: v1에서 Authorization 헤더 경로를 닫는 게 나을지, 아니면 일단 둘 다
+  열어두고 운영 데이터 보면서 정리하는 게 나을지?
+
+  (D) "나중에 하기로 한 일들" — v1 데모 전에 어디까지 해야 하나?
+
+  데모(잠재적 사용자나 투자자에게 시연하는 시점) 전에 처리해야 할 게 뭔지 멘토
+  의견을 듣고 싶어요. 각 항목의 위험과 작업 비용:
+
+  ┌────────────────┬──────────────────────────────────────────┬────────────┐
+  │      항목      │         안 하면 무슨 일이 생기나         │ 작업 비용  │
+  ├────────────────┼──────────────────────────────────────────┼────────────┤
+  │                │ 사용자가 로그아웃해도 토큰이 만료        │ 중 (Redis  │
+  │ 토큰 denylist  │ 전까지(15분~1일) 유효. 토큰 탈취당하면   │ + 필터)    │
+  │                │ 로그아웃해도 무력함                      │            │
+  ├────────────────┼──────────────────────────────────────────┼────────────┤
+  │ GitHub access  │ DB가 유출되면 사용자들의 GitHub API      │ 중 (암호화 │
+  │ token 암호화   │ 토큰이 통째로 노출 → 공격자가 사용자     │  키 관리)  │
+  │                │ private repo 접근 가능                   │            │
+  ├────────────────┼──────────────────────────────────────────┼────────────┤
+  │ LLM 멀티       │ 지금은 GLM만 씀. GLM 장애 = 분석 기능    │ 상 (추상화 │
+  │ 프로바이더     │ 전체 정지                                │  확장)     │
+  │ 라우팅         │                                          │            │
+  ├────────────────┼──────────────────────────────────────────┼────────────┤
+  │ 비동기 잡 모델 │ 분석이 30초+ 걸리면 사용자 화면이 그동안 │ 상 (큐 +   │
+  │                │  멈춰있음. timeout 위험도                │ 폴링 API)  │
+  ├────────────────┼──────────────────────────────────────────┼────────────┤
+  │ GitHub API     │ Slice 3 fetcher 도입 시 사용자 늘면 5000 │ 중 (token  │
+  │ rate limit     │  req/hr 한도 초과 가능                   │ bucket)    │
+  │ 가드           │                                          │            │
+  └────────────────┴──────────────────────────────────────────┴────────────┘
+
+  데모 청중/시점이 정해지지 않은 지금 "보여주기엔 화려하지만 위험 큰 것" vs 
+  "지루하지만 안 하면 사고 날 것" 의 균형이 어디인지 감을 잡고 싶어요.
+
+  ---
+  4. 다음 주 목표 (초안)
+
+  Slice 5 — 역량 진단 시작. Slice 2가 만든 분석
+  결과(analysis_payload.finalTechProfile)와 사용자 프로필, 목표 직무 기준표를
+  LLM에 같이 넣어서 "이 사람이 목표 직무 대비 부족한 기술과 우선순위"를 진단.
+  capability_diagnoses 테이블 + 서비스 + JSONB 저장 + version 규칙은 Slice 2
+  패턴 그대로 재사용.
+
+  왜 Slice 3(GitHub HTTP fetcher) 안 하고 Slice 5로 점프? Slice 2를 fixture로
+  만들었기 때문에 fetcher 없이도 분석 결과가 DB에 있음 → Slice 5도 fixture로
+  충분히 진행 가능. Slice 3은 정확성에 직결되지만 v1 흐름 시연에는 필수가 아니라
+   백그라운드로 천천히 진행.
+
+  (병행) Slice 3 — GitHub HTTP fetcher 슬랙 시간에 조금씩.
+
+  프런트엔드 — Slice 2 분석 결과를 표시할 최소 화면 (여전히 디자인 미고려,
+  데이터 검증용).
+
+> 이거 말고 v1완성이 이번 주 목표임. 근데 v1(MVP)가 이번 주에 안 되면 v2의 기능 
+   축소 고려중임.                                                               
+
+● Section 4만 갈아끼우면 돼요:
+
+  ---
+  4. 다음 주 목표 — v1 (MVP) 완성
+
+  이번 주 안에 v1 (MVP) 전체를 동작 가능한 상태로 마무리하는 게 목표예요.
+
+  v1 완성에 남은 슬라이스
+
+  ┌────────────┬───────────────────────────────────────────────┬────────────┐
+  │  슬라이스  │                     내용                      │ 현재 상태  │
+  ├────────────┼───────────────────────────────────────────────┼────────────┤
+  │            │ PATCH /api/github-analyses/{id}/corrections — │ 미착수     │
+  │ Slice 2.5  │  사용자가 분석 결과 수정                      │ (작은      │
+  │            │                                               │ 슬라이스)  │
+  ├────────────┼───────────────────────────────────────────────┼────────────┤
+  │            │ GitHub HTTP fetcher — 진짜 GitHub API에서     │ 미착수 (큰 │
+  │ Slice 3    │ commit/PR/issue/README 가져와                 │  슬라이스) │
+  │            │ metadata_payload JSONB 채움. Rate limit 처리  │            │
+  ├────────────┼───────────────────────────────────────────────┼────────────┤
+  │            │ 역량 진단 — analysis_payload.finalTechProfile │ 미착수     │
+  │ Slice 5    │  + 직무 기준표 → 부족 기술 진단               │ (중간      │
+  │            │                                               │ 슬라이스)  │
+  ├────────────┼───────────────────────────────────────────────┼────────────┤
+  │ Slice 6    │ 학습 로드맵 — 진단 결과 기반으로 주차별 학습  │ 미착수 (큰 │
+  │            │ 계획 생성                                     │  슬라이스) │
+  ├────────────┼───────────────────────────────────────────────┼────────────┤
+  │ 프런트엔드 │ 위 결과들을 표시할 최소 화면 (디자인 미고려)  │ 미착수     │
+  └────────────┴───────────────────────────────────────────────┴────────────┘
+
+  이미 완료: Slice 1, 1.5, 2, 프런트 인증 스모크.
+
+  이번 주에 끝나지 않을 가능성에 대한 대응
+
+  작업량을 정직하게 보면 일주일 안에 위 5개 트랙 전부 끝내기엔 빠듯해요. v1이 
+  이번 주에 안 끝나면 v2 기능을 줄일지 고민 중이에요.
+
+  원래 v2 계획에는 Coach (자율 피드백 루프), Planner (학습 자료 자동 결합),
+  Context Manager 같은 큰 기능이 있어요. 이걸 그대로 가면 v1 마무리 압력 + v2 
+  부담이 동시에 옴 → v1 마지막 일정과 v2 시작 시점이 충돌.
+
+  대응 옵션:
+  1. v2 기능 일부를 v1.5나 v3로 미루기 (Coach 자율 트리거를 단순 버튼 트리거로
+  후퇴 등)
+  2. v2 범위는 유지하고 v1 데모를 부분(예: Slice 6 학습 로드맵을 stub 결과로
+  시연)으로 가기
+  3. v1 일정을 1주 미루고 v2도 그만큼 미루기
+
+  이건 (D) 피드백 항목과 연결돼서 멘토 의견 듣고 정하려고 해요 — 어떤 항목을
+  v1에 꼭 넣어야 하고, 어떤 걸 v2/v3로 미뤄도 데모가 성립하는지.
+
+※ recap: Slice 2 GitHub 분석 파이프라인 13단계 TDD 모두 GREEN으로 끝냈고, 멘토링 준비 문서를 v1 (MVP) 이번 주 완성 목표로 업데이트했어. 다음은 Slice 2.5/3/5/6 중 어디부터 갈지 정하는 것.
+
+> (D) "나중에 하기로 한 일들" —  어디까지 해야 하나?                            
+                                                                                
+  토큰 denylist                                                                 
+                                                                                
+  GitHub access token 암호화                                                    
+                                                                                
+  LLM 멀티 프로바이더                                                           
+                                                                                
+  (E)채팅 내용 암호하는 어디까지 하는 게 좋은가? 이거 말고도 TOON을 쓰는 게     
+  좋을 건지도 물어보고 싶어.                                                    
+
+● Sections (D) + (E)만 갈아끼우면 돼요:
+
+  ---
+  (D) "나중에 하기로 한 일들" — 어디까지 v1에 넣어야 하나?
+
+  각 항목의 위험과 작업 비용:
+
+  ┌───────────────┬────────────────────────────────────┬────────────────────┐
+  │     항목      │      안 하면 무슨 일이 생기나      │     작업 비용      │
+  ├───────────────┼────────────────────────────────────┼────────────────────┤
+  │               │ 사용자가 로그아웃해도 토큰이 만료  │                    │
+  │ 토큰 denylist │ 전까지(15분~1일) 유효. 토큰        │ 중 (Redis + 필터)  │
+  │               │ 탈취당하면 로그아웃해도 무력함     │                    │
+  ├───────────────┼────────────────────────────────────┼────────────────────┤
+  │ GitHub access │ DB가 유출되면 사용자들의 GitHub    │ 중 (암호화 키      │
+  │  token 암호화 │ API 토큰이 통째로 노출 → 공격자가  │ 관리)              │
+  │               │ 사용자 private repo 접근 가능      │                    │
+  ├───────────────┼────────────────────────────────────┼────────────────────┤
+  │ LLM 멀티      │ 지금은 GLM만 씀. GLM 장애 = 분석   │ 상 (LlmClient      │
+  │ 프로바이더    │ 기능 전체 정지. fallback           │ 추상화 확장 +      │
+  │ 라우팅        │ 모델/프로바이더가 없어서 분석      │ 프로바이더별       │
+  │               │ 기능이 단일 장애점                 │ 어댑터)            │
+  └───────────────┴────────────────────────────────────┴────────────────────┘
+
+  데모 청중/시점이 정해지지 않은 지금 "보여주기엔 화려하지만 위험 큰 것" vs 
+  "지루하지만 안 하면 사고 날 것" 의 균형이 어디인지 감을 잡고 싶어요.
+
+  (E) 사용자 콘텐츠 암호화 범위 + TOON 도입 여부
+
+  암호화 범위
+
+  GitHub access token 암호화는 (D)에서 다뤘고, 그 외에 사용자가 만든/우리가 모은
+   콘텐츠 중 어디까지 암호화해야 할까요? 후보들:
+
+  - analysis_payload JSONB (분석 결과 — 사용자의 기술 프로필, 약점 진단 근거)
+  - metadata_payload JSONB (Slice 3에서 채울 commit 본문 발췌, PR/issue 본문)
+  - 사용자-Coach 대화 로그 (v2 Coach 기능 도입 시)
+  - 진단 결과 (capability_diagnoses — 사용자의 부족한 기술)
+
+  이 데이터들은 공개 레포지토리에서 가져온 것이지만 "이 사용자가 
+  약점이다/잘한다"는 평가가 결합되면 민감도가 올라가요. DB 유출 시 "X 사용자는
+  OAuth를 잘 모른다" 같은 정보가 노출되면 평판 위험.
+
+  선택지:
+  1. 일체 안 함 — JSONB 평문 저장. 빠르고 검색/디버깅 쉬움. DB 유출 시 위험.
+  2. 컬럼 단위 암호화 (Hibernate @ColumnTransformer 또는 KMS-backed 키) —
+  컬럼별로 토글 가능. 검색은 어려움.
+  3. 전체 DB 암호화 (PostgreSQL TDE, 클라우드 인프라 옵션) — 코드 변경 없음.
+  백업/복원 시 키 관리 필요. 개발자 권한 가진 누군가가 DB 직접 조회하면 여전히
+  평문.
+
+  v1 MVP 시점에 어디까지 가는 게 합리적인지.
+
+  TOON 도입 여부
+
+  TOON (Token-Oriented Object Notation) 은 LLM 호출에 쓰는 JSON 대안 포맷이에요.
+   같은 데이터를 표현하는 데 JSON보다 토큰을 30~60% 적게 사용하는 게 특징.
+  핵심은 따옴표/중괄호/필드 반복 제거 + 컬럼형 표현. 예:
+
+  JSON  : [{"sha":"abc","add":10,"del":2},{"sha":"def","add":5,"del":1}]
+  TOON  : sha,add,del / abc,10,2 / def,5,1
+
+  우리 파이프라인에서 LLM에 보내는 데이터의 상당 부분이 반복적인 list of objects
+   (commit 메타 100개, PR 50개, issue 50개) 라서 TOON 도입 시 Triage/Stage 2 
+  입력 토큰을 꽤 줄일 수 있어요. 운영 비용 직격.
+
+  도입 시 트레이드오프:
+  - 득: 토큰 30~60% 절감 → byte cap 안에 더 많은 candidate 넣을 수 있음 + 비용↓
+  - 실: LLM이 TOON 포맷을 안정적으로 파싱하는지 모델별 검증 필요 (Claude/GPT-4는
+   OK 보고된 바 있음, GLM은 미검증). 구조 손상 시 디버깅 어려움. 응답까지
+  TOON으로 받기는 위험 → 입력만 TOON, 출력은 JSON Schema 유지가 현실적.
+
+  질문:
+  - v1에서 TOON을 도입할 가치가 있는지 vs 일단 JSON으로 굳히고 운영 데이터로
+  비용 측정 후 v1.5에서 도입할지
+  - GLM 같은 비주류 모델에서 TOON 호환성을 어떻게 검증해야 안전한지
+
+> /export                                                                       
+  ⎿  Conversation exported to: C:\Users\lozy9\IdeaProjects\INT6-Roadmap-Team06\ba
+     ckend\2026-04-29-165652-local-command-caveatcaveat-the-messages-below.txt
+
+> /branch 
+  ⎿  Branched conversation. You are now in the branch. Use /resume a791001d-21f5-4ac9-b1df-f26cda056d9a to return to the original.
+
+※ recap: v1 MVP 완성이 이번 주 목표이고 지금은 멘토링 준비 문서를 작성 중이에요. 다음 할 일은 (D)와 (E) 섹션이 반영된 최종본을 멘토에게 보낼 형태로 정리하는 거예요.
+
+> write me a commit message                                                     
+
+● feat(github): GitHub 분석 슬라이스 — commit-based 2-stage LLM 파이프라인
+
+  Slice 2 풀 버티컬: domain/service/controller/DTOs + 통합 테스트.
+  github_projects.metadata_payload는 fixture 가정 (실제 fetcher는 Slice 3).
+
+  - Stage 1 Triage: Haiku급 경량 LLM이 본인 commit/PR/issue
+    메타데이터(README framing 포함)에서 champion 6~9개 선정, 폴백은
+    최신 commit 6개 + meta.triageFallback=true
+  - Stage 2 Per-repo Summary: champion 본문(전처리된 diff/PR/issue thread)
+    → schema 검증된 RepoSummary JSON. Diff는 lockfile/generated/binary/
+    vendored 경로 블랙리스트로 hunk 통째 drop
+  - Stage 3 Synthesis: static signals + 모든 repo summary →
+    techTags/depthEstimates/evidences/finalTechProfile
+
+  세부:
+  - AnalysisPayload + Jackson helper, RepoMetadata 역직렬화 record
+  - 3종 JSON Schema (champion-triage/repo-summary/synthesis) +
+    com.networknt schema validator로 LLM 응답 검증
+  - StaticSignalAggregator: listLanguages 합산 비율 + primary_language 폴백
+  - POST/GET /api/github-analyses, version=max+1, 소유권 FORBIDDEN
+  - ErrorCode.LLM_TRIAGE_FAILED 추가 (commit 0개 + LLM 실패 극단 케이스)
+  - GithubAnalysis.create(...) 팩토리 추가
+  - WireMock 기반 3-stage end-to-end 통합 테스트 1개
+  - 신규 unit 테스트 약 36개
+
+  문서: docs/11_github_analysis_pipeline.md (파이프라인 설계),
+  docs/12_github_analysis_implementation_notes.md (설계→구현 deltas 12건).
+
+> ## 연관 이슈                                                                  
+                                                                                
+  Closes #44                                                                    
+                                                                                
+  ## 변경 요약                                                                  
+                                                                                
+  -                                                                             
+                                                                                
+  ## 테스트                                                                     
+                                                                                
+  실행 내용:                                                                    
+                                                                                
+  ```text                                                                       
+  예) ./gradlew test jacocoTestReport                                           
+  ``` 이 템플릿도 작성해 줘. 팀원 누구나 이해하기 쉽게                          
+
+● 연관 이슈
+
+  Closes #44
+
+  변경 요약
+
+  GitHub 분석 기능의 Slice 2 (가장 얇은 end-to-end 흐름)를 구현했습니다.
+  사용자가 핵심 repo를 체크박스로 고르면, 본인 활동(commit/PR/issue)을 LLM이
+  분석해 기술 프로필을 만들고 DB에 저장하는 흐름까지 통과합니다.
+
+  파이프라인 (3-stage LLM):
+  1. Triage — 경량 LLM이 본인의 commit/PR/issue 메타데이터(diff 본문 X)와 README
+   발췌만 보고 가장 의미 있는 6~9개를 고름
+  2. Per-repo Summary — 선정된 champion의 본문(전처리된 diff/PR body/issue
+  thread)을 받아 repo별 요약 JSON 생성
+  3. Synthesis — 정적 신호 + 모든 repo 요약을 묶어 techTags / depthEstimates / 
+  evidences / finalTechProfile 합성
+
+  신규 API:
+  - POST /api/github-analyses — 분석 실행 (selected/core repo IDs)
+  - GET /api/github-analyses/{id} — 결과 조회
+
+  핵심 구현 포인트:
+  - LLM 호출 결과는 JSON Schema (com.networknt)로 검증 → 손상된 응답은 fallback
+  또는 실패 처리
+  - Triage fallback: LLM이 0개 선정/타임아웃/스키마 위반이면 최신 commit 6개를
+  champion으로 사용 (meta.triageFallback=true로 기록). LLM 일시 장애로 분석이
+  죽지 않도록.
+  - Diff 전처리: lockfile, 번들/생성 파일, 바이너리, vendored 경로의 hunk를
+  통째로 drop해 토큰 낭비 방지 (언어 불가지론적, hunk-level cleanup은 Slice 4)
+  - 컨텍스트 캡: Triage 20KB, Summary 24KB, Synthesis 16KB. Synthesis 초과 시
+  highlights를 앞 3개로 압축 후 재시도
+  - 권한 체크: 모든 read/write가 userId 필터링 + 연결 소유권 검증 (FORBIDDEN,
+  NOT_FOUND 아님 — ID leak 방지)
+  - 버전: 같은 트랜잭션에서 max+1
+
+  범위 밖 (후속 슬라이스):
+  - Slice 2.5: PATCH /corrections (사용자 보정값)
+  - Slice 3: GitHub HTTP fetcher (실제 GraphQL/REST로 metadata_payload 채우기).
+  현재는 fixture 가정.
+  - Slice 4: Decision Reversal 처리, hunk-level diff cleanup, 멀티 프로바이더
+  라우팅, agentic Stage 2 비교 실험
+
+  문서:
+  - docs/11_github_analysis_pipeline.md — 파이프라인 설계 (이전 PR에서 추가)
+  - docs/12_github_analysis_implementation_notes.md — 설계 대비 실구현 결정 12건
+
+  테스트
+
+  ./gradlew test integrationTest
+
+  커버리지:
+  - Unit 테스트 약 36개 — 각 컴포넌트(prompt builder/response parser/triage
+  service/aggregator/diff preprocessor) 단위 검증
+  - Integration 테스트 1개 — WireMock으로 AI Gateway 3-stage 응답을 stub하고
+  Testcontainers Postgres에서 POST → DB 영속화 → payload round-trip까지 확인
+
+  검증 결과: 신규 테스트 모두 GREEN, 기존 테스트 회귀 없음.
+
+  리뷰 시 우선 봐주실 곳:
+  - service/github/GithubAnalysisService.java — orchestrator 흐름
+  - service/github/triage/ChampionTriageService.java — fallback 정책이
+  의도대로인지
+  - docs/11_* / docs/12_* — 설계 의도 + 구현 결정 차이
+
+> 아니 slice 1부터 1.5 부터 2까지 전부 다                                       
+
+● 연관 이슈
+
+  Closes #44
+
+  변경 요약
+
+  GitHub 기반 사용자 분석 흐름의 백엔드 첫 큰 덩어리를 세 슬라이스로 나눠
+  구현했습니다. Slice 1 (OAuth 로그인) → Slice 1.5 (인증 강화) → Slice 2 (GitHub
+   분석) 순서로, 각 슬라이스가 다음의 입력이 되도록 설계했습니다.
+
+  ---
+  🔐 Slice 1 — GitHub OAuth 로그인 + JWT 쿠키 인증
+
+  신규 API:
+  - GET /api/v1/auth/me — 현재 인증된 사용자 정보
+  - POST /api/v1/auth/refresh — refreshToken 쿠키로 access/refresh 회전
+  - POST /api/v1/auth/logout — 토큰 쿠키 만료
+
+  핵심 구현:
+  - GitHub OAuth2 콜백 성공 시 User + GithubConnection upsert → JWT 쌍 발급 →
+  HttpOnly + SameSite=Lax 쿠키로 내려주고 프론트로 redirect
+  - JwtAuthenticationFilter가 Authorization: Bearer 헤더와 accessToken 쿠키 둘
+  다 지원
+  - User.signupFromOAuth(provider, providerUserId, email) 팩토리 —
+  provider/이메일 검증 일원화
+  - GithubConnection.connect(...) + accessToken 컬럼 (V3 마이그레이션) — 이후
+  슬라이스에서 GitHub API 호출에 사용
+
+  ---
+  🛡️ Slice 1.5 — 인증 슬라이스 보강
+
+  OAuth 흐름의 빈 곳들을 채웠습니다:
+  - OAuth2State — Base64URL 인코딩된 JSON으로 redirectUrl을 state 파라미터에
+  round-trip. 손상된 state는 기본 URL fallback
+  - CookieManager — SameSite/HttpOnly/Secure 일관성 위해 단일 진입점화.
+  AuthController/SuccessHandler가 동일 메서드 사용
+  - CoachOAuth2LoginFailureHandler — OAuth 실패 시 일관된 에러 응답
+  - CookieOAuth2AuthorizationRequestRepository — STATELESS 세션 정책에서 인증
+  요청 객체 보존
+  - OAuth2 빈은 @ConditionalOnProperty로 wiring — client-id 미설정 환경에서
+  컨텍스트 시동 실패 안 하도록
+  - JwtTokenProvider.parseRefreshToken() 추가 (token type claim 검증)
+
+  ---
+  🤖 Slice 2 — GitHub 분석 (commit-based 3-stage LLM)
+
+  신규 API:
+  - POST /api/github-analyses — 분석 실행 (선택한 repo + 핵심 repo IDs)
+  - GET /api/github-analyses/{id} — 결과 조회
+
+  파이프라인:
+  1. Triage (경량 LLM) — 본인 commit/PR/issue 메타데이터 + README 발췌만 보고
+  champion 6~9개 선정 (diff 본문 X, 토큰 절약)
+  2. Per-repo Summary — champion 본문(전처리 diff / PR body / issue thread)으로
+  repo별 요약 JSON 생성
+  3. Synthesis — 정적 신호 + 모든 repo 요약을 합쳐 techTags / depthEstimates / 
+  evidences / finalTechProfile 도출
+
+  핵심 결정:
+  - JSON Schema (com.networknt) 검증 — 모든 LLM 응답은 schema 위반 시
+  LLM_INVALID_RESPONSE. 결정적이고 회귀 테스트 가능
+  - Triage fallback — 0개 선정/타임아웃/스키마 위반 시 최신 commit 6개로
+  fallback + meta.triageFallback=true 기록. LLM 일시 장애로 분석 자체가 죽지
+  않도록
+  - Diff 전처리 — lockfile/번들/바이너리/vendored 경로의 hunk를 통째로 drop
+  (언어 불가지론적 path 블랙리스트). hunk-level cleanup은 Slice 4
+  - 컨텍스트 캡 — Triage 20KB / Summary 24KB / Synthesis 16KB. Synthesis 초과 시
+   highlights를 앞 3개로 압축 후 재시도
+  - 권한 — 모든 read/write가 userId 필터링. 연결 소유권은 existsByIdAndUserId →
+  FORBIDDEN (NOT_FOUND 아님, ID leak 방지)
+  - 버전 — max+1을 같은 트랜잭션에서 계산 → 충돌은 ANALYSIS_FAILED
+
+  범위 밖 (후속 슬라이스로 명시):
+  - Slice 2.5: PATCH /corrections (사용자 보정)
+  - Slice 3: GitHub HTTP fetcher (실제 GraphQL/REST로 metadata_payload 채우기).
+  현재는 fixture 가정
+  - Slice 4: Decision Reversal 처리, hunk-level diff cleanup, 멀티 프로바이더
+  라우팅, agentic Stage 2 A/B 비교
+
+  ---
+  📚 문서 / 인프라
+
+  - docs/11_github_analysis_pipeline.md — Slice 2 파이프라인 설계 (3-stage IO,
+  byte-cap 상수, JSONB shape, 거부한 대안과 근거)
+  - docs/12_github_analysis_implementation_notes.md — 설계→실구현 deltas 12건
+  (signature 변경, 새 invariants 등)
+  - docs/04_function_spec_aligned.md, docs/05_architecture_aligned.md — doc 11
+  포인터만 추가
+  - 신규 ErrorCode: LLM_TRIAGE_FAILED
+  - 3종 JSON Schema
+  (ai/schema/champion-triage|repo-summary|synthesis.schema.json)
+
+  ---
+  테스트
+
+  실행 내용:
+
+  ./gradlew test integrationTest jacocoTestReport
+
+  커버리지:
+
+  슬라이스: Slice 1
+  Unit: OAuth state, User factory, JwtTokenProvider, GithubUserInfoMapper,
+    AuthService, AuthController
+  Integration: AuthFlowIntegrationTest (OAuth 콜백 → User/Connection upsert →
+    쿠키 발급, 재로그인 시 token 갱신)
+  ────────────────────────────────────────
+  슬라이스: Slice 1.5
+  Unit: CookieManager, OAuth2State, FailureHandler,
+    CookieOAuth2AuthorizationRequestRepository
+  Integration: SecurityConfigTest (CORS, 보호 API, accessToken 쿠키 폴백)
+  ────────────────────────────────────────
+  슬라이스: Slice 2
+  Unit: 약 36개 — 각 builder/parser/aggregator/preprocessor + orchestrator
+    (Mockito) + controller (@MockitoBean)
+  Integration: GithubAnalysisFlowIntegrationTest (WireMock 3-stage stub +
+    Testcontainers Postgres + payload round-trip)
+
+  결과: 신규 테스트 전부 GREEN, 기존 테스트 회귀 없음.
+
+  리뷰 시 우선 봐주실 곳:
+  - service/github/GithubAnalysisService.java — Slice 2 orchestrator 흐름
+  - service/github/triage/ChampionTriageService.java — fallback 정책 의도 일치
+  여부
+  - global/security/oauth2/CoachOAuth2LoginSuccessHandler.java — Slice 1.5
+  쿠키/state 처리
+  - docs/11_* + docs/12_* — 설계 의도와 실제 구현 차이를 짚어둔 문서
+※ recap: Slice 2 GitHub 분석 (3-stage LLM 파이프라인) 구현 끝, 모든 테스트 GREEN, PR 템플릿 작성 완료. 다음은 PR 올리고 머지하거나 Slice 2.5 (PATCH /corrections) 또는 Slice 3 (GitHub HTTP fetcher)로 진행.
+
+> /branch 
+  ⎿  Branched conversation. You are now in the branch. Use /resume 8c0abff9-96d8-4c38-8775-25149cd3e7a1 to return to the original.
+
+> 아니, 왜 application-secret을 gitignore에 안 넣어 줬어?                       
+
+● Bash(cat ../.gitignore 2>&1; echo "---"; find .. -name "application-secret*"
+      -not -path "*/node_modules/*" 2>&1; echo "---"; git ls-files | grep -i
+      "secret\|applicat…)
+  ⎿  # IDE
+     .idea/
+     *.iml
+     … +40 lines (ctrl+o to expand)
+
+● Bash(git log --oneline --all -- src/main/resources/application-secret.yml |
+      head -5; echo "---CURRENT CONTENT---"; head -20
+      src/main/resources/application-secret.yml…)
+  ⎿  cb9e25e   feat: GitHub OAuth 로그인 및 JWT 발급 슬라이스 구현   GitHub
+      OAuth2 로그인 성공 시 User/GithubConnection 업서트 후 JWT 액세스/리프
+     레시 토큰을 HttpOnly 쿠키로 발급하는 인증 흐름 구축.   - OAuth2State B
+     … +13 lines (ctrl+o to expand)
+
+● 상황을 솔직히 말씀드릴게요. 두 가지 사실이 같이 있어요:
+
+  1. .gitignore에는 이미 application-secret.yml 규칙이 있어요 (제가 이번
+  세션에서 빠뜨린 게 아닙니다 — 규칙은 7~8번째 줄에 명시됨)
+  2. 하지만 파일이 이미 tracked 상태로 커밋되어 있어요. gitignore는 untracked
+  파일만 막아요. 이미 추가된 파일은 차단 못 합니다.
+
+  가장 심각한 건 — 실제 GitHub OAuth clientSecret 값이 평문으로 들어있는 채 
+  커밋되어 있어요:
+
+  clientId: Ov23lihYqrb2cm4gNrt1
+  clientSecret: 1f28efa2aa7861a748e049a5326aec06962fafb0
+
+  git log로 보면 Slice 1 commit (cb9e25e)에 함께 들어갔습니다. 이게 만약 진짜
+  운영용 secret이고 레포가 public이면 즉시 외부 노출 상태예요.
+
+  ---
+  즉시 확인할 것
+
+  1. 이게 진짜 secret인지 / 테스트용 더미인지
+  2. 레포가 public인지 / private인지
+  3. 이 commit이 origin에 push된 상태인지
+
+  권장 조치 (중요도 순)
+
+  (A) Secret rotation — 진짜 값이고 push된 상태면 1순위. GitHub Developer
+  Settings → 해당 OAuth App → "Generate a new client secret" 후 기존 secret
+  폐기. 다른 모든 조치보다 먼저 해야 해요. 이미 외부에서 봤다면 git에서 지워도
+  소용없으니까.
+
+  (B) 파일을 untrack:
+  git rm --cached backend/src/main/resources/application-secret.yml
+  git commit -m "chore: untrack application-secret.yml (이미 .gitignore됨)"
+  이러면 로컬 파일은 유지되고, 앞으로 추적 안 됨.
+
+  (C) .example 파일은 그대로 유지 — application-secret.yml.example에 placeholder
+   키를 넣어두고 README에 "이걸 복사해서 application-secret.yml로 두고 본인 키
+  채우세요" 안내.
+
+  (D) 과거 history에서 secret 제거 — 신중히 결정. git filter-repo 또는 BFG
+  Repo-Cleaner로 과거 commit에서도 secret 줄을 지울 수 있어요. 단점:
+  - force push 필요 → 협업 중인 팀원 모두에게 영향 (rebase 강제)
+  - 이미 외부에 노출됐다면 늦음 (rotation이 우선)
+  - 결정은 본인이 내려야 함 (제가 git filter-repo/push -f를 알아서 하면 안 됨)
+
+  ---
+  어떻게 진행할까요? 일단 (1)~(3) 답해주시면 (A)/(B) 부분만 안전하게 진행하고,
+  (D)는 별도 결정으로 미룰 수 있어요.
+
+> 지금 이미 커밋해서, 아에 Oauth application을 삭제했어.                        
+
+● OAuth 앱 자체를 지운 게 가장 안전한 조치예요. 노출된 secret이 이제 무효라서 더
+   이상 보안 사고 위험은 없어요. 남은 건 정리 작업.
+
+  .example 파일에 placeholder만 있는지 먼저 확인할게요.
+
+  Read 1 file (ctrl+o to expand)
+
+● .example는 placeholder만 있어서 안전. 이제 정리 단계 두 가지만 하면 돼요.
+  destructive하지 않은 작업이지만 commit이 발생하니 진행 전에 확인해주세요.
+
+  제안하는 정리 순서
+
+  1. 파일을 git에서 untrack (로컬 파일은 그대로 유지)
+  git rm --cached backend/src/main/resources/application-secret.yml
+
+  2. commit
+  git commit -m "chore: untrack application-secret.yml (.gitignore 일치시킴)"
+
+  이러면:
+  - 로컬 application-secret.yml은 그대로 살아 있음 (untracked로 변환만 됨)
+  - 앞으로 git이 변경 감지 안 함
+  - 팀원이 pull받으면 그쪽 로컬 파일은 영향 없이 유지됨 (이미 추적된 적 있는
+  상태에서만 pull 시 사라짐. 보통 안전)
+
+  새 OAuth 앱 만든 후
+
+  새 client ID/secret을 받으면 로컬 application-secret.yml만 갱신하면 끝. commit
+   안 됨.
+
+  history 재작성은 건너뛰어도 OK
+
+  OAuth 앱 자체가 지워졌으니 과거 commit에 있는 값은 이제 무효. 그래도 깔끔하게
+  지우고 싶으면 git filter-repo/BFG 옵션은 있는데, force push가 필요해서 팀원
+  영향 큼. 권하지 않아요.
+
+  ---
+  진행할까요? 진행 OK면 1번 명령 실행해드릴게요. (2번 commit은 직접 하시거나,
+  메시지 확정해주시면 같이 할 수 있어요.)
+
+> git filter-repo 해줘. 대신 dev로부터 새 chore 브랜치를 만들어서 할 수 있음?   
+
+● 진행하기 전에 환경 + 작업 상태 확인할게요.
+
+● Bash(git filter-repo --version 2>&1; echo "---STATUS---"; git status --short
+      2>&1; echo "---BRANCH---"; git branch --show-current; echo "---REMOTE---";
+       git remote -v…)
+  ⎿  git: 'filter-repo' is not a git command. See 'git --help'.
+     ---STATUS---
+     ---BRANCH---
+     … +6 lines (ctrl+o to expand)
+
+● 두 가지 확인했어요:
+  1. git filter-repo 미설치 — 설치 필요
+  2. 현재 브랜치가 feature/github-auth-impl (dev 아님) — 명시하신 대로 dev에서
+  새 브랜치 생성 필요
+  3. 작업 트리는 깨끗 (committed/clean)
+
+  진행 계획 (확인 부탁)
+
+  # 1. filter-repo 설치
+  pip install git-filter-repo
+
+  # 2. dev 최신화 + 새 브랜치
+  git fetch origin
+  git checkout -b chore/scrub-leaked-oauth-secret origin/dev
+
+  # 3. (안전망) 정리 직전 상태를 백업 태그로 박아둠 — 잘못되면 reset 가능
+  git tag backup/before-secret-scrub
+
+  # 4. 누출된 값을 모두 [REDACTED]로 치환 — 새 브랜치의 reachable 커밋만 대상
+  cat > /tmp/replacements.txt <<'EOF'
+  Ov23lihYqrb2cm4gNrt1==>[REDACTED-CLIENT-ID]
+  1f28efa2aa7861a748e049a5326aec06962fafb0==>[REDACTED-CLIENT-SECRET]
+  EOF
+  git filter-repo --replace-text /tmp/replacements.txt --refs
+  chore/scrub-leaked-oauth-secret --force
+
+  # 5. 결과 확인 (검증 전 push 안 함)
+  git log --oneline -5
+  git show <secret-가-있던-커밋> --
+  backend/src/main/resources/application-secret.yml
+
+  진행 전 알아주실 점
+
+  - commit hash가 전부 바뀜 — chore 브랜치만. dev 자체는 안 건드려요.
+  - filter-repo는 origin remote를 지움 — 보안 정책. 끝나고 git remote add origin
+   <url>로 다시 붙여야 해요. 위 명령에 포함시킬게요.
+  - 이건 destructive 작업이라 진행 직전 한 번 더 멈춰서 확인받을게요.
+  1~3단계까지만 먼저 실행하고, filter-repo 실행 직전에 다시 OK 받을게요.
+
+  진행해도 될까요? OK면 1단계(pip install)부터 갑니다.
+
+> 아니, 그냥 filter repo 대신 지워만 줘.                                        
+
+● 알겠어요. filter-repo 대신 untrack만 하는 깔끔한 방법으로 갈게요.
+
+● Bash(git fetch origin 2>&1 | tail -3 && git checkout -b
+      chore/untrack-application-secret origin/dev 2>&1 | tail -5)
+  ⎿     1dcd47e..7450f36  dev        -> origin/dev
+      * [new branch]      feat/frontend-api-client -> origin/feat/frontend-
+     api-client
+     … +5 lines (ctrl+o to expand)
+
+● Bash(git ls-files backend/src/main/resources/application-secret.yml; echo
+      "---"; ls backend/src/main/resources/application-secret.yml)
+  ⎿  Error: Exit code 2
+     ---
+     ls: cannot access 'backend/src/main/resources/application-secret.yml': No 
+     such file or directory
+
+● Bash(git log --all --oneline --
+      backend/src/main/resources/application-secret.yml | head -10; echo
+      "---branches containing the secret commit---"; git log --all --sou…)
+  ⎿  ---branches containing the secret commit---
+
+● Bash(git ls-tree -r feature/github-auth-impl --
+      backend/src/main/resources/application-secret.yml 2>&1; echo "---"; git
+      ls-tree -r origin/dev -- backend/src/main/res…)
+  ⎿  ---
+● Bash(git log --all --oneline --diff-filter=A -- '**/application-secret.yml'
+      2>&1 | head -5; echo "---"; git log --all --oneline --diff-filter=A --
+      '**/application-se…)
+  ⎿  cb9e25e   feat: GitHub OAuth 로그인 및 JWT 발급 슬라이스 구현   GitHub
+      OAuth2 로그인 성공 시 User/GithubConnection 업서트 후 JWT 액세스/리프
+     레시 토큰을 HttpOnly 쿠키로 발급하는 인증 흐름 구축.   - OAuth2State B
+     … +29 lines (ctrl+o to expand)
+
+● Bash(git branch -a --contains 31070e5 2>&1 | head -20)
+  ⎿  * chore/untrack-application-secret
+       feature/github-auth-impl
+       remotes/origin/dev
+       remotes/origin/feature/github-auth-impl
+
+● Bash(git log origin/dev --oneline --all-match --
+      'backend/src/main/resources/application-secret.yml' | head -5; echo
+      "---HEAD on dev---"; git log origin/dev --onelin…)
+  ⎿  ---HEAD on dev---
+     ---PATH IN COMMIT 31070e5---
+         chore(backend): application-secret.yml 프로필 추가 (Github API등)
+     … +2 lines (ctrl+o to expand)
+
+● Bash(git branch -a --contains cb9e25e 2>&1 | head -10; echo "---FILE in
+      cb9e25e?---"; git show --stat cb9e25e | grep -i "secret")
+  ⎿  * chore/untrack-application-secret
+       feature/github-auth-impl
+       remotes/origin/dev
+     … +3 lines (ctrl+o to expand)
+
+● Bash(git ls-tree origin/dev backend/src/main/resources/ | grep secret; echo
+      "---"; git log origin/dev --oneline --diff-filter=D --
+      'backend/src/main/resources/applic…)
+  ⎿  ---
+
+● Bash(git log origin/dev --oneline | head -5; echo "---SHOW cb9e25e
+      parents---"; git log --oneline --parents cb9e25e | head -3; echo "---is
+      cb9e25e an ANCESTOR of dev…)
+  ⎿  7450f36 Merge pull request #105 from Programmers-Intern-Program/feat/r
+     oadmap-progress-page
+     8fd5544 Merge pull request #99 from Programmers-Intern-Program/feature
+     … +19 lines (ctrl+o to expand)
+
+● Bash(git show --stat cb4d48f 2>&1 | grep -i "secret"; echo "---"; git show
+      cb4d48f --name-status 2>&1 | grep "secret")
+  ⎿  ---
+
+● Bash(git show 8fd5544 --name-status 2>&1 | grep -i "secret"; echo "---SHOW
+      MERGE---"; git log --oneline 8fd5544 -1; echo "---DIFF MERGE TO
+      PARENT---"; git diff 8fd55…)
+  ⎿  ---SHOW MERGE---
+     8fd5544 Merge pull request #99 from Programmers-Intern-Program/feature
+     /github-auth-impl
+     ---DIFF MERGE TO PARENT---
+
+● Bash(git log --all --oneline --follow --
+      backend/src/main/resources/application-secret.yml 2>&1 | head -10; echo
+      "---"; git log --all --oneline -- '*application-secr…)
+  ⎿  ---
+     cb9e25e   feat: GitHub OAuth 로그인 및 JWT 발급 슬라이스 구현   GitHub
+      OAuth2 로그인 성공 시 User/GithubConnection 업서트 후 JWT 액세스/리프
+     … +12 lines (ctrl+o to expand)
+
+● Bash(git cat-file -p
+      origin/dev:backend/src/main/resources/application-secret.yml 2>&1 | head
+      -10)
+  ⎿  spring:
+       security:
+         oauth2:
+     … +5 lines (ctrl+o to expand)
+
+● Bash(git ls-files | grep secret; echo "---"; ls
+      backend/src/main/resources/application-secret.yml 2>&1)
+  ⎿  Error: Exit code 2
+     src/main/resources/application-secret.yml
+     src/main/resources/application-secret.yml.example
+     ---
+     ls: cannot access 'backend/src/main/resources/application-secret.yml': No 
+     such file or directory
+
+● 내 working dir이 backend/라 path 헷갈렸어요. 파일은
+  src/main/resources/application-secret.yml로 tracked 상태. 이제 untrack:
+
+● Bash(ls src/main/resources/application-secret.yml 2>&1; echo "---"; git rm
+      --cached src/main/resources/application-secret.yml 2>&1; echo
+      "---STATUS---"; git status -…)
+  ⎿  src/main/resources/application-secret.yml
+     ---
+     rm 'backend/src/main/resources/application-secret.yml'
+     … +2 lines (ctrl+o to expand)
+
+● Bash(ls src/main/resources/application-secret.yml; echo "---verify gitignore
+      catches it---"; git check-ignore -v
+      src/main/resources/application-secret.yml)
+  ⎿  src/main/resources/application-secret.yml
+     ---verify gitignore catches it---
+     .gitignore:15:application-secret.yml       src/m
+     ain/resources/application-sec
+     ret.yml
+
+● 로컬 파일 그대로 살아있고, .gitignore가 정상 작동 확인. 이제 commit:
+● Bash(git commit -m "$(cat <<'EOF'
+      chore(backend): application-secret.yml untrack — .gitignore 일치시킴…)
+  ⎿  [chore/untrack-application-secret 3007bd9] chore(backend): application
+     -secret.yml untrack — .gitignore 일치시킴
+      1 file changed, 8 deletions(-)
+      delete mode 100644 backend/src/main/resources/application-secret.yml
+
+● 완료. 정리 요약:
+
+  - 브랜치: chore/untrack-application-secret (origin/dev 기반)
+  - commit: 3007bd9 — secret 파일 untrack
+  - 로컬 파일: 그대로 살아 있음 (사용자 본인이 새 OAuth 앱 키 채우면 됨)
+  - .gitignore: 이제 effective — 다음부터는 자동 무시
+
+  origin/dev에는 여전히 secret 값이 들어있는 commit이 남아 있지만, OAuth 앱이
+  삭제됐으니 그 값은 무효 상태. push + PR 후 dev에 머지되면 트리에서 사라져요.
+  (history는 그대로 — filter-repo는 비용 대비 가치 낮아 보류한다고 commit
+  message에도 명시했어요.)
+
+  push + PR 진행하시면 됩니다.
+
+> /branch 
+  ⎿  Branched conversation. You are now in the branch. Use /resume facc4951-0aaf-4071-8f20-422b1149ffbb to return to the original.
+
+※ recap: Goal: scrub leaked OAuth secret from the repo. Done — `chore/untrack-application-secret` branch off origin/dev now removes `application-secret.yml` from tracking (commit `3007bd9`); local file preserved. Next: push the branch and open a PR into dev.

--- a/backend/2026-05-02-002123-local-command-caveatcaveat-the-messages-below.txt
+++ b/backend/2026-05-02-002123-local-command-caveatcaveat-the-messages-below.txt
@@ -1,0 +1,845 @@
+╭─── Claude Code v2.1.123 ─────────────────────────────────────────────────────╮
+│                                                    │ What's new              │
+│                   Welcome back J!                  │ Fixed OAuth authentica… │
+│                                                    │ Added `ANTHROPIC_BEDRO… │
+│                       ▐▛███▜▌                      │ Pasting a PR URL into … │
+│                      ▝▜█████▛▘                     │ /release-notes for more │
+│                        ▘▘ ▝▝                       │                         │
+│   Opus 4.7 · Claude Pro · lozy960422@gmail.com's   │                         │
+│   Organization                                     │                         │
+│     ~\IdeaProjects\INT6-Roadmap-Team06\backend     │                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+✻ Conversation compacted (ctrl+o for history)
+
+
+❯ /compact                                                                      
+  ⎿  Compacted (ctrl+o to see full summary)
+  ⎿  Read src\test\java\com\back\coach\domain\github\service\GithubConnectionServiceTest.java (125 lines)
+  ⎿  Read src\test\java\com\back\coach\domain\github\controller\GithubConnectionControllerTest.java (265 lines)
+  ⎿  Read src\test\java\com\back\coach\external\github\RestGithubApiClientTest.java (272 lines)
+  ⎿  Read src\main\java\com\back\coach\domain\github\service\GithubConnectionService.java (116 lines)
+  ⎿  Read src\main\java\com\back\coach\external\github\dto\GithubUserInfoDto.java (11 lines)
+  ⎿  Plan file referenced (~\.claude\plans\cryptic-exploring-quail.md)
+
+❯ continue slice 3 (write issue template first though)                          
+
+● Let me check the current state before proceeding.
+
+● Bash(git status --short && echo "---" && git stash list)
+  ⎿  ---
+     stash@{0}: WIP on main: f91f798 Doc: docs: GitHub 분석 2단계 분리,
+     분석
+      순서 변경 등변경사항 반영, Context Manager 설계 변경(Use-case), 로드
+     … +4 lines (ctrl+o to expand)
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Bash(git status && echo "---" && git branch)
+  ⎿  On branch feat/github-http-fetcher
+     Your branch is ahead of 'origin/dev' by 2 commits.
+       (use "git push" to publish your local commits)
+     … +10 lines (ctrl+o to expand)
+
+● The commits are already in. Let me check what was committed, then look at the
+  existing GitHub issue templates.
+
+● Bash(git log --oneline -5)
+  ⎿  2062e1b refactor: convention에 맞추기
+     e2e4b81    feat(github): Slice 3 — GitHub HTTP 패처 + 연결/저장소 API
+     c84a635 Merge pull request #109 from Programmers-Intern-Program/feat/g
+     … +5 lines (ctrl+o to expand)
+
+  Searched for 1 pattern (ctrl+o to expand)
+
+● Good — Slice 3 is committed. Now I need to create the GitHub issue template.
+  Let me check what PR templates already exist and look at existing issues for
+  style.
+
+  Searched for 1 pattern, read 4 files, listed 2 directories (ctrl+o to expand)
+  ⎿  Interrupted · What should Claude do instead?
+
+❯ wait , i meant continue after the slice 3, slice 3 is done.                   
+
+● Got it — skipping the issue template, moving straight to Slice 4. Let me read
+  the plan to get the details.
+
+  Read 1 file (ctrl+o to expand)
+
+● The plan only covers Slice 3. Let me find the docs to understand Slice 4's
+  scope.
+
+  Searched for 1 pattern, read 2 files (ctrl+o to expand)
+
+● Now I have a clear picture. Let me also check
+  12_github_analysis_implementation_notes.md and the current state of the
+  analysis codebase.
+
+  Searched for 1 pattern, read 1 file (ctrl+o to expand)
+
+● Good picture of the codebase. Slice 4 has four distinct tracks from the docs:
+
+  1. Hunk-level diff cleanup — import-only / whitespace-only / @generated hunk
+  drop inside DiffPreprocessor (purely additive, TDD-safe)
+  2. Decision Reversal — arc grouping on Triage input, champion-context
+  injection to Stage 2, currentStatus: ADOPTED|EVOLVED|REVERSED on highlights,
+  HEAD file sampling
+  3. Bounded Agentic Stage 2 A/B — LLM-with-tools path vs. current pre-digest,
+  ≤10 tool calls
+  4. Multi-provider routing — Anthropic/OpenAI fallback in AiGatewayLlmClient
+
+  Before I start building, a few scoping questions:
+
+  a) Priority order — docs list them all as "Slice 4" without ordering. My
+  recommendation: hunk cleanup → Decision Reversal → multi-provider routing, and
+   defer bounded agentic A/B to Slice 4.5 (it's genuinely experimental and needs
+   live LLM calls to validate). Agree?
+
+  b) Decision Reversal depth — the doc says "HEAD 시점 핵심 파일 샘플링으로 현재
+   상태 검증." This implies calling the GitHub API again at analysis time (not
+  just at connect time). Should HEAD sampling re-use GithubApiClient directly
+  from GithubAnalysisService, or does it need its own fetcher component?
+
+  c) Arc grouping — the doc mentions grouping commits/PRs into "arcs" (decision
+  bundles). Is the grouping logic: same file touched in consecutive commits =
+  same arc, or is it LLM-assigned (Stage 1 labels the arc)?
+
+  d) New branch — should I fork from feat/github-http-fetcher (the current
+  branch ahead of dev by 2 commits), or wait for it to be merged to dev first
+  and branch from there?
+
+❯ i agree with a). for now... work from the same current branch.                
+  (github-http-fetcher). I need to think about b) and c)                        
+● Explore(Explore DiffPreprocessor and related test patterns)
+  ⎿  Done (6 tool uses · 29.4k tokens · 24s)
+  (ctrl+o to expand)
+
+● Good — I have everything I need. The existing DiffPreprocessor works at
+  file-block level (drops entire diff --git blocks). Slice 4 hunk cleanup needs
+  to go one level deeper: split each kept block by @@ ... @@ hunk headers and
+  drop individual hunks that are import-only / whitespace-only /
+  @generated-only.
+
+  Let me write the plan — scoped to hunk cleanup only (Decision Reversal
+  deferred pending your decisions on b/c).
+
+● Updated plan
+  ⎿  /plan to preview
+
+● User approved Claude's plan
+  ⎿  Plan saved to: ~\.claude\plans\cryptic-exploring-quail.md · /plan to edit
+     Plan — Slice 4a: Hunk-level Diff Cleanup
+
+     Context
+
+     Slice 2's DiffPreprocessor.clean() already drops entire file blocks for
+     lockfiles, binaries, and vendored paths. The doc (§6, §11) explicitly
+     deferred hunk-level cleanup to Slice 4:
+
+     ▎ Hunk 단위 cleanup (import-only / whitespace-only / @generated 마커 hunk 
+     ▎ drop)
+
+     These hunks add noise to Stage 2 LLM input without contributing signal —
+     import reorders, blank-line formatting, and @generated annotation changes
+     tell the LLM nothing about the developer's decisions. Dropping them reduces
+      token usage and sharpens per-repo summaries.
+
+     Branch: feat/github-http-fetcher (stays on current branch per user
+     decision).
+     Decision Reversal (Slice 4b) is deferred until b/c design questions are
+     resolved.
+
+     ---
+     Scope
+
+     Single file to modify: DiffPreprocessor.java
+     Single test file to extend: DiffPreprocessorTest.java
+
+     No callers change — GithubAnalysisService calls
+     diffPreprocessor.clean(diff) unchanged.
+
+     ---
+     Design
+
+     Current flow (file-level)
+
+     unified diff
+       → split on "diff --git a/<path>" headers
+       → drop entire block if path is blacklisted
+       → concatenate kept blocks
+
+     New flow (adds hunk-level pass)
+
+     unified diff
+       → split on "diff --git a/<path>" headers
+       → drop entire block if path is blacklisted           ← unchanged
+       → for each kept block: split on "@@ ... @@" headers
+           → drop hunk if ALL changed lines are:
+               • import-only  (Java/Python/JS/TS/Rust/Go import lines)
+               • whitespace-only  (line is blank or spaces/tabs after +/-)
+               • @generated-only  (line adds/removes only @Generated/@generated
+     annotations)
+           → reassemble surviving hunks
+       → concatenate kept blocks
+
+     Hunk header pattern
+
+     private static final Pattern HUNK_HEADER = Pattern.compile(
+         "^(@@ -\\d+(?:,\\d+)? \\+\\d+(?:,\\d+)? @@[^\n]*\n)",
+     Pattern.MULTILINE);
+
+     Changed-line extraction
+
+     A "changed line" in a hunk is any line starting with + or - (excluding
+     +++/--- meta lines).
+
+     Drop predicates (applied to the set of changed lines in a hunk)
+
+     ┌──────────────────────┬───────────────────────────────────────────────────
+     ┐
+     │      Predicate       │                       Rule
+     │
+     ├──────────────────────┼───────────────────────────────────────────────────
+     ┤
+     │                      │ Every changed line (stripped of leading +/-)
+     │
+     │ isImportOnlyHunk     │ matches one of: ^import , ^from .+ import , ^use  
+     │
+     │                      │ , ^require 
+     │
+     ├──────────────────────┼───────────────────────────────────────────────────
+     ┤
+     │ isWhitespaceOnlyHunk │ Every changed line (stripped of +/-) is blank or
+     │
+     │                      │ contains only \s characters
+     │
+     ├──────────────────────┼───────────────────────────────────────────────────
+     ┤
+     │                      │ Every changed line (stripped of +/-) matches
+     │
+     │ isGeneratedOnlyHunk  │ ^\s*@\s*[Gg]enerated\b or ^\s*//\s*[Gg]enerated
+     │
+     │                      │ or ^\s*/\*.*[Gg]enerated
+     │
+     └──────────────────────┴───────────────────────────────────────────────────
+     ┘
+
+     A hunk with zero changed lines (context-only) is kept as-is — it doesn't
+     hurt and removing it would break line-number accounting for the reader.
+
+     New private method
+
+     private String filterHunks(String fileBlock) {
+         // split on hunk headers, filter, rejoin
+     }
+
+     clean() calls filterHunks(block) after the blacklist check, before
+     appending to output.
+
+     ---
+     File Map
+
+     File: domain/github/service/summary/DiffPreprocessor.java
+     Change: Add HUNK_HEADER pattern, filterHunks(), three predicate helpers
+     ────────────────────────────────────────
+     File: domain/github/service/summary/DiffPreprocessorTest.java
+     Change: Add 5 new test cases (see TDD Steps)
+
+     ---
+     TDD Steps
+
+     Red → Green order
+
+     Step 1 — import-only hunk in a Java file is dropped, non-import hunk is
+     kept
+     @Test
+     void clean_dropsImportOnlyHunk() {
+         String diff = """
+             diff --git a/src/Foo.java b/src/Foo.java
+             @@ -1,3 +1,4 @@
+             +import java.util.List;
+             +import java.util.Map;
+              class Foo {}
+             @@ -10,3 +11,4 @@
+             -    int old = 1;
+             +    int newVal = 2;
+             """;
+         String cleaned = preprocessor.clean(diff);
+         assertThat(cleaned).doesNotContain("import java.util");
+         assertThat(cleaned).contains("newVal");
+     }
+
+     Step 2 — whitespace-only hunk dropped
+     @Test
+     void clean_dropsWhitespaceOnlyHunk() {
+         String diff = """
+             diff --git a/src/Bar.java b/src/Bar.java
+             @@ -5,3 +5,4 @@
+             +
+             +   
+              context
+             @@ -20,2 +21,3 @@
+             -    return old;
+             +    return newVal;
+             """;
+         String cleaned = preprocessor.clean(diff);
+         assertThat(cleaned).doesNotContain("@@ -5,");
+         assertThat(cleaned).contains("newVal");
+     }
+
+     Step 3 — @generated hunk dropped
+     @Test
+     void clean_dropsGeneratedAnnotationHunk() {
+         String diff = """
+             diff --git a/src/Gen.java b/src/Gen.java
+             @@ -1,2 +1,3 @@
+             +@Generated("com.example.generator")
+              public class Gen {}
+             @@ -10,2 +11,3 @@
+             +    String realField = "value";
+             """;
+         String cleaned = preprocessor.clean(diff);
+         assertThat(cleaned).doesNotContain("@Generated");
+         assertThat(cleaned).contains("realField");
+     }
+
+     Step 4 — mixed hunk (imports + real change) is kept whole
+     @Test
+     void clean_keepsMixedHunk() {
+         String diff = """
+             diff --git a/src/Baz.java b/src/Baz.java
+             @@ -1,3 +1,5 @@
+             +import java.util.List;
+             +    int x = 42;
+              class Baz {}
+             """;
+         String cleaned = preprocessor.clean(diff);
+         assertThat(cleaned).contains("import java.util.List");
+         assertThat(cleaned).contains("x = 42");
+     }
+
+     Step 5 — context-only hunk (zero changed lines) is preserved
+     @Test
+     void clean_keepsContextOnlyHunk() {
+         String diff = """
+             diff --git a/src/Ctx.java b/src/Ctx.java
+             @@ -1,3 +1,3 @@
+              line1
+              line2
+              line3
+             """;
+         String cleaned = preprocessor.clean(diff);
+         assertThat(cleaned).contains("line1");
+     }
+
+     ---
+     Verification
+
+     ./gradlew test --tests "*.DiffPreprocessorTest"   # new cases GREEN
+     ./gradlew test                                     # full suite stays GREEN
+
+     Existing GithubAnalysisFlowIntegrationTest unchanged — clean() signature is
+      identical.
+
+     ---
+     Deferred (Slice 4b)
+
+     Decision Reversal (arc grouping, currentStatus on highlights, HEAD file
+     sampling) waits for design decisions on:
+     - b) Whether HEAD sampling re-uses GithubApiClient directly from
+     GithubAnalysisService or gets its own fetcher
+     - c) Whether arc grouping is rule-based (co-touched files) or LLM-assigned
+     (Stage 1 labels)
+
+● Starting TDD. First, the 5 failing tests.
+
+  Read 1 file (ctrl+o to expand)
+
+● Update(src\test\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssorTest.java)
+  ⎿  Added 93 lines
+       89          assertThat(preprocessor.clean("")).isEmpty();
+       90          assertThat(preprocessor.clean(null)).isEmpty();
+       91      }
+       92 +                                                              
+       93 +    // ── Hunk-level cleanup (Slice 4a) ──                    
+       94 +                                                              
+       95 +    @Test                                                     
+       96 +    @DisplayName("import-only hunk는 drop되고 실질 변경 hunk는
+          + 유지된다")                                                   
+       97 +    void clean_dropsImportOnlyHunk() {                        
+       98 +        String diff = """                                     
+       99 +                diff --git a/src/Foo.java b/src/Foo.java      
+      100 +                @@ -1,3 +1,4 @@                               
+      101 +                +import java.util.List;                       
+      102 +                +import java.util.Map;                        
+      103 +                 class Foo {}                                 
+      104 +                @@ -10,3 +11,4 @@                             
+      105 +                -    int old = 1;                             
+      106 +                +    int newVal = 2;                          
+      107 +                """;                                          
+      108 +                                                              
+      109 +        String cleaned = preprocessor.clean(diff);            
+      110 +                                                              
+      111 +        assertThat(cleaned).doesNotContain("import java.util")
+          +;                                                             
+      112 +        assertThat(cleaned).contains("newVal");               
+      113 +    }                                                         
+      114 +                                                              
+      115 +    @Test                                                     
+      116 +    @DisplayName("whitespace-only hunk는 drop되고 실질 변경 hu
+          +nk는 유지된다")                                               
+      117 +    void clean_dropsWhitespaceOnlyHunk() {                    
+      118 +        String diff = """                                     
+      119 +                diff --git a/src/Bar.java b/src/Bar.java      
+      120 +                @@ -5,3 +5,4 @@                               
+      121 +                +                                             
+      122 +                +\t                                           
+      123 +                 context                                      
+      124 +                @@ -20,2 +21,3 @@                             
+      125 +                -    return old;                              
+      126 +                +    return newVal;                           
+      127 +                """;                                          
+      128 +                                                              
+      129 +        String cleaned = preprocessor.clean(diff);            
+      130 +                                                              
+      131 +        assertThat(cleaned).doesNotContain("@@ -5,");         
+      132 +        assertThat(cleaned).contains("newVal");               
+      133 +    }                                                         
+      134 +                                                              
+      135 +    @Test                                                     
+      136 +    @DisplayName("@Generated hunk는 drop되고 실질 변경 hunk는 
+          +유지된다")                                                    
+      137 +    void clean_dropsGeneratedAnnotationHunk() {               
+      138 +        String diff = """                                     
+      139 +                diff --git a/src/Gen.java b/src/Gen.java      
+      140 +                @@ -1,2 +1,3 @@                               
+      141 +                +@Generated("com.example.generator")          
+      142 +                 public class Gen {}                          
+      143 +                @@ -10,2 +11,3 @@                             
+      144 +                +    String realField = "value";              
+      145 +                """;                                          
+      146 +                                                              
+      147 +        String cleaned = preprocessor.clean(diff);            
+      148 +                                                              
+      149 +        assertThat(cleaned).doesNotContain("@Generated");     
+      150 +        assertThat(cleaned).contains("realField");            
+      151 +    }                                                         
+      152 +                                                              
+      153 +    @Test                                                     
+      154 +    @DisplayName("import + 실질 변경이 섞인 hunk는 통째로 유지
+          +된다")                                                        
+      155 +    void clean_keepsMixedHunk() {                             
+      156 +        String diff = """                                     
+      157 +                diff --git a/src/Baz.java b/src/Baz.java      
+      158 +                @@ -1,3 +1,5 @@                               
+      159 +                +import java.util.List;                       
+      160 +                +    int x = 42;                              
+      161 +                 class Baz {}                                 
+      162 +                """;                                          
+      163 +                                                              
+      164 +        String cleaned = preprocessor.clean(diff);            
+      165 +                                                              
+      166 +        assertThat(cleaned).contains("import java.util.List");
+      167 +        assertThat(cleaned).contains("x = 42");               
+      168 +    }                                                         
+      169 +                                                              
+      170 +    @Test                                                     
+      171 +    @DisplayName("context-only hunk(변경 줄 없음)는 그대로 유 
+          +지된다")                                                      
+      172 +    void clean_keepsContextOnlyHunk() {                       
+      173 +        String diff = """                                     
+      174 +                diff --git a/src/Ctx.java b/src/Ctx.java      
+      175 +                @@ -1,3 +1,3 @@                               
+      176 +                 line1                                        
+      177 +                 line2                                        
+      178 +                 line3                                        
+      179 +                """;                                          
+      180 +                                                              
+      181 +        String cleaned = preprocessor.clean(diff);            
+      182 +                                                              
+      183 +        assertThat(cleaned).contains("line1");                
+      184 +    }                                                         
+      185  }
+
+● Now verify the 5 new tests are RED:
+
+● Bash(./gradlew test --tests "*.DiffPreprocessorTest" -q 2>&1 | tail -20)
+  ⎿  9 tests completed, 3 failed
+
+     FAILURE: Build failed with an exception.
+     … +12 lines (ctrl+o to expand)
+  ⎿  (timeout 1m)
+
+● Good — 3 fail (import-only, whitespace-only, @Generated), 2 pass (mixed,
+  context-only). Now implement the Green.
+
+  Read 1 file (ctrl+o to expand)
+
+● Update(src\main\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssor.java)
+  ⎿  Added 12 lines, removed 1 line
+       8  import java.util.regex.Pattern;
+       9  
+      10  // Stage 2 입력 전처리. unified diff에서 노이즈 파일(lockfile/g
+          enerated/binary/vendored)의 hunk를 통째로 drop.
+      11 -// 언어 불가지론적 — 파일 경로만 본다. Hunk 단위 cleanup(import
+         --only 등)은 Slice 4.                                           
+      11 +// 언어 불가지론적 — 파일 경로만 본다.                         
+      12  @Component
+      13  public class DiffPreprocessor {
+      14  
+      15      // diff --git a/<path> b/<path>
+      16      private static final Pattern DIFF_HEADER = Pattern.compile(
+          "^diff --git a/(\\S+) b/\\S+", Pattern.MULTILINE);
+      17  
+      18 +    // @@ -x,y +a,b @@ optional-context                        
+      19 +    private static final Pattern HUNK_HEADER = Pattern.compile(
+         +"^@@[^\n]*\n", Pattern.MULTILINE);                             
+      20 +                                                               
+      21 +    // import-only: Java/Kotlin, Python, JS/TS (ESM), Rust, Go 
+      22 +    private static final Pattern IMPORT_LINE = Pattern.compile(
+      23 +            "^(import |from .+ import |use |require )", Pattern
+         +.CASE_SENSITIVE);                                              
+      24 +                                                               
+      25 +    // @generated annotation or comment variants               
+      26 +    private static final Pattern GENERATED_LINE = Pattern.compi
+         +le(                                                            
+      27 +            "^\\s*(@\\s*[Gg]enerated\\b|//\\s*[Gg]enerated|/\\*
+         +.*[Gg]enerated)");                                             
+      28 +                                                               
+      29      public static final List<Predicate<String>> BLACKLISTED_PAT
+          H_PATTERNS = List.of(
+      30              // Lockfiles
+      31              exactName("package-lock.json"),
+
+● Now add the filterHunks call in clean() and the implementation:
+
+● Update(src\main\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssor.java)
+  ⎿  Added 1 line, removed 1 line
+      61              int blockStart = m.start();
+      62              int blockEnd = (idx + 1 < starts.length) ? starts[i
+          dx + 1] : unifiedDiff.length();
+      63              if (!isBlacklisted(path)) {
+      64 -                out.append(unifiedDiff, blockStart, blockEnd); 
+      64 +                out.append(filterHunks(unifiedDiff.substring(bl
+         +ockStart, blockEnd)));                                         
+      65              }
+      66              idx++;
+      67          }
+
+● Now add filterHunks and the helper methods before the closing brace:
+
+● Update(src\main\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssor.java)
+  ⎿  Added 62 lines
+       94      private static Predicate<String> prefix(String prefix) {
+       95          return p -> p.startsWith(prefix) || p.contains("/" + p
+           refix);
+       96      }
+       97 +                                                              
+       98 +    // ── Hunk-level cleanup ──                               
+       99 +                                                              
+      100 +    private static String filterHunks(String fileBlock) {     
+      101 +        Matcher m = HUNK_HEADER.matcher(fileBlock);           
+      102 +        if (!m.find()) return fileBlock; // no hunks — keep as
+          +-is                                                           
+      103 +                                                              
+      104 +        // preamble: everything before the first @@ header (in
+          +dex, ---, +++ lines)                                          
+      105 +        StringBuilder out = new StringBuilder(fileBlock, 0, m.
+          +start());                                                     
+      106 +                                                              
+      107 +        do {                                                  
+      108 +            int hunkStart = m.start();                        
+      109 +            int hunkEnd = m.find() ? m.start() : fileBlock.len
+          +gth();                                                        
+      110 +            String hunk = fileBlock.substring(hunkStart, hunkE
+          +nd);                                                          
+      111 +            if (!shouldDropHunk(hunk)) {                      
+      112 +                out.append(hunk);                             
+      113 +            }                                                 
+      114 +            // m.find() already advanced; if it found next hea
+          +der the loop continues                                        
+      115 +        } while (false); // loop control handled inside — rewr
+          +ite with while loop below                                     
+      116 +                                                              
+      117 +        // Reset and redo with proper iteration               
+      118 +        out = new StringBuilder(fileBlock, 0, 0);             
+      119 +        m = HUNK_HEADER.matcher(fileBlock);                   
+      120 +        List<Integer> hunkStarts = new java.util.ArrayList<>()
+          +;                                                             
+      121 +        while (m.find()) hunkStarts.add(m.start());           
+      122 +        if (hunkStarts.isEmpty()) return fileBlock;           
+      123 +                                                              
+      124 +        out.append(fileBlock, 0, hunkStarts.get(0)); // preamb
+          +le                                                            
+      125 +        for (int i = 0; i < hunkStarts.size(); i++) {         
+      126 +            int start = hunkStarts.get(i);                    
+      127 +            int end = (i + 1 < hunkStarts.size()) ? hunkStarts
+          +.get(i + 1) : fileBlock.length();                             
+      128 +            String hunk = fileBlock.substring(start, end);    
+      129 +            if (!shouldDropHunk(hunk)) {                      
+      130 +                out.append(hunk);                             
+      131 +            }                                                 
+      132 +        }                                                     
+      133 +        return out.toString();                                
+      134 +    }                                                         
+      135 +                                                              
+      136 +    private static boolean shouldDropHunk(String hunk) {      
+      137 +        List<String> changedLines = hunk.lines()              
+      138 +                .filter(l -> (l.startsWith("+") || l.startsWit
+          +h("-"))                                                       
+      139 +                        && !l.startsWith("+++") && !l.startsWi
+          +th("---"))                                                    
+      140 +                .map(l -> l.substring(1)) // strip leading +/-
+      141 +                .toList();                                    
+      142 +        if (changedLines.isEmpty()) return false; // context-o
+          +nly hunk — keep                                               
+      143 +        return changedLines.stream().allMatch(DiffPreprocessor
+          +::isImportLine)                                               
+      144 +                || changedLines.stream().allMatch(DiffPreproce
+          +ssor::isWhitespaceLine)                                       
+      145 +                || changedLines.stream().allMatch(DiffPreproce
+          +ssor::isGeneratedLine);                                       
+      146 +    }                                                         
+      147 +                                                              
+      148 +    private static boolean isImportLine(String line) {        
+      149 +        return IMPORT_LINE.matcher(line.stripLeading()).find()
+          +;                                                             
+      150 +    }                                                         
+      151 +                                                              
+      152 +    private static boolean isWhitespaceLine(String line) {    
+      153 +        return line.isBlank();                                
+      154 +    }                                                         
+      155 +                                                              
+      156 +    private static boolean isGeneratedLine(String line) {     
+      157 +        return GENERATED_LINE.matcher(line).find();           
+      158 +    }                                                         
+      159  }
+
+● The filterHunks has a dead do-while block that I need to clean up — the
+  working version is the second iteration:
+
+● Update(src\main\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssor.java)
+  ⎿  Added 2 lines, removed 19 lines
+       99  
+      100      private static String filterHunks(String fileBlock) {
+      101          Matcher m = HUNK_HEADER.matcher(fileBlock);
+      102 -        if (!m.find()) return fileBlock; // no hunks — keep as
+          --is                                                           
+      103 -                                                              
+      104 -        // preamble: everything before the first @@ header (in
+          -dex, ---, +++ lines)                                          
+      105 -        StringBuilder out = new StringBuilder(fileBlock, 0, m.
+          -start());                                                     
+      106 -                                                              
+      107 -        do {                                                  
+      108 -            int hunkStart = m.start();                        
+      109 -            int hunkEnd = m.find() ? m.start() : fileBlock.len
+          -gth();                                                        
+      110 -            String hunk = fileBlock.substring(hunkStart, hunkE
+          -nd);                                                          
+      111 -            if (!shouldDropHunk(hunk)) {                      
+      112 -                out.append(hunk);                             
+      113 -            }                                                 
+      114 -            // m.find() already advanced; if it found next hea
+          -der the loop continues                                        
+      115 -        } while (false); // loop control handled inside — rewr
+          -ite with while loop below                                     
+      116 -                                                              
+      117 -        // Reset and redo with proper iteration               
+      118 -        out = new StringBuilder(fileBlock, 0, 0);             
+      119 -        m = HUNK_HEADER.matcher(fileBlock);                   
+      102          List<Integer> hunkStarts = new java.util.ArrayList<>()
+           ;
+      103          while (m.find()) hunkStarts.add(m.start());
+      104          if (hunkStarts.isEmpty()) return fileBlock;
+      105  
+      124 -        out.append(fileBlock, 0, hunkStarts.get(0)); // preamb
+          -le                                                            
+      106 +        StringBuilder out = new StringBuilder();              
+      107 +        out.append(fileBlock, 0, hunkStarts.get(0)); // preamb
+          +le: index/---/+++ lines                                       
+      108          for (int i = 0; i < hunkStarts.size(); i++) {
+      109              int start = hunkStarts.get(i);
+      110              int end = (i + 1 < hunkStarts.size()) ? hunkStarts
+           .get(i + 1) : fileBlock.length();
+
+● Bash(./gradlew test --tests "*.DiffPreprocessorTest" -q 2>&1 | tail -15)
+  ⎿  * What went wrong:
+     Execution failed for task ':compileJava'.
+     > Compilation failed; see the compiler output below.
+     … +16 lines (ctrl+o to expand)
+  ⎿  (timeout 1m)
+
+● Update(src\main\java\com\back\coach\domain\github\service\summary\DiffPreproce
+        ssor.java)
+  ⎿  Added 1 line, removed 1 line
+      20  
+      21      // import-only: Java/Kotlin, Python, JS/TS (ESM), Rust, Go
+      22      private static final Pattern IMPORT_LINE = Pattern.compile(
+      23 -            "^(import |from .+ import |use |require )", Pattern
+         -.CASE_SENSITIVE);                                              
+      23 +            "^(import |from .+ import |use |require )");       
+      24  
+      25      // @generated annotation or comment variants
+      26      private static final Pattern GENERATED_LINE = Pattern.compi
+          le(
+
+● Bash(./gradlew test --tests "*.DiffPreprocessorTest" -q 2>&1 | tail -15)
+  ⎿  (No output)
+  ⎿  (timeout 1m)
+● All 9 tests pass. Run the full suite:
+
+● Bash(./gradlew test -q 2>&1 | tail -10)
+  ⎿  OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot l
+     oader classes because bootstrap classpath has been appended
+     2026-04-30T17:17:53.576+09:00 INFO  [SpringApplicationShutdownHook] tr
+     … +8 lines (ctrl+o to expand)
+  ⎿  (timeout 2m)
+
+● Bash(./gradlew test -q 2>&1 | grep -E "BUILD|tests completed|FAILED")
+  ⎿  No matches found
+  ⎿  (timeout 2m)
+
+● Bash(./gradlew test 2>&1 | grep -E "BUILD|tests completed|FAILED|passed")
+  ⎿  BUILD SUCCESSFUL in 2s
+  ⎿  (timeout 3m)
+
+● All GREEN. Let me do a final review of the file before committing:
+
+  Read 1 file (ctrl+o to expand)
+
+● Clean. Now commit:
+
+● Bash(git diff --stat HEAD)
+  ⎿  warning: LF will be replaced by CRLF in backend/src/main/java/com/back
+     /coach/domain/github/service/summary/DiffPreprocessor.java.
+     The file will have its original line endings in your working directory
+     … +8 lines (ctrl+o to expand)
+
+● Bash(git add backend/src/main/java/com/back/coach/domain/github/service/summar
+      y/DiffPreprocessor.java
+      backend/src/test/java/com/back/coach/domain/github/service/summ…)
+  ⎿  Error: Exit code 128
+     warning: could not open directory 'backend/backend/src/': No such file or 
+     directory
+     fatal: pathspec 'backend/src/main/java/com/back/coach/domain/github/service
+     /summary/DiffPreprocessor.java' did not match any files
+
+● Bash(git add src/main/java/com/back/coach/domain/github/service/summary/DiffPr
+      eprocessor.java
+      src/test/java/com/back/coach/domain/github/service/summary/DiffPreproce…)
+  ⎿  warning: LF will be replaced by CRLF in backend/src/main/java/com/back
+     /coach/domain/github/service/summary/DiffPreprocessor.java.
+     The file will have its original line endings in your working directory
+     … +6 lines (ctrl+o to expand)
+
+● Done. Slice 4a is committed — 9 tests GREEN (4 existing + 5 new), full suite
+  passes.
+
+  What was added: DiffPreprocessor now has a second filtering pass that operates
+   inside each file block. After the file-level blacklist drops
+  lockfiles/binaries/vendored, filterHunks() splits by @@ ... @@ headers and
+  drops individual hunks where every changed line is an import statement,
+  whitespace, or @Generated annotation. Mixed hunks and context-only hunks are
+  kept intact.
+
+  When you've thought through questions b) and c) for Decision Reversal, we can
+  plan Slice 4b.
+
+❯ what shoudl I do?                                                             
+
+● Two things, in order:
+
+  1. Push the branch and open a PR to dev — you have 3 solid commits
+  (feat/github-http-fetcher is 3 ahead of origin/dev), tests are green,
+  convention-checked. This should ship before starting more work.
+  2. Decide on the two Slice 4b questions so we can continue:
+    - b) HEAD sampling — my recommendation: reuse GithubApiClient directly in
+  GithubAnalysisService (no new fetcher). It's one or two getFileContent() calls
+   per champion file, not a general-purpose fetch. A separate fetcher would be
+  over-abstraction at this scale.
+    - c) Arc grouping — my recommendation: LLM-assigned. Rule-based (co-touched
+  files) is fragile for typical intern/junior commit patterns where file churn
+  is noisy. Stage 1 already reads commit subjects and paths — giving it
+  arc-grouping as an additional output adds zero extra API calls.
+
+  Want me to open the PR now?
+
+※ recap: Building an AI Developer Growth Coach backend in Spring Boot. Slice 3 (GitHub HTTP fetcher) and Slice 4a (hunk-level diff cleanup) are done and committed. Next: push the branch and open a PR to dev.
+
+❯ 일단 hunk commit만 따로 stash 해줘.                                           
+
+● 마지막 커밋(Slice 4a)을 되돌리고 stash에 넣겠습니다.
+
+● Bash(git reset HEAD~1 && git stash push -m "slice-4a: hunk 단위 diff 전처리")
+  ⎿  Unstaged changes after reset:
+     M  backend/src/main/java/com/back/coach/domain/github/service/summary/D
+     i
+     ffPreprocessor.java
+     … +10 lines (ctrl+o to expand)
+
+● 완료. 현재 상태:
+
+  - 브랜치: feat/github-http-fetcher — Slice 3 + convention 커밋 2개만 남음
+  - git stash list로 확인하면 slice-4a: hunk 단위 diff 전처리 가 보관돼 있음
+  - 나중에 git stash pop으로 되살릴 수 있음
+
+※ recap: Building a GitHub-analysis AI coaching service. Slice 3 (GitHub HTTP fetcher) is committed, Slice 4a (hunk diff cleanup) is stashed. Next: push the branch and open a PR to dev.
+
+❯ 깃허브 이슈 템플릿 해줘, 3이랑 4a                                             
+
+● Bash(gh repo view --json nameWithOwner,url 2>&1 | head -5)
+  ⎿  /usr/bin/bash: gh: command not found
+
+● gh CLI가 없네요. 이슈 템플릿 YAML 파일로 만들어드릴게요 —
+  .github/ISSUE_TEMPLATE/ 에 추가하는 방식으로. 기존 feature.yml 스타일에 맞춰
+  작성합니다.
+
+  Slice 3용과 Slice 4a용, 두 파일 동시에 씁니다.
+
+● Write(~\IdeaProjects\INT6-Roadmap-Team06\.github\ISSUE_TEMPLATE\slice3-github-
+       http-fetcher.yml)
+  ⎿  Wrote 54 lines to
+     ..\.github\ISSUE_TEMPLATE\slice3-github-http-fetcher.yml
+       2 description: GitHub OAuth 연결 + 저장소 메타데이터 수집 작업을 
+         등록합니다.
+       3 title: "[Slice 3] GitHub HTTP 패처 — 연결/저장소 API + metadata_
+       4 body:ad 채우기"
+       5   - type: textarea
+       6     id: purpose
+       8       label: 목적
+       9       description: 이 작업이 필요한 이유와 해결하려는 문제를 적
+         어주세요.
+      10       placeholder: |
+     … +65 lines (ctrl+o to expand)
+
+● Write(~\IdeaProjects\INT6-Roadmap-Team06\.github\ISSUE_TEMPLATE\slice4a-hunk-d
+       iff-cleanup.yml)  ⎿  Wrote 49 lines to
+     ..\.github\ISSUE_TEMPLATE\slice4a-hunk-diff-cleanup.yml
+       2 description: DiffPreprocessor 에 hunk 단위 노이즈 제거 작업을 등
+         록합니다.
+       3 title: "[Slice 4a] Hunk 단위 Diff 전처리 — import-only / whitesp
+       4 body:nly / @Generated hunk drop"
+       5   - type: textarea
+       6     id: purpose
+       8       label: 목적
+       9       value: |
+      10         Slice 2의 `DiffPreprocessor`는 lockfile/바이너리/vendore
+         d 파일 블록 전체를 drop한다.
+     … +50 lines (ctrl+o to expand)
+
+● 두 파일 생성 완료:
+
+  - .github/ISSUE_TEMPLATE/slice3-github-http-fetcher.yml
+  - .github/ISSUE_TEMPLATE/slice4a-hunk-diff-cleanup.yml
+
+  기존 feature.yml 스타일(목적 / 작업 내용 / 완료 조건)을 그대로 따랐고, 제목
+  prefix만 [Slice 3] / [Slice 4a] 로 붙였습니다. GitHub 이슈 생성 화면에서 바로
+  선택해서 쓸 수 있습니다.
+
+※ recap: Slice 3 (GitHub HTTP fetcher) and Slice 4a (hunk-level diff cleanup) are done and committed. Slice 4a changes are stashed. Next: push the branch and open a PR to dev.

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.github.dto;
 
 import com.back.coach.global.code.GithubDepthLevel;
 import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.global.code.HighlightStatus;
 
 import java.util.List;
 
@@ -33,7 +34,13 @@ public record GithubAnalysisPayload(
             String repoId,
             String repoName,
             String summary,
-            List<String> highlights
+            List<Highlight> highlights
+    ) {
+    }
+
+    public record Highlight(
+            String text,
+            HighlightStatus status
     ) {
     }
 

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -172,9 +172,11 @@ public class GithubAnalysisService {
         List<ResolvedChampion> out = new ArrayList<>();
         for (Champion c : champions) {
             switch (c.kind()) {
-                case COMMIT -> findCommit(metadata, c.ref()).ifPresent(commit ->
-                        out.add(new ResolvedChampion(c.kind(), c.ref(), commit.subject(),
-                                diffPreprocessor.clean(commit.diffExcerpt()))));
+                case COMMIT -> findCommit(metadata, c.ref()).ifPresent(commit -> {
+                    List<String> subsequent = subsequentSubjects(metadata, c.ref());
+                    out.add(new ResolvedChampion(c.kind(), c.ref(), commit.subject(),
+                            diffPreprocessor.clean(commit.diffExcerpt()), subsequent));
+                });
                 case PR -> findPr(metadata, c.ref()).ifPresent(pr ->
                         out.add(new ResolvedChampion(c.kind(), c.ref(), pr.title(),
                                 pr.bodyExcerpt() == null ? "" : pr.bodyExcerpt())));
@@ -189,6 +191,21 @@ public class GithubAnalysisService {
     private static java.util.Optional<RepoMetadata.CommitItem> findCommit(RepoMetadata m, String sha) {
         return m.commits() == null ? java.util.Optional.empty()
                 : m.commits().stream().filter(c -> sha.equals(c.sha())).findFirst();
+    }
+
+    // GitHub API는 커밋을 최신순(newest-first)으로 반환한다.
+    // 따라서 champion SHA의 인덱스보다 앞(lower index)에 있는 커밋이 champion 이후에 온 커밋이다.
+    private static List<String> subsequentSubjects(RepoMetadata m, String sha) {
+        if (m.commits() == null) return List.of();
+        List<RepoMetadata.CommitItem> commits = m.commits();
+        int idx = -1;
+        for (int i = 0; i < commits.size(); i++) {
+            if (sha.equals(commits.get(i).sha())) { idx = i; break; }
+        }
+        if (idx <= 0) return List.of();
+        return commits.subList(0, Math.min(idx, 5)).stream()
+                .map(RepoMetadata.CommitItem::subject)
+                .toList();
     }
 
     private static java.util.Optional<RepoMetadata.PullRequestItem> findPr(RepoMetadata m, String ref) {

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
@@ -34,7 +34,9 @@ public class RepoSummaryPromptBuilder {
         sb.append("repoName: ").append(repoName).append("\n");
         sb.append("primaryLanguage: ").append(primaryLanguage == null ? "unknown" : primaryLanguage).append("\n\n");
         sb.append("Below are the user's most technically meaningful contributions. ");
-        sb.append("Output a single JSON object {repoId, repoName, summary, highlights[]}.\n\n");
+        sb.append("Output a single JSON object {repoId, repoName, summary, highlights[{text, status}]}.\n");
+        sb.append("Each highlight must have: text (string) and status (ADOPTED|EVOLVED|REVERSED).\n");
+        sb.append("Use REVERSED if a subsequent activity shows the feature was reverted or abandoned.\n\n");
 
         int dropped = 0;
         Champion.Kind currentSection = null;
@@ -66,6 +68,10 @@ public class RepoSummaryPromptBuilder {
         StringBuilder item = new StringBuilder();
         item.append(c.kind()).append(" ").append(c.ref()).append(": ").append(c.headline()).append("\n");
         item.append(truncateBytes(c.body() == null ? "" : c.body(), MAX_ITEM_BYTES)).append("\n");
+        if (!c.subsequentCommitSubjects().isEmpty()) {
+            item.append("Subsequent activity:\n");
+            c.subsequentCommitSubjects().forEach(s -> item.append("  - ").append(s).append("\n"));
+        }
         return item.toString();
     }
 

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParser.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service.summary;
 
+import com.back.coach.global.code.HighlightStatus;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
@@ -44,8 +45,11 @@ public class RepoSummaryResponseParser {
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
         }
 
-        List<String> highlights = new ArrayList<>();
-        root.get("highlights").forEach(n -> highlights.add(n.asText()));
+        List<GithubAnalysisPayload.Highlight> highlights = new ArrayList<>();
+        root.get("highlights").forEach(n -> highlights.add(new GithubAnalysisPayload.Highlight(
+                n.get("text").asText(),
+                HighlightStatus.valueOf(n.get("status").asText())
+        )));
 
         return new GithubAnalysisPayload.RepoSummary(
                 root.get("repoId").asText(),

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/ResolvedChampion.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/ResolvedChampion.java
@@ -2,11 +2,18 @@ package com.back.coach.domain.github.service.summary;
 
 import com.back.coach.domain.github.service.Champion;
 
+import java.util.List;
+
 // Orchestrator가 Champion (kind+ref) → 실제 본문(diff/PR body/issue thread)을 RepoMetadata에서 lookup해 만든 결과.
-// builder는 이 record만 받아 dumb하게 렌더링한다.
+// subsequentCommitSubjects: 이 champion 이후에 온 커밋 제목들 (최신순 최대 5개). LLM이 reversal 감지에 사용.
 public record ResolvedChampion(
         Champion.Kind kind,
         String ref,
         String headline,  // commit subject / PR title / issue title
-        String body       // 전처리된 diff / PR body+review / issue thread
-) {}
+        String body,      // 전처리된 diff / PR body+review / issue thread
+        List<String> subsequentCommitSubjects
+) {
+    public ResolvedChampion(Champion.Kind kind, String ref, String headline, String body) {
+        this(kind, ref, headline, body, List.of());
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.github.service.synthesis;
 
 import com.back.coach.global.code.GithubDepthLevel;
 import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.global.code.HighlightStatus;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,10 +51,13 @@ public class SynthesisPromptBuilder {
             sb.append("\n### ").append(s.repoName()).append(" (id=").append(s.repoId()).append(")\n");
             sb.append(s.summary()).append("\n");
             sb.append("highlights:\n");
-            List<String> hl = compress && s.highlights().size() > COMPRESSED_HIGHLIGHTS_PER_SUMMARY
+            List<GithubAnalysisPayload.Highlight> hl = compress && s.highlights().size() > COMPRESSED_HIGHLIGHTS_PER_SUMMARY
                     ? s.highlights().subList(0, COMPRESSED_HIGHLIGHTS_PER_SUMMARY)
                     : s.highlights();
-            hl.forEach(h -> sb.append("  - ").append(h).append("\n"));
+            hl.forEach(h -> {
+                String prefix = h.status() == HighlightStatus.REVERSED ? "[REVERSED] " : "";
+                sb.append("  - ").append(prefix).append(h.text()).append("\n");
+            });
         }
 
         sb.append("\n## Output\n");

--- a/backend/src/main/java/com/back/coach/global/code/HighlightStatus.java
+++ b/backend/src/main/java/com/back/coach/global/code/HighlightStatus.java
@@ -1,0 +1,12 @@
+package com.back.coach.global.code;
+
+public enum HighlightStatus implements CodeEnum {
+    ADOPTED,
+    EVOLVED,
+    REVERSED;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -2,8 +2,12 @@ package com.back.coach.global.security.oauth2;
 
 import com.back.coach.global.security.CookieManager;
 import com.back.coach.global.security.JwtProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
@@ -11,27 +15,27 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * STATELESS 환경에서 OAuth2AuthorizationRequest 를 쿠키에 저장한다.
  *
  * <p>형식: {@code base64url(payloadLen | payload | hmacSha256(payload))}.
- * 서버는 자기 서명을 검증한 뒤에만 역직렬화하므로, 외부에서 임의 페이로드를 주입한
- * 쿠키로는 절대 deserialization 이 일어나지 않는다 (RCE 차단).
+ * payload 는 Java 직렬화 대신 JSON 으로 저장해 쿠키 크기를 ~400바이트로 유지한다.
+ * HMAC 검증 후에만 역직렬화하므로 외부 주입 페이로드로 인한 RCE 위험이 없다.
  */
 @Component
 @ConditionalOnProperty(prefix = "spring.security.oauth2.client.registration.github", name = "client-id")
 public class CookieOAuth2AuthorizationRequestRepository
         implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final Logger log = LoggerFactory.getLogger(CookieOAuth2AuthorizationRequestRepository.class);
 
     static final String COOKIE_NAME = "oauth2_auth_request";
     private static final Duration COOKIE_TTL = Duration.ofMinutes(5);
@@ -39,6 +43,7 @@ public class CookieOAuth2AuthorizationRequestRepository
 
     private final CookieManager cookieManager;
     private final SecretKeySpec hmacKey;
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public CookieOAuth2AuthorizationRequestRepository(CookieManager cookieManager, JwtProperties jwt) {
         this.cookieManager = cookieManager;
@@ -48,7 +53,16 @@ public class CookieOAuth2AuthorizationRequestRepository
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
         String value = cookieManager.readValue(request, COOKIE_NAME);
-        return value == null ? null : tryDeserialize(value);
+        if (value == null) {
+            log.debug("oauth2_auth_request cookie not found");
+            return null;
+        }
+        log.debug("oauth2_auth_request cookie found, size={} chars", value.length());
+        OAuth2AuthorizationRequest result = tryDeserialize(value);
+        if (result == null) {
+            log.warn("oauth2_auth_request cookie deserialization failed (HMAC mismatch or invalid format)");
+        }
+        return result;
     }
 
     @Override
@@ -59,7 +73,9 @@ public class CookieOAuth2AuthorizationRequestRepository
             cookieManager.clear(response, COOKIE_NAME);
             return;
         }
-        cookieManager.add(response, COOKIE_NAME, serialize(authorizationRequest), COOKIE_TTL);
+        String serialized = serialize(authorizationRequest);
+        log.debug("Saving oauth2_auth_request cookie, size={} chars", serialized.length());
+        cookieManager.add(response, COOKIE_NAME, serialized, COOKIE_TTL);
     }
 
     @Override
@@ -70,16 +86,21 @@ public class CookieOAuth2AuthorizationRequestRepository
         return existing;
     }
 
-    private String serialize(OAuth2AuthorizationRequest authRequest) {
+    private String serialize(OAuth2AuthorizationRequest req) {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-                oos.writeObject(authRequest);
-            }
-            byte[] payload = baos.toByteArray();
-            byte[] sig = sign(payload);
-            ByteBuffer buf = ByteBuffer.allocate(4 + payload.length + sig.length);
-            buf.putInt(payload.length).put(payload).put(sig);
+            CookiePayload payload = new CookiePayload(
+                    req.getAuthorizationUri(),
+                    req.getClientId(),
+                    req.getRedirectUri(),
+                    req.getScopes(),
+                    req.getState(),
+                    req.getAdditionalParameters(),
+                    req.getAuthorizationRequestUri()
+            );
+            byte[] payloadBytes = mapper.writeValueAsBytes(payload);
+            byte[] sig = sign(payloadBytes);
+            ByteBuffer buf = ByteBuffer.allocate(4 + payloadBytes.length + sig.length);
+            buf.putInt(payloadBytes.length).put(payloadBytes).put(sig);
             return Base64.getUrlEncoder().withoutPadding().encodeToString(buf.array());
         } catch (Exception e) {
             throw new IllegalStateException("OAuth2AuthorizationRequest serialize failed", e);
@@ -93,19 +114,26 @@ public class CookieOAuth2AuthorizationRequestRepository
             ByteBuffer buf = ByteBuffer.wrap(raw);
             int len = buf.getInt();
             if (len <= 0 || len > raw.length - 4 - 32) return null;
-            byte[] payload = new byte[len];
-            buf.get(payload);
+            byte[] payloadBytes = new byte[len];
+            buf.get(payloadBytes);
             byte[] expectedSig = new byte[32];
             buf.get(expectedSig);
-            byte[] actualSig = sign(payload);
+            byte[] actualSig = sign(payloadBytes);
             if (!MessageDigest.isEqual(expectedSig, actualSig)) {
                 return null;
             }
-            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(payload))) {
-                Object obj = ois.readObject();
-                return (obj instanceof OAuth2AuthorizationRequest req) ? req : null;
-            }
+            CookiePayload p = mapper.readValue(payloadBytes, CookiePayload.class);
+            return OAuth2AuthorizationRequest.authorizationCode()
+                    .authorizationUri(p.authorizationUri())
+                    .clientId(p.clientId())
+                    .redirectUri(p.redirectUri())
+                    .scopes(p.scopes())
+                    .state(p.state())
+                    .additionalParameters(p.additionalParameters())
+                    .authorizationRequestUri(p.authorizationRequestUri())
+                    .build();
         } catch (Exception e) {
+            log.warn("oauth2_auth_request deserialization exception: {}", e.getMessage());
             return null;
         }
     }
@@ -125,4 +153,15 @@ public class CookieOAuth2AuthorizationRequestRepository
             throw new IllegalStateException("Cannot derive HMAC key", e);
         }
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record CookiePayload(
+            String authorizationUri,
+            String clientId,
+            String redirectUri,
+            Set<String> scopes,
+            String state,
+            Map<String, Object> additionalParameters,
+            String authorizationRequestUri
+    ) {}
 }

--- a/backend/src/main/resources/ai/schema/repo-summary.schema.json
+++ b/backend/src/main/resources/ai/schema/repo-summary.schema.json
@@ -11,7 +11,15 @@
     "highlights": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "object",
+        "required": ["text", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "text":   { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["ADOPTED", "EVOLVED", "REVERSED"] }
+        }
+      }
     }
   }
 }

--- a/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
@@ -1,0 +1,252 @@
+package com.back.coach.domain.flow;
+
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.external.github.GithubApiClient;
+import com.back.coach.external.github.dto.GithubRepoDto;
+import com.back.coach.external.github.dto.GithubUserInfoDto;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.security.JwtTokenProvider;
+import com.back.coach.support.ApiTestBase;
+import com.back.coach.support.JwtAuthHelper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GithubAnalysisE2eTest extends ApiTestBase {
+
+    private static final WireMockServer wireMock;
+
+    static {
+        wireMock = new WireMockServer(options().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        wireMock.stop();
+    }
+
+    @DynamicPropertySource
+    static void overrideAiGatewayUrl(DynamicPropertyRegistry registry) {
+        registry.add("ai.gateway.base-url", () -> "http://127.0.0.1:" + wireMock.port());
+    }
+
+    @MockitoBean
+    private GithubApiClient githubApiClient;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private User user;
+    private String authHeader;
+
+    @BeforeEach
+    void setUpUser() {
+        String unique = UUID.randomUUID().toString().substring(0, 8);
+        user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-" + unique, "e2e-" + unique + "@test.com"));
+        authHeader = JwtAuthHelper.bearerToken(jwtTokenProvider, user.getId());
+    }
+
+    @Test
+    @DisplayName("GitHub 연결 → 저장소 목록 조회 → 분석 실행 → 분석 결과 조회 전체 플로우")
+    void fullFlow_connectAndAnalyse() throws Exception {
+        // GitHub API mock
+        given(githubApiClient.exchangeCode("auth-code-123")).willReturn("ghp_fake_token");
+        given(githubApiClient.getUserInfo("ghp_fake_token"))
+                .willReturn(new GithubUserInfoDto(99L, "testuser"));
+        given(githubApiClient.listUserRepos("ghp_fake_token")).willReturn(List.of(
+                new GithubRepoDto("node-1", "testuser/backend", "https://github.com/testuser/backend", "Java", "main", false)
+        ));
+        given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
+        given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of("Java", 10000L));
+        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), any(int.class))).willReturn(List.of());
+        given(githubApiClient.listPullRequests(anyString(), anyString(), anyString())).willReturn(List.of());
+        given(githubApiClient.listIssues(anyString(), anyString(), anyString())).willReturn(List.of());
+
+        // LLM mock — Slice 4b highlight 형식
+        stubLlm("Candidates", triageResponse());
+        stubLlm("repoId:", summaryResponse());
+        stubLlm("Static Signals", synthesisResponse());
+
+        // 1. GitHub 연결
+        String connectResult = mockMvc.perform(
+                        post("/api/github/connections")
+                                .header("Authorization", authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"authorizationCode\":\"auth-code-123\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.githubConnectionId").isNotEmpty())
+                .andExpect(jsonPath("$.data.githubLogin").value("testuser"))
+                .andReturn().getResponse().getContentAsString();
+
+        long connectionId = extractLong(connectResult, "githubConnectionId");
+
+        // 2. 저장소 목록 조회
+        String reposResult = mockMvc.perform(
+                        get("/api/github/repositories")
+                                .header("Authorization", authHeader)
+                                .param("githubConnectionId", String.valueOf(connectionId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.repositories").isArray())
+                .andExpect(jsonPath("$.data.repositories[0].repoFullName").value("testuser/backend"))
+                .andReturn().getResponse().getContentAsString();
+
+        long repoId = extractLong(reposResult, "repositoryId");
+
+        // 3. 분석 실행
+        String analysisResult = mockMvc.perform(
+                        post("/api/github-analyses")
+                                .header("Authorization", authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(String.format(
+                                        "{\"githubConnectionId\":%d,\"selectedRepositoryIds\":[%d],\"coreRepositoryIds\":[%d]}",
+                                        connectionId, repoId, repoId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.githubAnalysisId").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+
+        long analysisId = extractLong(analysisResult, "githubAnalysisId");
+
+        // 4. 분석 결과 조회 — Slice 4b highlight 형식 검증
+        mockMvc.perform(
+                        get("/api/github-analyses/{id}", analysisId)
+                                .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].text").value("Spring Boot 도입"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].status").value("ADOPTED"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[1].text").value("GraphQL 시도 후 제거"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[1].status").value("REVERSED"))
+                .andExpect(jsonPath("$.data.finalTechProfile.confirmedSkills[0]").value("Spring Boot"));
+    }
+
+    @Test
+    @DisplayName("REVERSED highlight가 API 응답 JSON에 올바르게 직렬화된다")
+    void analysis_reversedHighlightSerializesCorrectly() throws Exception {
+        given(githubApiClient.exchangeCode("code-reversed")).willReturn("ghp_rev_token");
+        given(githubApiClient.getUserInfo("ghp_rev_token"))
+                .willReturn(new GithubUserInfoDto(88L, "revuser"));
+        given(githubApiClient.listUserRepos("ghp_rev_token")).willReturn(List.of(
+                new GithubRepoDto("node-2", "revuser/api", "https://github.com/revuser/api", "Java", "main", false)
+        ));
+        given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
+        given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of());
+        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), any(int.class))).willReturn(List.of());
+        given(githubApiClient.listPullRequests(anyString(), anyString(), anyString())).willReturn(List.of());
+        given(githubApiClient.listIssues(anyString(), anyString(), anyString())).willReturn(List.of());
+
+        stubLlm("Candidates", triageResponse());
+        stubLlm("repoId:", summaryResponseWithReversed());
+        stubLlm("Static Signals", synthesisResponse());
+
+        String connectResult = mockMvc.perform(
+                        post("/api/github/connections")
+                                .header("Authorization", authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"authorizationCode\":\"code-reversed\"}"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        long connectionId = extractLong(connectResult, "githubConnectionId");
+
+        String reposResult = mockMvc.perform(
+                        get("/api/github/repositories")
+                                .header("Authorization", authHeader)
+                                .param("githubConnectionId", String.valueOf(connectionId)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        long repoId = extractLong(reposResult, "repositoryId");
+
+        String analysisResult = mockMvc.perform(
+                        post("/api/github-analyses")
+                                .header("Authorization", authHeader)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(String.format(
+                                        "{\"githubConnectionId\":%d,\"selectedRepositoryIds\":[%d],\"coreRepositoryIds\":[%d]}",
+                                        connectionId, repoId, repoId)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        long analysisId = extractLong(analysisResult, "githubAnalysisId");
+
+        mockMvc.perform(
+                        get("/api/github-analyses/{id}", analysisId)
+                                .header("Authorization", authHeader))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].status").value("REVERSED"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].text").isNotEmpty());
+    }
+
+    private void stubLlm(String promptContains, String content) {
+        wireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/v1/chat/completions")
+                .withRequestBody(matchingJsonPath("$.messages[0].content",
+                        new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*" + promptContains + ".*")))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(chatResponse(content))));
+    }
+
+    private static String chatResponse(String content) {
+        String escaped = content.replace("\"", "\\\"");
+        return "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"" + escaped + "\"}}]}";
+    }
+
+    private static String triageResponse() {
+        return "{\"champions\":[{\"kind\":\"COMMIT\",\"ref\":\"abc123\",\"reason\":\"Spring Boot 핵심 로직\"}]}";
+    }
+
+    private static String summaryResponse() {
+        return "{\"repoId\":\"REPO_ID_PLACEHOLDER\",\"repoName\":\"testuser/backend\",\"summary\":\"Spring Boot 백엔드 서비스\"," +
+                "\"highlights\":[{\"text\":\"Spring Boot 도입\",\"status\":\"ADOPTED\"},{\"text\":\"GraphQL 시도 후 제거\",\"status\":\"REVERSED\"}]}";
+    }
+
+    private static String summaryResponseWithReversed() {
+        return "{\"repoId\":\"REPO_ID_PLACEHOLDER\",\"repoName\":\"revuser/api\",\"summary\":\"실험적 아키텍처\"," +
+                "\"highlights\":[{\"text\":\"마이크로서비스 전환 시도\",\"status\":\"REVERSED\"}]}";
+    }
+
+    private static String synthesisResponse() {
+        return "{\"techTags\":[{\"skillName\":\"Spring Boot\",\"tagReason\":\"백엔드 프레임워크\"}]," +
+                "\"depthEstimates\":[{\"skillName\":\"Spring Boot\",\"level\":\"PRACTICAL\",\"reason\":\"일관된 사용\"}]," +
+                "\"evidences\":[{\"repoName\":\"testuser/backend\",\"type\":\"COMMIT\",\"source\":\"abc123\",\"summary\":\"핵심 로직\"}]," +
+                "\"finalTechProfile\":{\"confirmedSkills\":[\"Spring Boot\"],\"focusAreas\":[\"백엔드\"]}}";
+    }
+
+    private static long extractLong(String json, String field) {
+        int idx = json.indexOf("\"" + field + "\":");
+        if (idx < 0) throw new AssertionError(field + " not found in: " + json);
+        int start = idx + field.length() + 3;
+        // handle quoted string IDs
+        if (json.charAt(start) == '"') {
+            int end = json.indexOf('"', start + 1);
+            return Long.parseLong(json.substring(start + 1, end));
+        }
+        int end = start;
+        while (end < json.length() && (Character.isDigit(json.charAt(end)))) end++;
+        return Long.parseLong(json.substring(start, end));
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
@@ -227,7 +227,8 @@ class V1ResultFlowIntegrationTest {
                         "1",
                         "user/backend",
                         "Spring Boot API 구현 경험",
-                        List.of("REST API", "JPA")
+                        List.of(new GithubAnalysisPayload.Highlight("REST API", com.back.coach.global.code.HighlightStatus.ADOPTED),
+                                new GithubAnalysisPayload.Highlight("JPA", com.back.coach.global.code.HighlightStatus.ADOPTED))
                 )),
                 List.of(),
                 List.of(),

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerUnitTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerUnitTest.java
@@ -84,7 +84,8 @@ class GithubAnalysisControllerUnitTest {
                                 "9001",
                                 "team06/ai-growth-coach",
                                 "Spring Boot backend service",
-                                List.of("Redis cache", "Batch processing")
+                                List.of(new GithubAnalysisPayload.Highlight("Redis cache", com.back.coach.global.code.HighlightStatus.ADOPTED),
+                                        new GithubAnalysisPayload.Highlight("Batch processing", com.back.coach.global.code.HighlightStatus.ADOPTED))
                         )),
                         List.of(new GithubAnalysisPayload.TechTag(
                                 "Redis",
@@ -126,7 +127,8 @@ class GithubAnalysisControllerUnitTest {
                 .andExpect(jsonPath("$.data.repoSummaries[0].repoId").value("9001"))
                 .andExpect(jsonPath("$.data.repoSummaries[0].repoName").value("team06/ai-growth-coach"))
                 .andExpect(jsonPath("$.data.repoSummaries[0].summary").value("Spring Boot backend service"))
-                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0]").value("Redis cache"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].text").value("Redis cache"))
+                .andExpect(jsonPath("$.data.repoSummaries[0].highlights[0].status").value("ADOPTED"))
                 .andExpect(jsonPath("$.data.techTags[0].skillName").value("Redis"))
                 .andExpect(jsonPath("$.data.depthEstimates[0].level").value("APPLIED"))
                 .andExpect(jsonPath("$.data.evidences[0].type").value("CODE"))

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
@@ -73,7 +73,10 @@ class GithubAnalysisDetailServiceTest {
                 "9001",
                 "team06/ai-growth-coach",
                 "Spring Boot backend service",
-                java.util.List.of("Redis cache", "Batch processing")
+                java.util.List.of(
+                        new GithubAnalysisPayload.Highlight("Redis cache", com.back.coach.global.code.HighlightStatus.ADOPTED),
+                        new GithubAnalysisPayload.Highlight("Batch processing", com.back.coach.global.code.HighlightStatus.ADOPTED)
+                )
         ));
         assertThat(result.techTags()).containsExactly(new GithubAnalysisPayload.TechTag(
                 "Redis",
@@ -149,7 +152,8 @@ class GithubAnalysisDetailServiceTest {
                 "9001",
                 "team06/ai-growth-coach",
                 "Spring Boot backend service",
-                List.of("Redis cache", "Batch processing")
+                List.of(new GithubAnalysisPayload.Highlight("Redis cache", com.back.coach.global.code.HighlightStatus.ADOPTED),
+                        new GithubAnalysisPayload.Highlight("Batch processing", com.back.coach.global.code.HighlightStatus.ADOPTED))
         ));
         assertThat(updatedPayload.techTags()).containsExactly(new GithubAnalysisPayload.TechTag(
                 "Redis",
@@ -242,8 +246,8 @@ class GithubAnalysisDetailServiceTest {
                       "repoName": "team06/ai-growth-coach",
                       "summary": "Spring Boot backend service",
                       "highlights": [
-                        "Redis cache",
-                        "Batch processing"
+                        {"text": "Redis cache", "status": "ADOPTED"},
+                        {"text": "Batch processing", "status": "ADOPTED"}
                       ]
                     }
                   ],

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisFlowIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisFlowIntegrationTest.java
@@ -69,20 +69,20 @@ class GithubAnalysisFlowIntegrationTest {
     void fullFlow_persistsAnalysisRow() {
         wireMock.resetAll();
         // Triage: 프롬프트에 "Candidates" 포함 → champion 1개 반환
-        wireMock.stubFor(post("/v1/completions")
-                .withRequestBody(matchingJsonPath("$.prompt", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*Candidates.*")))
+        wireMock.stubFor(post("/v1/chat/completions")
+                .withRequestBody(matchingJsonPath("$.messages[0].content", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*Candidates.*")))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"{\\\"champions\\\":[{\\\"kind\\\":\\\"COMMIT\\\",\\\"ref\\\":\\\"abc\\\",\\\"reason\\\":\\\"OAuth\\\"}]}\"}")));
-        // Per-repo summary: 프롬프트에 "Repository" + "repoId" 포함
-        wireMock.stubFor(post("/v1/completions")
-                .withRequestBody(matchingJsonPath("$.prompt", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*repoId:.*")))
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"champions\\\":[{\\\"kind\\\":\\\"COMMIT\\\",\\\"ref\\\":\\\"abc\\\",\\\"reason\\\":\\\"OAuth\\\"}]}\"}}]}")));
+        // Per-repo summary: 프롬프트에 "repoId" 포함
+        wireMock.stubFor(post("/v1/chat/completions")
+                .withRequestBody(matchingJsonPath("$.messages[0].content", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*repoId:.*")))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"{\\\"repoId\\\":\\\"PROJECT_ID\\\",\\\"repoName\\\":\\\"user/cool\\\",\\\"summary\\\":\\\"Spring Boot\\\",\\\"highlights\\\":[\\\"OAuth\\\"]}\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"repoId\\\":\\\"PROJECT_ID\\\",\\\"repoName\\\":\\\"user/cool\\\",\\\"summary\\\":\\\"Spring Boot\\\",\\\"highlights\\\":[{\\\"text\\\":\\\"OAuth\\\",\\\"status\\\":\\\"ADOPTED\\\"}]}\"}}]}")));
         // Synthesis: 프롬프트에 "Static Signals" 포함
-        wireMock.stubFor(post("/v1/completions")
-                .withRequestBody(matchingJsonPath("$.prompt", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*Static Signals.*")))
+        wireMock.stubFor(post("/v1/chat/completions")
+                .withRequestBody(matchingJsonPath("$.messages[0].content", new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*Static Signals.*")))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
-                        .withBody("{\"text\":\"{\\\"techTags\\\":[{\\\"skillName\\\":\\\"Spring Boot\\\",\\\"tagReason\\\":\\\"백엔드\\\"}],\\\"depthEstimates\\\":[{\\\"skillName\\\":\\\"Spring Boot\\\",\\\"level\\\":\\\"PRACTICAL\\\",\\\"reason\\\":\\\"r\\\"}],\\\"evidences\\\":[{\\\"repoName\\\":\\\"user/cool\\\",\\\"type\\\":\\\"COMMIT\\\",\\\"source\\\":\\\"abc\\\",\\\"summary\\\":\\\"x\\\"}],\\\"finalTechProfile\\\":{\\\"confirmedSkills\\\":[\\\"Spring Boot\\\"],\\\"focusAreas\\\":[]}}\"}")));
+                        .withBody("{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"techTags\\\":[{\\\"skillName\\\":\\\"Spring Boot\\\",\\\"tagReason\\\":\\\"백엔드\\\"}],\\\"depthEstimates\\\":[{\\\"skillName\\\":\\\"Spring Boot\\\",\\\"level\\\":\\\"PRACTICAL\\\",\\\"reason\\\":\\\"r\\\"}],\\\"evidences\\\":[{\\\"repoName\\\":\\\"user/cool\\\",\\\"type\\\":\\\"COMMIT\\\",\\\"source\\\":\\\"abc\\\",\\\"summary\\\":\\\"x\\\"}],\\\"finalTechProfile\\\":{\\\"confirmedSkills\\\":[\\\"Spring Boot\\\"],\\\"focusAreas\\\":[]}}\"}}]}")));
 
         User user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-int-1", "int1@example.com"));
         GithubConnection connection = connectionRepository.save(GithubConnection.connect(

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisPayloadJsonTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisPayloadJsonTest.java
@@ -3,6 +3,7 @@ package com.back.coach.domain.github.service;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.global.code.GithubDepthLevel;
 import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.global.code.HighlightStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +24,8 @@ class GithubAnalysisPayloadJsonTest {
                                 new GithubAnalysisPayload.PrimaryLanguage("TypeScript", 0.3)),
                         3, "WEEKLY", "CONSISTENT"),
                 List.of(new GithubAnalysisPayload.RepoSummary("1", "user/cool-app", "Spring Boot 백엔드",
-                        List.of("OAuth2 도입", "JPA 마이그레이션"))),
+                        List.of(new GithubAnalysisPayload.Highlight("OAuth2 도입", HighlightStatus.ADOPTED),
+                                new GithubAnalysisPayload.Highlight("JPA 마이그레이션", HighlightStatus.EVOLVED)))),
                 List.of(new GithubAnalysisPayload.TechTag("Spring Boot", "주요 백엔드 프레임워크")),
                 List.of(new GithubAnalysisPayload.DepthEstimate("Spring Boot", GithubDepthLevel.PRACTICAL, "여러 repo에서 일관된 사용")),
                 List.of(new GithubAnalysisPayload.GithubEvidence("user/cool-app", GithubEvidenceType.COMMIT, "abc123", "OAuth2 핸들러 추가")),

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -74,7 +74,7 @@ class GithubAnalysisServiceTest {
                 {"champions":[{"kind":"COMMIT","ref":"abc","reason":"OAuth"}]}
                 """;
         repoSummaryJson = """
-                {"repoId":"1","repoName":"user/a","summary":"Spring Boot","highlights":["OAuth"]}
+                {"repoId":"1","repoName":"user/a","summary":"Spring Boot","highlights":[{"text":"OAuth","status":"ADOPTED"}]}
                 """;
         synthesisJson = """
                 {

--- a/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilderTest.java
@@ -28,8 +28,9 @@ class RepoSummaryPromptBuilderTest {
         assertThat(prompt).contains("COMMIT").contains("abc").contains("feat: OAuth").contains("diff body here");
         assertThat(prompt).contains("PR").contains("42").contains("Add OAuth").contains("PR body discussion");
         assertThat(prompt).contains("ISSUE").contains("7").contains("Login broken").contains("issue thread");
-        // RepoSummary JSON 응답 형식을 LLM에 알려주는 instruction marker가 있어야 함
-        assertThat(prompt.toLowerCase()).contains("json");
+        // RepoSummary JSON 응답 형식과 highlight status enum을 LLM에 알려주는 instruction이 있어야 함
+        assertThat(prompt).contains("highlights[{text, status}]");
+        assertThat(prompt).contains("ADOPTED").contains("EVOLVED").contains("REVERSED");
     }
 
     @Test
@@ -64,11 +65,26 @@ class RepoSummaryPromptBuilderTest {
     }
 
     @Test
+    @DisplayName("COMMIT champion에 후속 커밋이 있으면 Subsequent activity 섹션이 렌더링된다")
+    void build_renderSubsequentActivity() {
+        List<ResolvedChampion> champions = List.of(
+                new ResolvedChampion(Champion.Kind.COMMIT, "abc", "feat: OAuth", "diff",
+                        List.of("revert: OAuth 롤백", "fix: 인증 우회"))
+        );
+
+        String prompt = builder.build("1", "user/r", "Java", champions);
+
+        assertThat(prompt).contains("Subsequent activity");
+        assertThat(prompt).contains("revert: OAuth 롤백");
+        assertThat(prompt).contains("fix: 인증 우회");
+    }
+
+    @Test
     @DisplayName("champion이 비어있어도 빌드 성공 — repo header만 포함")
     void build_emptyChampions() {
         String prompt = builder.build("1", "user/r", "Java", List.of());
 
         assertThat(prompt).contains("user/r");
-        assertThat(prompt.toLowerCase()).contains("json"); // 출력 형식 안내는 항상 포함
+        assertThat(prompt).contains("highlights[{text, status}]");
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service.summary;
 
+import com.back.coach.global.code.HighlightStatus;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
@@ -21,7 +22,10 @@ class RepoSummaryResponseParserTest {
                   "repoId": "1",
                   "repoName": "user/cool-app",
                   "summary": "Spring Boot 백엔드 + OAuth 도입",
-                  "highlights": ["OAuth2 핸들러", "JPA 마이그레이션"]
+                  "highlights": [
+                    {"text": "OAuth2 핸들러", "status": "ADOPTED"},
+                    {"text": "JPA 마이그레이션", "status": "EVOLVED"}
+                  ]
                 }
                 """;
 
@@ -30,6 +34,29 @@ class RepoSummaryResponseParserTest {
         assertThat(summary.repoId()).isEqualTo("1");
         assertThat(summary.repoName()).isEqualTo("user/cool-app");
         assertThat(summary.highlights()).hasSize(2);
+        assertThat(summary.highlights().get(0).text()).isEqualTo("OAuth2 핸들러");
+        assertThat(summary.highlights().get(0).status()).isEqualTo(HighlightStatus.ADOPTED);
+        assertThat(summary.highlights().get(1).status()).isEqualTo(HighlightStatus.EVOLVED);
+    }
+
+    @Test
+    @DisplayName("REVERSED 상태의 highlight도 정상 파싱한다")
+    void parse_reversedHighlight() {
+        String json = """
+                {
+                  "repoId": "2",
+                  "repoName": "user/repo",
+                  "summary": "실험적 기능 도입 후 롤백",
+                  "highlights": [
+                    {"text": "GraphQL 도입 시도", "status": "REVERSED"}
+                  ]
+                }
+                """;
+
+        GithubAnalysisPayload.RepoSummary summary = parser.parse(json);
+
+        assertThat(summary.highlights()).hasSize(1);
+        assertThat(summary.highlights().get(0).status()).isEqualTo(HighlightStatus.REVERSED);
     }
 
     @Test
@@ -39,7 +66,7 @@ class RepoSummaryResponseParserTest {
                 {
                   "repoId": "1",
                   "repoName": "user/x",
-                  "highlights": ["a"]
+                  "highlights": [{"text": "a", "status": "ADOPTED"}]
                 }
                 """;
 
@@ -66,14 +93,31 @@ class RepoSummaryResponseParserTest {
     }
 
     @Test
-    @DisplayName("타입 불일치(highlights가 string)이면 LLM_INVALID_RESPONSE")
+    @DisplayName("highlight status가 허용되지 않은 값이면 LLM_INVALID_RESPONSE")
+    void parse_invalidStatus_throws() {
+        String json = """
+                {
+                  "repoId": "1",
+                  "repoName": "user/x",
+                  "summary": "s",
+                  "highlights": [{"text": "a", "status": "UNKNOWN"}]
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("highlights가 string 배열이면 LLM_INVALID_RESPONSE (schema 위반)")
     void parse_wrongType_throws() {
         String json = """
                 {
                   "repoId": "1",
                   "repoName": "user/x",
                   "summary": "s",
-                  "highlights": "not an array"
+                  "highlights": ["not an object"]
                 }
                 """;
 

--- a/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilderTest.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.github.service.synthesis;
 
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.global.code.HighlightStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,9 +24,17 @@ class SynthesisPromptBuilderTest {
         );
         List<GithubAnalysisPayload.RepoSummary> summaries = List.of(
                 new GithubAnalysisPayload.RepoSummary("1", "user/a", "Spring Boot 백엔드",
-                        List.of("OAuth2", "JPA", "Flyway", "Testcontainers")),
+                        List.of(
+                                new GithubAnalysisPayload.Highlight("OAuth2", HighlightStatus.ADOPTED),
+                                new GithubAnalysisPayload.Highlight("JPA", HighlightStatus.EVOLVED),
+                                new GithubAnalysisPayload.Highlight("Flyway", HighlightStatus.REVERSED),
+                                new GithubAnalysisPayload.Highlight("Testcontainers", HighlightStatus.ADOPTED)
+                        )),
                 new GithubAnalysisPayload.RepoSummary("2", "user/b", "Python ETL",
-                        List.of("pandas", "Airflow"))
+                        List.of(
+                                new GithubAnalysisPayload.Highlight("pandas", HighlightStatus.ADOPTED),
+                                new GithubAnalysisPayload.Highlight("Airflow", HighlightStatus.ADOPTED)
+                        ))
         );
 
         String prompt = builder.build(signals, summaries);
@@ -33,6 +42,8 @@ class SynthesisPromptBuilderTest {
         assertThat(prompt).contains("Java").contains("0.7").contains("Python");
         assertThat(prompt).contains("user/a").contains("user/b");
         assertThat(prompt).contains("OAuth2").contains("pandas");
+        assertThat(prompt).contains("[REVERSED] Flyway");
+        assertThat(prompt).doesNotContain("[REVERSED] OAuth2");
         // 출력 형식 / enum 값 안내
         assertThat(prompt).contains("INTRO").contains("APPLIED").contains("PRACTICAL").contains("DEEP");
         assertThat(prompt).contains("README").contains("CODE").contains("CONFIG").contains("REPO_METADATA").contains("COMMIT");
@@ -46,7 +57,10 @@ class SynthesisPromptBuilderTest {
         List<GithubAnalysisPayload.RepoSummary> bigSummaries = IntStream.range(0, 8)
                 .mapToObj(i -> new GithubAnalysisPayload.RepoSummary(
                         String.valueOf(i), "repo" + i, "S".repeat(500),
-                        IntStream.range(0, 30).mapToObj(j -> "highlight-" + i + "-" + j + "-" + "X".repeat(80)).toList()
+                        IntStream.range(0, 30).mapToObj(j -> new GithubAnalysisPayload.Highlight(
+                                "highlight-" + i + "-" + j + "-" + "X".repeat(80),
+                                HighlightStatus.ADOPTED
+                        )).toList()
                 ))
                 .toList();
 

--- a/backend/src/test/java/com/back/coach/global/code/CodeEnumsTest.java
+++ b/backend/src/test/java/com/back/coach/global/code/CodeEnumsTest.java
@@ -45,6 +45,7 @@ class CodeEnumsTest {
         assertCodes(RoadmapTaskType.class, "READ_DOCS", "BUILD_EXAMPLE", "WRITE_NOTE", "APPLY_PROJECT", "REVIEW");
         assertCodes(MaterialType.class, "DOCS", "ARTICLE", "REPOSITORY", "VIDEO", "TEMPLATE");
         assertCodes(JobStatus.class, "REQUESTED", "RUNNING", "SUCCEEDED", "FAILED");
+        assertCodes(HighlightStatus.class, "ADOPTED", "EVOLVED", "REVERSED");
     }
 
     @SafeVarargs

--- a/backend/src/test/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -43,6 +43,8 @@ class CookieOAuth2AuthorizationRequestRepositoryTest {
                 .contains("SameSite=Lax");
 
         String value = extractCookieValue(cookieHeader);
+        // JSON 직렬화로 쿠키 크기가 4KB 미만임을 검증
+        assertThat(value.length()).isLessThan(2000);
         MockHttpServletRequest loadRequest = new MockHttpServletRequest();
         loadRequest.setCookies(new Cookie("oauth2_auth_request", value));
 

--- a/backend/src/test/java/com/back/coach/support/JwtAuthHelper.java
+++ b/backend/src/test/java/com/back/coach/support/JwtAuthHelper.java
@@ -1,0 +1,21 @@
+package com.back.coach.support;
+
+import com.back.coach.global.security.JwtTokenProvider;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+public final class JwtAuthHelper {
+
+    private JwtAuthHelper() {}
+
+    public static String bearerToken(JwtTokenProvider provider, Long userId) {
+        return "Bearer " + provider.createAccessToken(userId);
+    }
+
+    public static MockHttpServletRequestBuilder withAuth(
+            MockHttpServletRequestBuilder builder,
+            JwtTokenProvider provider,
+            Long userId) {
+        return builder.header(HttpHeaders.AUTHORIZATION, bearerToken(provider, userId));
+    }
+}


### PR DESCRIPTION
## Summary

- **Slice 4b**: `highlights[{text, status}]` 도입 — LLM이 ADOPTED/EVOLVED/REVERSED를 판단, 후속 커밋 activity 섹션 추가
- **OAuth 수정**: `oauth2_auth_request` 쿠키 Java 직렬화 → JSON 직렬화로 교체 (4KB 초과 → ~400바이트)
- **E2e 테스트**: `GithubAnalysisE2eTest` — MockMvc로 GitHub 연결~분석~결과 조회 전 구간 HTTP 검증

Closes #151

## Test plan

- [ ] `./gradlew test integrationTest` 전체 통과 확인
- [ ] `GithubAnalysisE2eTest` — highlight `{text, status}` 형식 및 REVERSED 상태 응답 검증
- [ ] `CookieOAuth2AuthorizationRequestRepositoryTest` — 쿠키 크기 < 2000자 검증
- [ ] 브라우저에서 GitHub OAuth 첫 시도 성공 확인