### PR TITLE
chore(ci): GitHub Actions Node 24 opt-in 적용

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -23,6 +23,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   backend-pr-check:
     name: backend-pr-check

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -23,6 +23,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   frontend-check:
     name: frontend-check


### PR DESCRIPTION
## 변경 요약
- frontend CI workflow에 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`를 추가했습니다.
- backend CI workflow에 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`를 추가했습니다.
- 검증용 Node 22, Java 25, Gradle task, artifact 업로드 동작은 변경하지 않았습니다.

## 왜 필요한가
GitHub Actions가 2026-06-02부터 JavaScript action runtime 기본값을 Node 24로 바꾸기 전에 현재 CI에서 미리 검증하기 위함입니다.

## 테스트 결과
- `git diff --check` 통과

Closes #160