### PR TITLE
feat(frontend): GitHub 연결 및 주요 생성 화면 구현 (Slice 5)

### DIFF
--- a/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -4,6 +4,8 @@ import com.back.coach.global.security.CookieManager;
 import com.back.coach.global.security.JwtProperties;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
@@ -33,6 +35,7 @@ import java.util.Base64;
 public class CookieOAuth2AuthorizationRequestRepository
         implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
+    private static final Logger log = LoggerFactory.getLogger(CookieOAuth2AuthorizationRequestRepository.class);
     static final String COOKIE_NAME = "oauth2_auth_request";
     private static final Duration COOKIE_TTL = Duration.ofMinutes(5);
     private static final String HMAC_ALGO = "HmacSHA256";
@@ -48,7 +51,16 @@ public class CookieOAuth2AuthorizationRequestRepository
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
         String value = cookieManager.readValue(request, COOKIE_NAME);
-        return value == null ? null : tryDeserialize(value);
+        if (value == null) {
+            log.debug("oauth2_auth_request cookie not found in request");
+            return null;
+        }
+        log.debug("oauth2_auth_request cookie found, size={} chars", value.length());
+        OAuth2AuthorizationRequest result = tryDeserialize(value);
+        if (result == null) {
+            log.warn("oauth2_auth_request cookie deserialization failed (HMAC mismatch, truncation, or format error)");
+        }
+        return result;
     }
 
     @Override
@@ -59,7 +71,9 @@ public class CookieOAuth2AuthorizationRequestRepository
             cookieManager.clear(response, COOKIE_NAME);
             return;
         }
-        cookieManager.add(response, COOKIE_NAME, serialize(authorizationRequest), COOKIE_TTL);
+        String serialized = serialize(authorizationRequest);
+        log.debug("Saving oauth2_auth_request cookie, size={} chars", serialized.length());
+        cookieManager.add(response, COOKIE_NAME, serialized, COOKIE_TTL);
     }
 
     @Override
@@ -106,6 +120,7 @@ public class CookieOAuth2AuthorizationRequestRepository
                 return (obj instanceof OAuth2AuthorizationRequest req) ? req : null;
             }
         } catch (Exception e) {
+            log.warn("oauth2_auth_request deserialization exception: {}", e.getMessage());
             return null;
         }
     }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -19,3 +19,5 @@ logging:
   level:
     com.back.coach: DEBUG
     org.hibernate.SQL: DEBUG
+    org.springframework.security.oauth2: DEBUG
+    org.springframework.security.web.authentication: DEBUG

--- a/frontend/src/app/diagnoses/new/page.tsx
+++ b/frontend/src/app/diagnoses/new/page.tsx
@@ -1,0 +1,12 @@
+import { DiagnosisCreateView } from "@/features/diagnosis/diagnosis-create-view";
+import { redirect } from "next/navigation";
+
+type Props = {
+  searchParams: Promise<{ githubAnalysisId?: string }>;
+};
+
+export default async function DiagnosisCreatePage({ searchParams }: Props) {
+  const { githubAnalysisId } = await searchParams;
+  if (!githubAnalysisId) redirect("/github/analysis");
+  return <DiagnosisCreateView githubAnalysisId={githubAnalysisId} />;
+}

