### PR TITLE
fix(auth): GitHub OAuth 로그인 실패 수정

### DIFF
--- a/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -95,6 +95,7 @@ public class CookieOAuth2AuthorizationRequestRepository
                     req.getScopes(),
                     req.getState(),
                     req.getAdditionalParameters(),
+                    req.getAttributes(),
                     req.getAuthorizationRequestUri()
             );
             byte[] payloadBytes = mapper.writeValueAsBytes(payload);
@@ -130,6 +131,7 @@ public class CookieOAuth2AuthorizationRequestRepository
                     .scopes(p.scopes())
                     .state(p.state())
                     .additionalParameters(p.additionalParameters())
+                    .attributes(p.attributes() == null ? Map.of() : p.attributes())
                     .authorizationRequestUri(p.authorizationRequestUri())
                     .build();
         } catch (Exception e) {
@@ -162,6 +164,7 @@ public class CookieOAuth2AuthorizationRequestRepository
             Set<String> scopes,
             String state,
             Map<String, Object> additionalParameters,
+            Map<String, Object> attributes,
             String authorizationRequestUri
     ) {}
 }

--- a/backend/src/test/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -53,6 +53,8 @@ class CookieOAuth2AuthorizationRequestRepositoryTest {
         assertThat(restored.getState()).isEqualTo("state-123");
         assertThat(restored.getClientId()).isEqualTo("test-client");
         assertThat(restored.getAuthorizationUri()).isEqualTo("https://github.com/login/oauth/authorize");
+        String registrationId = restored.getAttribute("registration_id");
+        assertThat(registrationId).isEqualTo("github");
     }
 
     @Test
@@ -69,9 +71,11 @@ class CookieOAuth2AuthorizationRequestRepositoryTest {
         repo.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
 
         String cookieValue = extractCookieValue(saveResponse.getHeader(HttpHeaders.SET_COOKIE));
-        // 마지막 한 글자 변조 → 서명 mismatch
-        String tampered = cookieValue.substring(0, cookieValue.length() - 1)
-                + (cookieValue.charAt(cookieValue.length() - 1) == 'A' ? 'B' : 'A');
+        // 중간 한 글자 변조 → payload/HMAC 바이트가 실제로 바뀌어 서명 mismatch
+        int tamperIndex = cookieValue.length() / 2;
+        String tampered = cookieValue.substring(0, tamperIndex)
+                + (cookieValue.charAt(tamperIndex) == 'A' ? 'B' : 'A')
+                + cookieValue.substring(tamperIndex + 1);
 
         MockHttpServletRequest loadRequest = new MockHttpServletRequest();
         loadRequest.setCookies(new Cookie("oauth2_auth_request", tampered));

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,12 +1,29 @@
 "use client";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { Suspense, useSyncExternalStore } from "react";
 import { githubLoginUrl } from "@/lib/api";
+
+function subscribeToOrigin() {
+  return () => {};
+}
+
+function getOriginSnapshot() {
+  return window.location.origin;
+}
+
+function getServerOriginSnapshot() {
+  return "";
+}
 
 function LoginInner() {
   const params = useSearchParams();
   const error = params.get("error");
-  const [loginUrl] = useState(() => githubLoginUrl());
+  const origin = useSyncExternalStore(
+    subscribeToOrigin,
+    getOriginSnapshot,
+    getServerOriginSnapshot
+  );
+  const loginUrl = origin ? githubLoginUrl(`${origin}/me`) : null;
 
   return (
     <>
@@ -17,9 +34,15 @@ function LoginInner() {
         </p>
       )}
       <p>
-        <a href={loginUrl}>
-          <button className="btn-primary">GitHub으로 다시 시도</button>
-        </a>
+        {loginUrl ? (
+          <a href={loginUrl}>
+            <button className="btn-primary">GitHub으로 다시 시도</button>
+          </a>
+        ) : (
+          <button className="btn-primary" disabled type="button">
+            GitHub으로 다시 시도
+          </button>
+        )}
       </p>
     </>
   );


### PR DESCRIPTION
﻿## 변경 요약
- OAuth 요청 쿠키 저장/복원 시 `registration_id`가 포함된 attributes를 유지하도록 수정했습니다.
- `/login`의 GitHub 로그인 URL을 client origin 기준으로 안정적으로 생성하도록 정리했습니다.

## 왜 필요한가
GitHub OAuth callback에서 `registrationId cannot be empty`가 발생하면 로그인 후 `/me`와 v1 GitHub 분석 흐름으로 진입할 수 없습니다.

## 테스트 결과
- `cd backend && .\gradlew.bat test --tests "*CookieOAuth2AuthorizationRequestRepositoryTest*" --tests "*CoachOAuth2AuthorizationRequestResolverTest*" --tests "*AuthFlowIntegrationTest*"`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `git diff --check`
- 로컬 `/login` 링크가 `redirectUrl=http%3A%2F%2Flocalhost%3A3000%2Fme`를 포함하는 것 확인

Closes #164
