### PR TITLE
fix(frontend): GitHub flow 이후 lint 실패 수정

### DIFF
--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError, githubConnectionOAuthUrl } from "@/lib/api";
 import { getRepositories, runAnalysis } from "@/features/github-connection/api";
@@ -8,6 +8,7 @@ import type { Repository } from "@/features/github-connection/types";
 import { StatePanel } from "@/components/state-panel";
 
 const CONNECTION_ID_KEY = "githubConnectionId";
+const CONNECTION_ID_CHANGE_EVENT = "githubConnectionIdChange";
 
 type ViewState =
   | { status: "disconnected" }
@@ -21,18 +22,42 @@ function getErrorMessage(error: unknown): string {
   return "오류가 발생했습니다. 다시 시도해주세요.";
 }
 
+function getConnectionIdSnapshot() {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(CONNECTION_ID_KEY);
+}
+
+function subscribeToConnectionId(onChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+
+  window.addEventListener("storage", onChange);
+  window.addEventListener(CONNECTION_ID_CHANGE_EVENT, onChange);
+
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(CONNECTION_ID_CHANGE_EVENT, onChange);
+  };
+}
+
+function clearConnectionId() {
+  localStorage.removeItem(CONNECTION_ID_KEY);
+  window.dispatchEvent(new Event(CONNECTION_ID_CHANGE_EVENT));
+}
+
 export function GithubConnectionView() {
   const router = useRouter();
+  const connectionId = useSyncExternalStore(
+    subscribeToConnectionId,
+    getConnectionIdSnapshot,
+    () => null
+  );
   const [state, setState] = useState<ViewState>({ status: "loading-repos" });
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [connectUrl] = useState(() => githubConnectionOAuthUrl());
 
   useEffect(() => {
-    const connectionId = localStorage.getItem(CONNECTION_ID_KEY);
-    if (!connectionId) {
-      setState({ status: "disconnected" });
-      return;
-    }
+    if (!connectionId) return;
+
     let cancelled = false;
     getRepositories(connectionId)
       .then((repos) => {
@@ -41,14 +66,13 @@ export function GithubConnectionView() {
       .catch((err) => {
         if (cancelled) return;
         if (err instanceof ApiError && err.status === 404) {
-          localStorage.removeItem(CONNECTION_ID_KEY);
-          setState({ status: "disconnected" });
+          clearConnectionId();
         } else {
           setState({ status: "error", message: getErrorMessage(err) });
         }
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [connectionId]);
 
   function toggleRepo(id: string) {
     setSelected((prev) => {
@@ -59,7 +83,6 @@ export function GithubConnectionView() {
   }
 
   async function handleAnalyze() {
-    const connectionId = localStorage.getItem(CONNECTION_ID_KEY);
     if (!connectionId || selected.size === 0) return;
     setState({ status: "analyzing" });
     try {
@@ -69,6 +92,20 @@ export function GithubConnectionView() {
     } catch (err) {
       setState({ status: "error", message: getErrorMessage(err) });
     }
+  }
+
+  if (!connectionId || state.status === "disconnected") {
+    return (
+      <div>
+        <h1>GitHub 연동</h1>
+        <p>GitHub 저장소를 연결하고 분석을 시작하세요.</p>
+        <a href={connectUrl}>
+          <button className="btn-primary" disabled={!connectUrl}>
+            GitHub 연결하기
+          </button>
+        </a>
+      </div>
+    );
   }
 
   if (state.status === "loading-repos") {
@@ -84,24 +121,10 @@ export function GithubConnectionView() {
       <div>
         <StatePanel message={state.message} tone="danger" />
         <p>
-          <button onClick={() => setState({ status: "disconnected" })}>
+          <button onClick={clearConnectionId}>
             다시 연결하기
           </button>
         </p>
-      </div>
-    );
-  }
-
-  if (state.status === "disconnected") {
-    return (
-      <div>
-        <h1>GitHub 연동</h1>
-        <p>GitHub 저장소를 연결하고 분석을 시작하세요.</p>
-        <a href={connectUrl}>
-          <button className="btn-primary" disabled={!connectUrl}>
-            GitHub 연결하기
-          </button>
-        </a>
       </div>
     );
   }
@@ -148,8 +171,7 @@ export function GithubConnectionView() {
       <p style={{ marginTop: "1rem" }}>
         <button
           onClick={() => {
-            localStorage.removeItem(CONNECTION_ID_KEY);
-            setState({ status: "disconnected" });
+            clearConnectionId();
             setSelected(new Set());
           }}
           style={{ fontSize: "0.875rem", color: "#888" }}

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError } from "@/lib/api";
 import { getMyProfile } from "@/features/profile/api";
@@ -17,6 +17,10 @@ function getErrorMessage(error: unknown): string {
   return "오류가 발생했습니다. 다시 시도해주세요.";
 }
 
+function getTomorrowDateValue() {
+  return new Date(Date.now() + 86400000).toISOString().split("T")[0];
+}
+
 type Props = {
   initialDiagnosisId?: string;
 };
@@ -28,14 +32,12 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
   const [weeklyStudyHours, setWeeklyStudyHours] = useState("");
   const [targetDate, setTargetDate] = useState("");
   const loadedProfile = useRef(false);
-  const minDate = useMemo(
-    () => new Date(Date.now() + 86400000).toISOString().split("T")[0],
-    []
-  );
+  const targetDateInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (loadedProfile.current) return;
     loadedProfile.current = true;
+    targetDateInputRef.current?.setAttribute("min", getTomorrowDateValue());
     getMyProfile()
       .then((profile) => {
         if (profile.weeklyStudyHours) {
@@ -126,9 +128,9 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
           <input
             id="targetDate"
             type="date"
+            ref={targetDateInputRef}
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
-            min={minDate}
             disabled={isSubmitting}
             required
           />


### PR DESCRIPTION
## 변경 요약
- GitHub 연결 화면에서 connection id 유무를 렌더 분기로 처리해 effect 안 즉시 state 갱신을 제거했습니다.
- 로드맵 생성 화면에서 날짜 input의 `min` 값을 mount 후 ref로 설정해 렌더 중 시간 호출을 제거했습니다.

## 왜 필요한가
#157 merge 이후 `dev`의 `frontend-ci`가 lint 실패 상태라, 이후 프론트 PR 검증 기준을 신뢰하기 어렵습니다.

## 테스트 결과
- `cd frontend && npm run lint` 통과
- `cd frontend && npm run build` 통과
- `git diff --check` 통과

Closes #158