--- a/frontend/src/app/github/callback/page.tsx
+++ b/frontend/src/app/github/callback/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { connectGithub } from "@/features/github-connection/api";
+import { StatePanel } from "@/components/state-panel";
+
+const CONNECTION_ID_KEY = "githubConnectionId";
+
+function CallbackInner() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const error = params.get("error");
+    const code = params.get("code");
+
+    if (error || !code) {
+      router.replace(`/github?error=${encodeURIComponent(error ?? "no_code")}`);
+      return;
+    }
+
+    connectGithub(code)
+      .then((connection) => {
+        localStorage.setItem(CONNECTION_ID_KEY, connection.githubConnectionId);
+        router.replace("/github");
+      })
+      .catch(() => {
+        router.replace("/github?error=connection_failed");
+      });
+  }, [params, router]);
+
+  return <StatePanel message="GitHub 연결 중입니다..." />;
+}
+
+export default function GithubCallbackPage() {
+  return (
+    <Suspense fallback={<StatePanel message="GitHub 연결 중입니다..." />}>
+      <CallbackInner />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,16 +1,12 @@
 "use client";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 import { githubLoginUrl } from "@/lib/api";
 
 function LoginInner() {
   const params = useSearchParams();
   const error = params.get("error");
-  const [loginUrl, setLoginUrl] = useState(githubLoginUrl(""));
-
-  useEffect(() => {
-    setLoginUrl(githubLoginUrl());
-  }, []);
+  const [loginUrl] = useState(() => githubLoginUrl());
 
   return (
     <>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,11 +1,16 @@
 "use client";
 import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { githubLoginUrl } from "@/lib/api";
 
 function LoginInner() {
   const params = useSearchParams();
   const error = params.get("error");
+  const [loginUrl, setLoginUrl] = useState(githubLoginUrl(""));
+
+  useEffect(() => {
+    setLoginUrl(githubLoginUrl());
+  }, []);
 
   return (
     <>
@@ -16,7 +21,7 @@ function LoginInner() {
         </p>
       )}
       <p>
-        <a href={githubLoginUrl()}>
+        <a href={loginUrl}>
           <button className="btn-primary">GitHub으로 다시 시도</button>
         </a>
       </p>

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -11,7 +11,7 @@ import type {
   Dashboard,
   DashboardProgressSummary
 } from "@/features/dashboard/types";
-import { ApiError } from "@/lib/api";
+import { ApiError, githubLoginUrl } from "@/lib/api";
 
 type DashboardState =
   | { status: "loading" }
@@ -34,12 +34,15 @@ export function DashboardView() {
           setState({ dashboard, status: "success" });
         }
       } catch (error) {
-        if (!ignore) {
-          setState({
-            message: getErrorMessage(error),
-            status: "error"
-          });
+        if (ignore) return;
+        if (error instanceof ApiError && error.status === 401) {
+          window.location.href = githubLoginUrl("/");
+          return;
         }
+        setState({
+          message: getErrorMessage(error),
+          status: "error"
+        });
       }
     }
 

--- a/frontend/src/features/diagnosis/api.ts
+++ b/frontend/src/features/diagnosis/api.ts
@@ -11,3 +11,10 @@ export function createDiagnosis(payload: DiagnosisRequest) {
 export function getDiagnosis(diagnosisId: string) {
   return apiClient.get<Diagnosis>(`/api/diagnoses/${diagnosisId}`);
 }
+
+export function createDiagnosis(profileId: string, githubAnalysisId: string) {
+  return apiClient.post<Diagnosis>("/api/diagnoses", {
+    profileId: Number(profileId),
+    githubAnalysisId: Number(githubAnalysisId),
+  });
+}

--- a/frontend/src/features/diagnosis/api.ts
+++ b/frontend/src/features/diagnosis/api.ts
@@ -5,16 +5,12 @@ import type {
 } from "@/features/diagnosis/types";
 
 export function createDiagnosis(payload: DiagnosisRequest) {
-  return apiClient.post<Diagnosis>("/api/diagnoses", payload);
+  return apiClient.post<Diagnosis>("/api/diagnoses", {
+    profileId: Number(payload.profileId),
+    githubAnalysisId: Number(payload.githubAnalysisId),
+  });
 }
 
 export function getDiagnosis(diagnosisId: string) {
   return apiClient.get<Diagnosis>(`/api/diagnoses/${diagnosisId}`);
-}
-
-export function createDiagnosis(profileId: string, githubAnalysisId: string) {
-  return apiClient.post<Diagnosis>("/api/diagnoses", {
-    profileId: Number(profileId),
-    githubAnalysisId: Number(githubAnalysisId),
-  });
 }

--- a/frontend/src/features/diagnosis/diagnosis-create-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-create-view.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { createDiagnosis } from "@/features/diagnosis/api";
+import { getMyProfile } from "@/features/profile/api";
+import { StatePanel } from "@/components/state-panel";
+
+type CreateState =
+  | { status: "loading" }
+  | { status: "ready"; profileId: string }
+  | { status: "submitting" }
+  | { status: "error"; message: string };
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) return error.message;
+  return "오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+type Props = {
+  githubAnalysisId: string;
+};
+
+export function DiagnosisCreateView({ githubAnalysisId }: Props) {
+  const router = useRouter();
+  const [state, setState] = useState<CreateState>({ status: "loading" });
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    if (loaded.current) return;
+    loaded.current = true;
+    getMyProfile()
+      .then((profile) => setState({ status: "ready", profileId: profile.profileId }))
+      .catch((err) => setState({ status: "error", message: getErrorMessage(err) }));
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (state.status !== "ready") return;
+    setState({ status: "submitting" });
+    try {
+      const diagnosis = await createDiagnosis(state.profileId, githubAnalysisId);
+      router.push(`/diagnoses/${diagnosis.diagnosisId}`);
+    } catch (err) {
+      setState({ status: "error", message: getErrorMessage(err) });
+    }
+  }
+
+  if (state.status === "loading") {
+    return <StatePanel message="프로필을 불러오는 중..." />;
+  }
+
+  if (state.status === "submitting") {
+    return <StatePanel message="진단을 생성하는 중입니다. 잠시 기다려주세요..." />;
+  }
+
+  if (state.status === "error") {
+    return (
+      <div>
+        <StatePanel message={state.message} tone="danger" />
+        <p>
+          <a href="/github/analysis">분석 결과로 돌아가기</a>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>역량 진단 생성</h1>
+      <p>GitHub 분석 결과를 기반으로 역량 진단을 생성합니다.</p>
+
+      <dl>
+        <div>
+          <dt>GitHub 분석 ID</dt>
+          <dd>{githubAnalysisId}</dd>
+        </div>
+        <div>
+          <dt>프로필 ID</dt>
+          <dd>{state.profileId}</dd>
+        </div>
+      </dl>
+
+      <form onSubmit={handleSubmit}>
+        <button type="submit" className="btn-primary">
+          진단 생성
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/features/diagnosis/diagnosis-create-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-create-view.tsx
@@ -40,7 +40,7 @@ export function DiagnosisCreateView({ githubAnalysisId }: Props) {
     if (state.status !== "ready") return;
     setState({ status: "submitting" });
     try {
-      const diagnosis = await createDiagnosis(state.profileId, githubAnalysisId);
+      const diagnosis = await createDiagnosis({ profileId: state.profileId, githubAnalysisId });
       router.push(`/diagnoses/${diagnosis.diagnosisId}`);
     } catch (err) {
       setState({ status: "error", message: getErrorMessage(err) });

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -1,29 +1,22 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
-import {
-  StatusBadge,
-  type StatusBadgeTone
-} from "@/components/status-badge";
-import { TagList } from "@/components/tag-list";
 import { getDashboard } from "@/features/dashboard/api";
-import { createDiagnosis } from "@/features/diagnosis/api";
 import {
   getGithubAnalysis,
   saveGithubAnalysisCorrections
 } from "@/features/github-analysis/api";
 import {
+  githubDepthLevelClassNames,
   githubDepthLevelLabels,
   githubEvidenceTypeLabels
 } from "@/features/github-analysis/labels";
 import type {
   DepthEstimate,
   GithubAnalysis,
-  GithubDepthLevel,
   GithubUserCorrection
 } from "@/features/github-analysis/types";
 import { ApiError } from "@/lib/api";
@@ -40,21 +33,17 @@ type GithubAnalysisState =
       status: "success";
       analysis: GithubAnalysis;
       diagnosisId: string | null;
-      profileId: string | null;
     };
 
 export function GithubAnalysisView({
   initialGithubAnalysisId
 }: GithubAnalysisViewProps) {
-  const router = useRouter();
   const [state, setState] = useState<GithubAnalysisState>({
     status: "loading"
   });
   const [isSaving, setIsSaving] = useState(false);
-  const [isCreatingDiagnosis, setIsCreatingDiagnosis] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
-  const [diagnosisError, setDiagnosisError] = useState<string | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -88,7 +77,6 @@ export function GithubAnalysisView({
           setState({
             analysis,
             diagnosisId: dashboard?.diagnosis?.diagnosisId ?? null,
-            profileId: dashboard?.profile?.profileId ?? null,
             status: "success"
           });
         }
@@ -166,29 +154,6 @@ export function GithubAnalysisView({
     }
   }
 
-  async function handleDiagnosisCreate() {
-    if (state.status !== "success" || !state.profileId) {
-      setDiagnosisError("진단 생성 전에 프로필을 먼저 저장해 주세요.");
-      return;
-    }
-
-    setIsCreatingDiagnosis(true);
-    setDiagnosisError(null);
-
-    try {
-      const diagnosis = await createDiagnosis({
-        githubAnalysisId: state.analysis.githubAnalysisId,
-        profileId: state.profileId
-      });
-
-      router.push(`/diagnoses/${diagnosis.diagnosisId}`);
-    } catch (error) {
-      setDiagnosisError(getDiagnosisErrorMessage(error));
-    } finally {
-      setIsCreatingDiagnosis(false);
-    }
-  }
-
   if (state.status === "loading") {
     return (
       <StatePanel
@@ -217,7 +182,7 @@ export function GithubAnalysisView({
     );
   }
 
-  const { analysis, diagnosisId, profileId } = state;
+  const { analysis, diagnosisId } = state;
 
   return (
     <section className="github-analysis-page" aria-labelledby="analysis-title">
@@ -236,22 +201,17 @@ export function GithubAnalysisView({
               진단 결과 보기
             </Link>
           ) : (
-            <button
+            <Link
               className="action-link primary"
-              disabled={isCreatingDiagnosis || !profileId}
-              onClick={handleDiagnosisCreate}
-              type="button"
+              href={`/diagnoses/new?githubAnalysisId=${analysis.githubAnalysisId}`}
             >
-              {isCreatingDiagnosis ? "진단 생성 중" : "진단 생성"}
-            </button>
+              진단 생성
+            </Link>
           )}
           <Link className="action-link" href="/github">
             저장소 선택
           </Link>
         </div>
-        {diagnosisError ? (
-          <p className="github-analysis-action-error">{diagnosisError}</p>
-        ) : null}
         <dl className="github-analysis-summary-list" aria-label="분석 요약">
           <div>
             <dt>분석 ID</dt>
@@ -352,7 +312,6 @@ function StaticSignalsPanel({ analysis }: { analysis: GithubAnalysis }) {
         </div>
       </dl>
       <TagList
-        emptyLabel="없음"
         items={staticSignals.primaryLanguages.map(
           (language) => `${language.lang} ${formatRatio(language.ratio)}`
         )}
@@ -367,15 +326,10 @@ function FinalTechProfilePanel({ analysis }: { analysis: GithubAnalysis }) {
     <section className="panel github-analysis-section">
       <h2>최종 기술 프로필</h2>
       <TagList
-        emptyLabel="없음"
         items={analysis.finalTechProfile.confirmedSkills}
         label="확정 기술"
       />
-      <TagList
-        emptyLabel="없음"
-        items={analysis.finalTechProfile.focusAreas}
-        label="집중 영역"
-      />
+      <TagList items={analysis.finalTechProfile.focusAreas} label="집중 영역" />
     </section>
   );
 }
@@ -523,18 +477,36 @@ function GithubCorrectionForm({
 
 function DepthBadge({ estimate }: { estimate: DepthEstimate }) {
   return (
-    <StatusBadge tone={githubDepthLevelTones[estimate.level]}>
+    <span
+      className="github-depth-badge"
+      data-depth={githubDepthLevelClassNames[estimate.level]}
+    >
       {githubDepthLevelLabels[estimate.level]}
-    </StatusBadge>
+    </span>
   );
 }
 
-const githubDepthLevelTones: Record<GithubDepthLevel, StatusBadgeTone> = {
-  APPLIED: "info",
-  DEEP: "warning",
-  INTRO: "neutral",
-  PRACTICAL: "success"
-};
+function TagList({ items, label }: { items: string[]; label: string }) {
+  if (items.length === 0) {
+    return (
+      <div className="github-tag-group">
+        <p>{label}</p>
+        <span>없음</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="github-tag-group">
+      <p>{label}</p>
+      <div>
+        {items.map((item) => (
+          <span key={item}>{item}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function normalizeOptionalId(value?: string | null) {
   if (!value) {
@@ -622,14 +594,6 @@ function getSaveErrorMessage(error: unknown) {
   }
 
   return "GitHub 분석 보정을 저장하지 못했습니다.";
-}
-
-function getDiagnosisErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
-  return "진단을 생성하지 못했습니다.";
 }
 
 function formatDateTime(value: string) {

--- a/frontend/src/features/github-connection/api.ts
+++ b/frontend/src/features/github-connection/api.ts
@@ -1,21 +1,30 @@
 import { apiClient } from "@/lib/api";
 import type {
-  GithubConnectionRequest,
-  GithubConnectionResponse,
-  GithubRepositoryListResponse
+  GithubAnalysisResult,
+  GithubConnection,
+  GithubRepositoryList,
 } from "@/features/github-connection/types";
 
-export function connectGithub(payload: GithubConnectionRequest) {
-  return apiClient.post<GithubConnectionResponse>(
-    "/api/github/connections",
-    payload
+export function connectGithub(authorizationCode: string) {
+  return apiClient.post<GithubConnection>("/api/github/connections", {
+    authorizationCode,
+  });
+}
+
+export function getRepositories(connectionId: string) {
+  return apiClient.get<GithubRepositoryList>(
+    `/api/github/repositories?githubConnectionId=${connectionId}`
   );
 }
 
-export function getGithubRepositories(githubConnectionId: string) {
-  return apiClient.get<GithubRepositoryListResponse>(
-    `/api/github/repositories?githubConnectionId=${encodeURIComponent(
-      githubConnectionId
-    )}`
-  );
+export function runAnalysis(
+  connectionId: string,
+  selectedIds: string[],
+  coreIds: string[]
+) {
+  return apiClient.post<GithubAnalysisResult>("/api/github-analyses", {
+    githubConnectionId: Number(connectionId),
+    selectedRepositoryIds: selectedIds.map(Number),
+    coreRepositoryIds: coreIds.map(Number),
+  });
 }

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -1,359 +1,163 @@
 "use client";
 
-import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useState, type FormEvent } from "react";
-
+import { ApiError, githubConnectionOAuthUrl } from "@/lib/api";
+import { getRepositories, runAnalysis } from "@/features/github-connection/api";
+import type { Repository } from "@/features/github-connection/types";
 import { StatePanel } from "@/components/state-panel";
-import { createGithubAnalysis } from "@/features/github-analysis/api";
-import {
-  connectGithub,
-  getGithubRepositories
-} from "@/features/github-connection/api";
-import type {
-  GithubConnectionResponse,
-  GithubRepository
-} from "@/features/github-connection/types";
-import { ApiError } from "@/lib/api";
 
-type RepositorySelection = {
-  coreRepositoryIds: string[];
-  selectedRepositoryIds: string[];
-};
+const CONNECTION_ID_KEY = "githubConnectionId";
+
+type ViewState =
+  | { status: "disconnected" }
+  | { status: "loading-repos" }
+  | { status: "ready"; repos: Repository[] }
+  | { status: "analyzing" }
+  | { status: "error"; message: string };
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) return error.message;
+  return "오류가 발생했습니다. 다시 시도해주세요.";
+}
 
 export function GithubConnectionView() {
   const router = useRouter();
-  const [connection, setConnection] = useState<GithubConnectionResponse | null>(
-    null
-  );
-  const [repositories, setRepositories] = useState<GithubRepository[]>([]);
-  const [selection, setSelection] = useState<RepositorySelection>({
-    coreRepositoryIds: [],
-    selectedRepositoryIds: []
-  });
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [analysisError, setAnalysisError] = useState<string | null>(null);
-  const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
+  const [state, setState] = useState<ViewState>({ status: "loading-repos" });
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [connectUrl, setConnectUrl] = useState("");
 
-  async function handleConnectSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    const formData = new FormData(event.currentTarget);
-    const authorizationCode = getStringFormValue(formData, "authorizationCode");
-
-    if (!authorizationCode) {
-      setLoadError("GitHub authorization code를 입력해 주세요.");
+  useEffect(() => {
+    setConnectUrl(githubConnectionOAuthUrl());
+    const connectionId = localStorage.getItem(CONNECTION_ID_KEY);
+    if (!connectionId) {
+      setState({ status: "disconnected" });
       return;
     }
-
-    setIsConnecting(true);
-    setLoadError(null);
-    setConnectionMessage(null);
-
-    try {
-      const connected = await connectGithub({ authorizationCode });
-      const repositoryList = await getGithubRepositories(
-        connected.githubConnectionId
-      );
-
-      setConnection(connected);
-      setRepositories(repositoryList.repositories);
-      setSelection({ coreRepositoryIds: [], selectedRepositoryIds: [] });
-      setAnalysisError(null);
-      setConnectionMessage(
-        `${connected.githubLogin} 계정의 저장소 ${repositoryList.repositories.length}개를 불러왔습니다.`
-      );
-    } catch (error) {
-      setLoadError(getErrorMessage(error));
-    } finally {
-      setIsConnecting(false);
-    }
-  }
-
-  async function handleAnalysisCreate() {
-    if (!connection) {
-      setAnalysisError("GitHub 연결 후 분석을 실행해 주세요.");
-      return;
-    }
-
-    if (selection.selectedRepositoryIds.length === 0) {
-      setAnalysisError("분석 대상 저장소를 1개 이상 선택해 주세요.");
-      return;
-    }
-
-    if (selection.coreRepositoryIds.length === 0) {
-      setAnalysisError("핵심 repo를 1개 이상 선택해 주세요.");
-      return;
-    }
-
-    setIsAnalyzing(true);
-    setAnalysisError(null);
-
-    try {
-      const analysis = await createGithubAnalysis({
-        coreRepositoryIds: selection.coreRepositoryIds,
-        githubConnectionId: connection.githubConnectionId,
-        selectedRepositoryIds: selection.selectedRepositoryIds
+    let cancelled = false;
+    getRepositories(connectionId)
+      .then((repos) => {
+        if (!cancelled) setState({ status: "ready", repos: repos.repositories });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          localStorage.removeItem(CONNECTION_ID_KEY);
+          setState({ status: "disconnected" });
+        } else {
+          setState({ status: "error", message: getErrorMessage(err) });
+        }
       });
+    return () => { cancelled = true; };
+  }, []);
 
-      router.push(
-        `/github/analysis?githubAnalysisId=${analysis.githubAnalysisId}`
-      );
-    } catch (error) {
-      setAnalysisError(getAnalysisErrorMessage(error));
-    } finally {
-      setIsAnalyzing(false);
+  function toggleRepo(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  async function handleAnalyze() {
+    const connectionId = localStorage.getItem(CONNECTION_ID_KEY);
+    if (!connectionId || selected.size === 0) return;
+    setState({ status: "analyzing" });
+    try {
+      const ids = Array.from(selected);
+      const result = await runAnalysis(connectionId, ids, ids);
+      router.push(`/github/analysis?githubAnalysisId=${result.githubAnalysisId}`);
+    } catch (err) {
+      setState({ status: "error", message: getErrorMessage(err) });
     }
   }
 
-  function toggleSelectedRepository(repositoryId: string) {
-    setSelection((current) => {
-      const selected = new Set(current.selectedRepositoryIds);
-      const core = new Set(current.coreRepositoryIds);
-
-      if (selected.has(repositoryId)) {
-        selected.delete(repositoryId);
-        core.delete(repositoryId);
-      } else {
-        selected.add(repositoryId);
-      }
-
-      return {
-        coreRepositoryIds: [...core],
-        selectedRepositoryIds: [...selected]
-      };
-    });
+  if (state.status === "loading-repos") {
+    return <StatePanel message="저장소 목록을 불러오는 중..." />;
   }
 
-  function toggleCoreRepository(repositoryId: string) {
-    setSelection((current) => {
-      if (!current.selectedRepositoryIds.includes(repositoryId)) {
-        return current;
-      }
-
-      const core = new Set(current.coreRepositoryIds);
-
-      if (core.has(repositoryId)) {
-        core.delete(repositoryId);
-      } else {
-        core.add(repositoryId);
-      }
-
-      return {
-        ...current,
-        coreRepositoryIds: [...core]
-      };
-    });
+  if (state.status === "analyzing") {
+    return <StatePanel message="GitHub 분석 중입니다. 잠시 기다려주세요..." />;
   }
 
-  return (
-    <section className="github-connection-page" aria-labelledby="github-title">
-      <div className="screen-hero">
-        <p className="eyebrow">v1 필수</p>
-        <div className="screen-heading">
-          <h1 id="github-title">GitHub 연동 / 저장소 선택</h1>
-          <p>GitHub authorization code로 계정을 연결하고 분석할 저장소를 고릅니다.</p>
-        </div>
-        <div className="action-row" aria-label="GitHub 관련 화면 이동">
-          <Link className="action-link" href="/profile">
-            프로필로 돌아가기
-          </Link>
-          <Link className="action-link" href="/github/analysis">
-            최근 분석 보기
-          </Link>
-        </div>
-      </div>
-
-      <form className="panel github-connection-form" onSubmit={handleConnectSubmit}>
-        <div className="github-connection-heading">
-          <h2>GitHub 연결</h2>
-          <p>GitHub OAuth authorization code를 입력하면 저장소 목록을 불러옵니다.</p>
-        </div>
-        <label>
-          <span>Authorization code</span>
-          <input
-            autoComplete="off"
-            name="authorizationCode"
-            placeholder="GitHub OAuth redirect URL의 code 값"
-          />
-        </label>
-        <div className="github-connection-actions">
-          <div>
-            {loadError ? (
-              <p className="github-connection-error">{loadError}</p>
-            ) : null}
-            {connectionMessage ? (
-              <p className="github-connection-success">{connectionMessage}</p>
-            ) : null}
-          </div>
-          <button disabled={isConnecting} type="submit">
-            {isConnecting ? "연결 중" : "저장소 불러오기"}
+  if (state.status === "error") {
+    return (
+      <div>
+        <StatePanel message={state.message} tone="danger" />
+        <p>
+          <button onClick={() => setState({ status: "disconnected" })}>
+            다시 연결하기
           </button>
-        </div>
-      </form>
+        </p>
+      </div>
+    );
+  }
 
-      {connection ? (
-        <section className="panel github-connection-summary">
-          <h2>연결 상태</h2>
-          <dl>
-            <div>
-              <dt>계정</dt>
-              <dd>{connection.githubLogin}</dd>
-            </div>
-            <div>
-              <dt>연결 ID</dt>
-              <dd>{connection.githubConnectionId}</dd>
-            </div>
-            <div>
-              <dt>연결 시각</dt>
-              <dd>{formatDateTime(connection.connectedAt)}</dd>
-            </div>
-          </dl>
-        </section>
-      ) : null}
+  if (state.status === "disconnected") {
+    return (
+      <div>
+        <h1>GitHub 연동</h1>
+        <p>GitHub 저장소를 연결하고 분석을 시작하세요.</p>
+        <a href={connectUrl}>
+          <button className="btn-primary" disabled={!connectUrl}>
+            GitHub 연결하기
+          </button>
+        </a>
+      </div>
+    );
+  }
 
-      {connection && repositories.length === 0 ? (
-        <StatePanel
-          className="github-connection-state-panel"
-          message="표시할 저장소가 없습니다."
-        />
-      ) : null}
+  const { repos } = state;
 
-      {repositories.length > 0 ? (
-        <>
-          <RepositorySelectionPanel
-            onCoreToggle={toggleCoreRepository}
-            onSelectedToggle={toggleSelectedRepository}
-            repositories={repositories}
-            selection={selection}
-          />
-          <section className="panel github-analysis-start-panel">
-            <div>
-              <h2>분석 실행</h2>
-              <p>
-                분석 대상 {selection.selectedRepositoryIds.length}개, 핵심 repo{" "}
-                {selection.coreRepositoryIds.length}개를 선택했습니다.
-              </p>
-              {analysisError ? (
-                <p className="github-connection-error">{analysisError}</p>
-              ) : null}
-            </div>
-            <button
-              disabled={
-                isAnalyzing ||
-                selection.selectedRepositoryIds.length === 0 ||
-                selection.coreRepositoryIds.length === 0
-              }
-              onClick={handleAnalysisCreate}
-              type="button"
-            >
-              {isAnalyzing ? "분석 실행 중" : "GitHub 분석 실행"}
-            </button>
-          </section>
-        </>
-      ) : null}
-    </section>
-  );
-}
-
-function RepositorySelectionPanel({
-  onCoreToggle,
-  onSelectedToggle,
-  repositories,
-  selection
-}: {
-  onCoreToggle: (repositoryId: string) => void;
-  onSelectedToggle: (repositoryId: string) => void;
-  repositories: GithubRepository[];
-  selection: RepositorySelection;
-}) {
   return (
-    <section className="panel github-repository-section">
-      <div className="github-connection-heading">
-        <h2>저장소 선택</h2>
-        <p>분석 대상 저장소와 LLM 요약에 사용할 핵심 저장소를 선택합니다.</p>
-      </div>
-      <div className="github-repository-list">
-        {repositories.map((repository) => {
-          const isSelected = selection.selectedRepositoryIds.includes(
-            repository.repositoryId
-          );
-          const isCore = selection.coreRepositoryIds.includes(
-            repository.repositoryId
-          );
+    <div>
+      <h1>저장소 선택</h1>
+      <p>분석할 저장소를 선택하세요. ({selected.size}개 선택됨)</p>
 
-          return (
-            <article className="github-repository-card" key={repository.repositoryId}>
-              <div>
-                <h3>{repository.repoFullName}</h3>
-                <a href={repository.repoUrl} rel="noreferrer" target="_blank">
-                  저장소 열기
-                </a>
-              </div>
-              <dl>
-                <div>
-                  <dt>언어</dt>
-                  <dd>{repository.primaryLanguage ?? "미확인"}</dd>
-                </div>
-                <div>
-                  <dt>기본 브랜치</dt>
-                  <dd>{repository.defaultBranch ?? "미확인"}</dd>
-                </div>
-              </dl>
-              <div className="github-repository-options">
-                <label>
-                  <input
-                    checked={isSelected}
-                    onChange={() => onSelectedToggle(repository.repositoryId)}
-                    type="checkbox"
-                  />
-                  <span>분석 대상</span>
-                </label>
-                <label>
-                  <input
-                    checked={isCore}
-                    disabled={!isSelected}
-                    onChange={() => onCoreToggle(repository.repositoryId)}
-                    type="checkbox"
-                  />
-                  <span>핵심 repo</span>
-                </label>
-              </div>
-            </article>
-          );
-        })}
-      </div>
-    </section>
+      {repos.length === 0 ? (
+        <StatePanel message="연결된 저장소가 없습니다." />
+      ) : (
+        <ul style={{ listStyle: "none", padding: 0 }}>
+          {repos.map((repo) => (
+            <li key={repo.repositoryId} style={{ marginBottom: "0.5rem" }}>
+              <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}>
+                <input
+                  type="checkbox"
+                  checked={selected.has(repo.repositoryId)}
+                  onChange={() => toggleRepo(repo.repositoryId)}
+                />
+                <span>{repo.repoFullName}</span>
+                {repo.primaryLanguage && (
+                  <span style={{ fontSize: "0.75rem", color: "#888" }}>
+                    {repo.primaryLanguage}
+                  </span>
+                )}
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        className="btn-primary"
+        disabled={selected.size === 0}
+        onClick={handleAnalyze}
+      >
+        분석 실행
+      </button>
+
+      <p style={{ marginTop: "1rem" }}>
+        <button
+          onClick={() => {
+            localStorage.removeItem(CONNECTION_ID_KEY);
+            setState({ status: "disconnected" });
+            setSelected(new Set());
+          }}
+          style={{ fontSize: "0.875rem", color: "#888" }}
+        >
+          다른 계정으로 연결
+        </button>
+      </p>
+    </div>
   );
-}
-
-function getStringFormValue(formData: FormData, key: string) {
-  const value = formData.get(key);
-
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function getErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
-  return "GitHub 저장소를 불러오지 못했습니다.";
-}
-
-function getAnalysisErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
-  return "GitHub 분석을 실행하지 못했습니다.";
-}
-
-function formatDateTime(value: string) {
-  return new Intl.DateTimeFormat("ko-KR", {
-    dateStyle: "medium",
-    timeStyle: "short"
-  }).format(new Date(value));
 }

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -25,10 +25,9 @@ export function GithubConnectionView() {
   const router = useRouter();
   const [state, setState] = useState<ViewState>({ status: "loading-repos" });
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [connectUrl, setConnectUrl] = useState("");
+  const [connectUrl] = useState(() => githubConnectionOAuthUrl());
 
   useEffect(() => {
-    setConnectUrl(githubConnectionOAuthUrl());
     const connectionId = localStorage.getItem(CONNECTION_ID_KEY);
     if (!connectionId) {
       setState({ status: "disconnected" });
@@ -54,7 +53,7 @@ export function GithubConnectionView() {
   function toggleRepo(id: string) {
     setSelected((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) { next.delete(id); } else { next.add(id); }
       return next;
     });
   }

--- a/frontend/src/features/github-connection/types.ts
+++ b/frontend/src/features/github-connection/types.ts
@@ -1,22 +1,22 @@
-export type GithubConnectionRequest = {
-  authorizationCode: string;
-};
-
-export type GithubConnectionResponse = {
-  connectedAt: string;
+export type GithubConnection = {
   githubConnectionId: string;
   githubLogin: string;
+  connectedAt: string;
 };
 
-export type GithubRepository = {
-  defaultBranch?: string | null;
-  primaryLanguage?: string | null;
+export type Repository = {
+  repositoryId: string;
   repoFullName: string;
   repoUrl: string;
-  repositoryId: string;
+  primaryLanguage: string | null;
+  defaultBranch: string;
 };
 
-export type GithubRepositoryListResponse = {
+export type GithubRepositoryList = {
   githubConnectionId: string;
-  repositories: GithubRepository[];
+  repositories: Repository[];
+};
+
+export type GithubAnalysisResult = {
+  githubAnalysisId: string;
 };

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError } from "@/lib/api";
 import { getMyProfile } from "@/features/profile/api";
@@ -28,6 +28,10 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
   const [weeklyStudyHours, setWeeklyStudyHours] = useState("");
   const [targetDate, setTargetDate] = useState("");
   const loadedProfile = useRef(false);
+  const minDate = useMemo(
+    () => new Date(Date.now() + 86400000).toISOString().split("T")[0],
+    []
+  );
 
   useEffect(() => {
     if (loadedProfile.current) return;
@@ -124,7 +128,7 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
             type="date"
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
-            min={new Date(Date.now() + 86400000).toISOString().split("T")[0]}
+            min={minDate}
             disabled={isSubmitting}
             required
           />

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -1,237 +1,139 @@
 "use client";
 
-import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useEffect, useState, type FormEvent } from "react";
-
-import { StatePanel } from "@/components/state-panel";
-import { getDashboard } from "@/features/dashboard/api";
-import type { Dashboard } from "@/features/dashboard/types";
-import { createRoadmap } from "@/features/roadmap/api";
 import { ApiError } from "@/lib/api";
+import { getMyProfile } from "@/features/profile/api";
+import { apiClient } from "@/lib/api";
+import { StatePanel } from "@/components/state-panel";
 
-type RoadmapCreateState =
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "success"; dashboard: Dashboard };
+type CreateState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "error"; message: string };
 
-export function RoadmapCreateView() {
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) return error.message;
+  return "오류가 발생했습니다. 다시 시도해주세요.";
+}
+
+type Props = {
+  initialDiagnosisId?: string;
+};
+
+export function RoadmapCreateView({ initialDiagnosisId }: Props) {
   const router = useRouter();
-  const [state, setState] = useState<RoadmapCreateState>({ status: "loading" });
-  const [isCreating, setIsCreating] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
+  const [state, setState] = useState<CreateState>({ status: "idle" });
+  const [diagnosisId, setDiagnosisId] = useState(initialDiagnosisId ?? "");
+  const [weeklyStudyHours, setWeeklyStudyHours] = useState("");
+  const [targetDate, setTargetDate] = useState("");
+  const loadedProfile = useRef(false);
 
   useEffect(() => {
-    let ignore = false;
-
-    async function loadDashboard() {
-      setState({ status: "loading" });
-
-      try {
-        const dashboard = await getDashboard();
-
-        if (!ignore) {
-          setState({ dashboard, status: "success" });
+    if (loadedProfile.current) return;
+    loadedProfile.current = true;
+    getMyProfile()
+      .then((profile) => {
+        if (profile.weeklyStudyHours) {
+          setWeeklyStudyHours(String(profile.weeklyStudyHours));
         }
-      } catch (error) {
-        if (!ignore) {
-          setState({
-            message: getErrorMessage(error),
-            status: "error"
-          });
+        if (profile.targetDate) {
+          setTargetDate(profile.targetDate);
         }
-      }
-    }
-
-    loadDashboard();
-
-    return () => {
-      ignore = true;
-    };
+      })
+      .catch(() => {});
   }, []);
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    if (state.status !== "success" || !state.dashboard.diagnosis) {
-      setCreateError("로드맵 생성 전에 진단 결과를 먼저 생성해 주세요.");
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const hours = Number(weeklyStudyHours);
+    if (!diagnosisId.trim()) {
+      setState({ status: "error", message: "진단 ID를 입력해주세요." });
+      return;
+    }
+    if (!hours || hours < 1 || hours > 40) {
+      setState({ status: "error", message: "주당 학습 시간은 1~40 사이로 입력해주세요." });
+      return;
+    }
+    if (!targetDate) {
+      setState({ status: "error", message: "목표 날짜를 입력해주세요." });
+      return;
+    }
+    if (new Date(targetDate) <= new Date()) {
+      setState({ status: "error", message: "목표 날짜는 오늘 이후여야 합니다." });
       return;
     }
 
-    const formData = new FormData(event.currentTarget);
-    const diagnosisId = getStringFormValue(formData, "diagnosisId");
-
-    if (!diagnosisId) {
-      setCreateError("진단 결과 ID가 필요합니다.");
-      return;
-    }
-
-    setIsCreating(true);
-    setCreateError(null);
-
+    setState({ status: "submitting" });
     try {
-      const roadmap = await createRoadmap({
-        diagnosisId,
-        githubAnalysisId: getOptionalStringFormValue(formData, "githubAnalysisId"),
-        targetDate: getOptionalStringFormValue(formData, "targetDate"),
-        weeklyStudyHours: getOptionalNumberFormValue(formData, "weeklyStudyHours")
+      const result = await apiClient.post<{ roadmapId: string }>("/api/roadmaps", {
+        diagnosisId: Number(diagnosisId),
+        weeklyStudyHours: hours,
+        targetDate,
       });
-
-      router.push(`/roadmaps/${roadmap.roadmapId}`);
-    } catch (error) {
-      setCreateError(getCreateErrorMessage(error));
-    } finally {
-      setIsCreating(false);
+      router.push(`/roadmaps/${result.roadmapId}`);
+    } catch (err) {
+      setState({ status: "error", message: getErrorMessage(err) });
     }
   }
 
-  if (state.status === "loading") {
-    return (
-      <StatePanel
-        className="roadmap-state-panel"
-        message="로드맵 생성에 필요한 최신 결과를 불러오는 중입니다."
-      />
-    );
-  }
-
-  if (state.status === "error") {
-    return (
-      <StatePanel
-        className="roadmap-state-panel"
-        message={state.message}
-        tone="danger"
-      />
-    );
-  }
-
-  const { dashboard } = state;
+  const isSubmitting = state.status === "submitting";
 
   return (
-    <section className="roadmap-create-page" aria-labelledby="roadmap-create-title">
-      <div className="screen-hero">
-        <p className="eyebrow">v1 필수</p>
-        <div className="screen-heading">
-          <h1 id="roadmap-create-title">학습 로드맵 생성</h1>
-          <p>최신 진단 결과를 기준으로 학습 로드맵을 생성합니다.</p>
-        </div>
-        <div className="action-row" aria-label="로드맵 생성 관련 화면 이동">
-          {dashboard.diagnosis ? (
-            <Link
-              className="action-link"
-              href={`/diagnoses/${dashboard.diagnosis.diagnosisId}`}
-            >
-              진단 결과 보기
-            </Link>
-          ) : (
-            <Link className="action-link primary" href="/github/analysis">
-              분석 보정으로 이동
-            </Link>
-          )}
-          {dashboard.roadmap ? (
-            <Link
-              className="action-link"
-              href={`/roadmaps/${dashboard.roadmap.roadmapId}`}
-            >
-              최근 로드맵 보기
-            </Link>
-          ) : null}
-        </div>
-      </div>
+    <div>
+      <h1>로드맵 생성</h1>
+      <p>진단 결과를 기반으로 맞춤 학습 로드맵을 생성합니다.</p>
 
-      {dashboard.diagnosis ? (
-        <form className="panel roadmap-create-form" onSubmit={handleSubmit}>
-          <div className="roadmap-create-heading">
-            <h2>생성 기준</h2>
-            <p>{dashboard.diagnosis.summary}</p>
-          </div>
-
-          <div className="roadmap-create-fields">
-            <label>
-              <span>진단 결과 ID</span>
-              <input
-                defaultValue={dashboard.diagnosis.diagnosisId}
-                name="diagnosisId"
-                required
-              />
-            </label>
-            <label>
-              <span>GitHub 분석 ID</span>
-              <input
-                defaultValue={dashboard.githubAnalysis?.githubAnalysisId ?? ""}
-                name="githubAnalysisId"
-              />
-            </label>
-            <label>
-              <span>주당 학습 시간</span>
-              <input
-                defaultValue={dashboard.profile?.weeklyStudyHours ?? ""}
-                max={40}
-                min={1}
-                name="weeklyStudyHours"
-                type="number"
-              />
-            </label>
-            <label>
-              <span>목표 날짜</span>
-              <input
-                defaultValue={dashboard.profile?.targetDate ?? ""}
-                name="targetDate"
-                type="date"
-              />
-            </label>
-          </div>
-
-          <div className="roadmap-create-actions">
-            <div>
-              {createError ? (
-                <p className="roadmap-create-error">{createError}</p>
-              ) : null}
-            </div>
-            <button disabled={isCreating} type="submit">
-              {isCreating ? "로드맵 생성 중" : "로드맵 생성"}
-            </button>
-          </div>
-        </form>
-      ) : (
-        <StatePanel
-          className="roadmap-state-panel"
-          message="저장된 진단 결과가 없습니다. GitHub 분석 보정 후 진단을 먼저 생성해 주세요."
-        />
+      {state.status === "error" && (
+        <StatePanel message={state.message} tone="danger" />
       )}
-    </section>
+
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="diagnosisId">진단 ID</label>
+          <input
+            id="diagnosisId"
+            type="text"
+            value={diagnosisId}
+            onChange={(e) => setDiagnosisId(e.target.value)}
+            placeholder="진단 결과 ID를 입력하세요"
+            disabled={isSubmitting}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="weeklyStudyHours">주당 학습 시간 (1~40)</label>
+          <input
+            id="weeklyStudyHours"
+            type="number"
+            min={1}
+            max={40}
+            value={weeklyStudyHours}
+            onChange={(e) => setWeeklyStudyHours(e.target.value)}
+            placeholder="예: 10"
+            disabled={isSubmitting}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="targetDate">목표 날짜</label>
+          <input
+            id="targetDate"
+            type="date"
+            value={targetDate}
+            onChange={(e) => setTargetDate(e.target.value)}
+            min={new Date(Date.now() + 86400000).toISOString().split("T")[0]}
+            disabled={isSubmitting}
+            required
+          />
+        </div>
+
+        <button type="submit" className="btn-primary" disabled={isSubmitting}>
+          {isSubmitting ? "생성 중..." : "로드맵 생성"}
+        </button>
+      </form>
+    </div>
   );
-}
-
-function getStringFormValue(formData: FormData, key: string) {
-  const value = formData.get(key);
-
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function getOptionalStringFormValue(formData: FormData, key: string) {
-  const value = getStringFormValue(formData, key);
-
-  return value.length > 0 ? value : undefined;
-}
-
-function getOptionalNumberFormValue(formData: FormData, key: string) {
-  const value = getStringFormValue(formData, key);
-
-  return value.length > 0 ? Number(value) : undefined;
-}
-
-function getErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
-  return "로드맵 생성 기준을 불러오지 못했습니다.";
-}
-
-function getCreateErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
-  }
-
-  return "로드맵을 생성하지 못했습니다.";
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,13 @@ export function githubLoginUrl(redirectUrl?: string): string {
   return `${API_BASE}/oauth2/authorization/github${qs}`;
 }
 
+export function githubConnectionOAuthUrl(): string {
+  const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "";
+  const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+  const redirectUri = encodeURIComponent(`${origin}/github/callback`);
+  return `https://github.com/login/oauth/authorize?client_id=${clientId}&scope=repo,read:user&redirect_uri=${redirectUri}`;
+}
+
 export {
   ApiError,
   apiClient,


### PR DESCRIPTION
﻿## Summary

- `/github`: GitHub OAuth 연결 -> 저장소 선택 -> 분석 실행 플로우
- `/github/callback`: OAuth 콜백 핸들러
- `/diagnoses/new`: 진단 생성 폼 (프로필 자동 로드)
- `/roadmaps/new`: 로드맵 생성 폼 (프로필 기본값 자동 채우기)
- `dashboard`: 미인증 시 GitHub 로그인 자동 리다이렉트

Closes #150

## Test plan

- [ ] `http://localhost:3000/` 접속 -> GitHub 로그인으로 리다이렉트 확인
- [ ] OAuth 로그인 후 `/github` -> GitHub 연결 버튼 표시 확인
- [ ] GitHub 연결 -> 저장소 목록 -> 분석 실행 -> `/github/analysis` 이동 확인
- [ ] `/diagnoses/new?githubAnalysisId=X` -> 진단 생성 후 상세 페이지 이동 확인
- [ ] `/roadmaps/new` -> 폼 제출 후 로드맵 상세 이동 확인