### PR TITLE
chore: 로컬 스모크 테스트용 Postman collection 추가

### DIFF
--- a/coach-backend.postman_collection.json
+++ b/coach-backend.postman_collection.json
@@ -1,0 +1,414 @@
+{
+  "info": {
+    "name": "Coach Backend",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl",           "value": "http://localhost:8080" },
+    { "key": "accessToken",       "value": "" },
+    { "key": "githubConnectionId","value": "" },
+    { "key": "repoId",            "value": "" },
+    { "key": "githubAnalysisId",  "value": "" },
+    { "key": "profileId",         "value": "" },
+    { "key": "diagnosisId",       "value": "" },
+    { "key": "roadmapId",         "value": "" },
+    { "key": "roadmapWeekId",     "value": "" }
+  ],
+  "item": [
+    {
+      "name": "0. Auth",
+      "item": [
+        {
+          "name": "GitHub OAuth 로그인 (브라우저)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/oauth2/authorization/github",
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth2", "authorization", "github"]
+            },
+            "description": "브라우저에서 열기 → GitHub 로그인 → 리다이렉트 후 쿠키에서 accessToken 복사 → 컬렉션 변수 accessToken에 붙여넣기.\n\nDevTools > Application > Cookies > localhost:8080 > accessToken"
+          }
+        },
+        {
+          "name": "내 정보 조회 (토큰 확인용)",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "me"]
+            }
+          }
+        },
+        {
+          "name": "토큰 갱신",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/refresh",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "refresh"]
+            },
+            "description": "refreshToken 쿠키가 있어야 동작합니다. Postman Cookies 탭에서 확인하세요."
+          }
+        },
+        {
+          "name": "로그아웃",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/logout",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "auth", "logout"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "1. Profile",
+      "item": [
+        {
+          "name": "프로필 저장",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.profileId) {",
+                  "    pm.collectionVariables.set('profileId', res.data.profileId);",
+                  "    console.log('profileId set:', res.data.profileId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetRole\": \"백엔드 개발자\",\n  \"currentLevel\": \"JUNIOR\",\n  \"skills\": [\n    { \"skillName\": \"Java\", \"proficiencyLevel\": \"INTERMEDIATE\" },\n    { \"skillName\": \"Spring Boot\", \"proficiencyLevel\": \"BASIC\" }\n  ],\n  \"interestAreas\": [\"백엔드\", \"API 설계\"],\n  \"weeklyStudyHours\": 10,\n  \"targetDate\": \"2026-12-31\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/profiles",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "profiles"]
+            },
+            "description": "currentLevel: BEGINNER | BASIC | JUNIOR | INTERMEDIATE | ADVANCED\nproficiencyLevel: BEGINNER | BASIC | INTERMEDIATE | ADVANCED | EXPERT"
+          }
+        },
+        {
+          "name": "내 프로필 조회",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/profiles/me",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "profiles", "me"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "2. GitHub Connection",
+      "item": [
+        {
+          "name": "GitHub 연결 (authorizationCode 필요)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.connectionId) {",
+                  "    pm.collectionVariables.set('githubConnectionId', res.data.connectionId);",
+                  "    console.log('githubConnectionId set:', res.data.connectionId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"authorizationCode\": \"PASTE_GITHUB_OAUTH_CODE_HERE\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/github/connections",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "github", "connections"]
+            },
+            "description": "GitHub OAuth code 받는 방법:\n\n1. 브라우저 주소창에 아래 URL 입력 (clientId는 application-secret.yml의 값):\n   https://github.com/login/oauth/authorize?client_id=<YOUR_CLIENT_ID>&scope=repo,read:user\n\n2. GitHub 승인 후 리다이렉트 URL에서 code= 파라미터 복사:\n   http://localhost:3000/...?code=XXXXXXXX\n\n3. 위 code를 authorizationCode에 붙여넣고 Send.\n\n⚠️ code는 1회용이며 10분 내에 사용해야 합니다."
+          }
+        },
+        {
+          "name": "저장소 목록 조회",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.repositories && res.data.repositories.length > 0) {",
+                  "    var firstId = res.data.repositories[0].repositoryId;",
+                  "    pm.collectionVariables.set('repoId', firstId);",
+                  "    console.log('repoId set (first):', firstId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/github/repositories?githubConnectionId={{githubConnectionId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "github", "repositories"],
+              "query": [{ "key": "githubConnectionId", "value": "{{githubConnectionId}}" }]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "3. GitHub Analysis",
+      "item": [
+        {
+          "name": "분석 실행",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.githubAnalysisId) {",
+                  "    pm.collectionVariables.set('githubAnalysisId', res.data.githubAnalysisId);",
+                  "    console.log('githubAnalysisId set:', res.data.githubAnalysisId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"githubConnectionId\": {{githubConnectionId}},\n  \"selectedRepositoryIds\": [{{repoId}}],\n  \"coreRepositoryIds\": [{{repoId}}]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/github-analyses",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "github-analyses"]
+            },
+            "description": "LLM 파이프라인을 실행합니다. 수 초 ~ 수십 초 소요될 수 있습니다.\n\nselectedRepositoryIds: 분석 대상 repo ID 목록\ncoreRepositoryIds: LLM 요약 대상 핵심 repo ID 목록 (selected의 부분집합)"
+          }
+        },
+        {
+          "name": "분석 결과 조회",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/github-analyses/{{githubAnalysisId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "github-analyses", "{{githubAnalysisId}}"]
+            }
+          }
+        },
+        {
+          "name": "보정 저장",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userCorrections\": [],\n  \"finalTechProfile\": {}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/github-analyses/{{githubAnalysisId}}/corrections",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "github-analyses", "{{githubAnalysisId}}", "corrections"]
+            },
+            "description": "분석 결과 조회 후 실제 payload 구조에 맞게 body를 채워주세요."
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. Diagnosis",
+      "item": [
+        {
+          "name": "진단 생성",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.diagnosisId) {",
+                  "    pm.collectionVariables.set('diagnosisId', res.data.diagnosisId);",
+                  "    console.log('diagnosisId set:', res.data.diagnosisId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"profileId\": {{profileId}},\n  \"githubAnalysisId\": {{githubAnalysisId}}\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/diagnoses",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "diagnoses"]
+            }
+          }
+        },
+        {
+          "name": "진단 결과 조회",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/diagnoses/{{diagnosisId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "diagnoses", "{{diagnosisId}}"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "5. Roadmap",
+      "item": [
+        {
+          "name": "로드맵 생성",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.roadmapId) {",
+                  "    pm.collectionVariables.set('roadmapId', res.data.roadmapId);",
+                  "    console.log('roadmapId set:', res.data.roadmapId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"diagnosisId\": {{diagnosisId}},\n  \"githubAnalysisId\": {{githubAnalysisId}},\n  \"weeklyStudyHours\": 10,\n  \"targetDate\": \"2026-12-31\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/roadmaps",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "roadmaps"]
+            }
+          }
+        },
+        {
+          "name": "로드맵 조회",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "var res = pm.response.json();",
+                  "if (res.data && res.data.weeks && res.data.weeks.length > 0) {",
+                  "    var firstWeekId = res.data.weeks[0].roadmapWeekId;",
+                  "    pm.collectionVariables.set('roadmapWeekId', firstWeekId);",
+                  "    console.log('roadmapWeekId set (first):', firstWeekId);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/roadmaps/{{roadmapId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "roadmaps", "{{roadmapId}}"]
+            }
+          }
+        },
+        {
+          "name": "진도 저장",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{accessToken}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"roadmapWeekId\": {{roadmapWeekId}},\n  \"status\": \"IN_PROGRESS\",\n  \"note\": \"1주차 시작\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/roadmaps/{{roadmapId}}/progress",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "roadmaps", "{{roadmapId}}", "progress"]
+            },
+            "description": "status: TODO | IN_PROGRESS | DONE | SKIPPED"
+          }
+        }
+      ]
+    },
+    {
+      "name": "6. Dashboard",
+      "item": [
+        {
+          "name": "대시보드 조회",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "Authorization", "value": "Bearer {{accessToken}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/api/dashboard",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "dashboard"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `coach-backend.postman_collection.json` 추가
- 전체 API 엔드포인트 포함 (인증, 프로필, GitHub 연결, 분석, 진단, 로드맵, 대시보드)
- Tests 탭에 ID 자동 추출 스크립트 포함

Closes #152

## Test plan

- [ ] Postman에서 collection import 확인
- [ ] `accessToken` 변수 설정 후 순서대로 실행 확인