### PR TITLE
fix(github): 저장소 OAuth 설정 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,14 @@ REDIS_PORT=6380
 JWT_SECRET=change-me-to-a-long-random-local-secret
 FRONTEND_URL=http://localhost:3000
 
-# GitHub OAuth
+# GitHub OAuth - login
 GITHUB_CLIENT_ID=your-github-oauth-client-id
 GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
+
+# GitHub OAuth - repository connection
+# GitHub App callback URL: http://localhost:3000/github/callback
+GITHUB_CONNECTION_CLIENT_ID=your-github-connection-oauth-client-id
+GITHUB_CONNECTION_CLIENT_SECRET=your-github-connection-oauth-client-secret
 
 # AI provider / gateway
 AI_GATEWAY_API_KEY=your-ai-gateway-api-key

--- a/README.md
+++ b/README.md
@@ -30,11 +30,18 @@ cd backend
 .\gradlew.bat bootRun
 ```
 
-기본 profile은 `local`입니다. GitHub OAuth까지 확인하려면 `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`을 `.env`에 채우고 `local,oauth` profile로 실행합니다.
+기본 profile은 `local`입니다. GitHub 로그인 OAuth까지 확인하려면 `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`을 `.env`에 채우고 `local,oauth` profile로 실행합니다.
 
 ```powershell
 .\gradlew.bat bootRun --args="--spring.profiles.active=local,oauth"
 ```
+
+GitHub OAuth App은 목적별로 분리합니다.
+
+- 로그인 OAuth App callback URL: `http://localhost:8080/login/oauth2/code/github`
+- 저장소 연결 OAuth App callback URL: `http://localhost:3000/github/callback`
+
+저장소 연결 OAuth App을 따로 만들었다면 `.env`에 `GITHUB_CONNECTION_CLIENT_ID`, `GITHUB_CONNECTION_CLIENT_SECRET`도 채웁니다. 값이 없으면 기존 `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`을 fallback으로 사용합니다.
 
 ## 프론트엔드 실행
 
@@ -50,6 +57,13 @@ npm run dev
 
 ```powershell
 Set-Content .env.local "NEXT_PUBLIC_API_BASE_URL=http://localhost:8080"
+```
+
+`/github`에서 저장소 연결을 확인하려면 `frontend/.env.local`에 저장소 연결 OAuth App client id와 callback URL을 추가합니다.
+
+```powershell
+Add-Content .env.local "NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=your-github-connection-oauth-client-id"
+Add-Content .env.local "NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback"
 ```
 
 프론트 변경 검증은 다음 명령으로 확인합니다.

--- a/backend/src/main/java/com/back/coach/external/github/GithubApiProperties.java
+++ b/backend/src/main/java/com/back/coach/external/github/GithubApiProperties.java
@@ -7,7 +7,9 @@ public record GithubApiProperties(
         String baseUrl,
         String oauthBaseUrl,
         String clientId,
-        String clientSecret
+        String clientSecret,
+        String connectionClientId,
+        String connectionClientSecret
 ) {
     public GithubApiProperties {
         if (baseUrl == null || baseUrl.isBlank()) {
@@ -18,5 +20,11 @@ public record GithubApiProperties(
         }
         clientId = clientId == null ? "" : clientId;
         clientSecret = clientSecret == null ? "" : clientSecret;
+        connectionClientId = isBlank(connectionClientId) ? clientId : connectionClientId;
+        connectionClientSecret = isBlank(connectionClientSecret) ? clientSecret : connectionClientSecret;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
@@ -49,8 +49,8 @@ public class RestGithubApiClient implements GithubApiClient {
     @Override
     public String exchangeCode(String code) {
         try {
-            String body = "client_id=" + properties.clientId()
-                    + "&client_secret=" + properties.clientSecret()
+            String body = "client_id=" + properties.connectionClientId()
+                    + "&client_secret=" + properties.connectionClientSecret()
                     + "&code=" + code;
 
             String response = oauthClient.post()

--- a/backend/src/main/resources/application-secret.yml.example
+++ b/backend/src/main/resources/application-secret.yml.example
@@ -10,6 +10,10 @@ spring:
           github:
             clientId: PASTE_GITHUB_CLIENT_ID_HERE
             clientSecret: PASTE_GITHUB_CLIENT_SECRET_HERE
+github:
+  api:
+    connection-client-id: PASTE_GITHUB_CONNECTION_CLIENT_ID_HERE
+    connection-client-secret: PASTE_GITHUB_CONNECTION_CLIENT_SECRET_HERE
 ai:
   gateway:
     api-key: 그렙-스레드-키

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -73,6 +73,8 @@ github:
     oauth-base-url: ${GITHUB_OAUTH_BASE_URL:https://github.com}
     client-id: ${GITHUB_CLIENT_ID:}
     client-secret: ${GITHUB_CLIENT_SECRET:}
+    connection-client-id: ${GITHUB_CONNECTION_CLIENT_ID:${GITHUB_CLIENT_ID:}}
+    connection-client-secret: ${GITHUB_CONNECTION_CLIENT_SECRET:${GITHUB_CLIENT_SECRET:}}
 
 springdoc:
   swagger-ui:

--- a/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
@@ -34,7 +34,8 @@ class RestGithubApiClientTest {
         wireMock.start();
         String base = "http://127.0.0.1:" + wireMock.port();
         client = new RestGithubApiClient(
-                new GithubApiProperties(base, base, "client-id", "client-secret")
+                new GithubApiProperties(base, base, "client-id", "client-secret",
+                        "connection-client-id", "connection-client-secret")
         );
     }
 
@@ -56,6 +57,37 @@ class RestGithubApiClientTest {
         String token = client.exchangeCode("code-abc");
 
         assertThat(token).isEqualTo("ghp_test123");
+        wireMock.verify(postRequestedFor(urlEqualTo("/login/oauth/access_token"))
+                .withRequestBody(containing("client_id=connection-client-id"))
+                .withRequestBody(containing("client_secret=connection-client-secret"))
+                .withRequestBody(containing("code=code-abc")));
+    }
+
+    @Test
+    @DisplayName("exchangeCode — connection 전용 설정이 없으면 기본 OAuth 설정으로 fallback")
+    void exchangeCode_fallsBackToDefaultOAuthCredentials() {
+        RestGithubApiClient fallbackClient = new RestGithubApiClient(
+                new GithubApiProperties(
+                        "http://127.0.0.1:" + wireMock.port(),
+                        "http://127.0.0.1:" + wireMock.port(),
+                        "client-id",
+                        "client-secret",
+                        "",
+                        null
+                )
+        );
+        wireMock.stubFor(post("/login/oauth/access_token")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .withBody("access_token=ghp_fallback&token_type=bearer&scope=repo")));
+
+        String token = fallbackClient.exchangeCode("fallback-code");
+
+        assertThat(token).isEqualTo("ghp_fallback");
+        wireMock.verify(postRequestedFor(urlEqualTo("/login/oauth/access_token"))
+                .withRequestBody(containing("client_id=client-id"))
+                .withRequestBody(containing("client_secret=client-secret"))
+                .withRequestBody(containing("code=fallback-code")));
     }
 
     @Test

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,7 @@
 # 백엔드 base URL — Next.js dev server에서 fetch 대상
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+
+# 저장소 연결용 GitHub OAuth App
+# callback URL: http://localhost:3000/github/callback
+NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=your-github-connection-oauth-client-id
+NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,10 +31,23 @@ export function githubLoginUrl(redirectUrl?: string): string {
 }
 
 export function githubConnectionOAuthUrl(): string {
-  const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "";
+  const clientId =
+    process.env.NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID ??
+    process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ??
+    "";
+  if (!clientId) return "";
+
   const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
-  const redirectUri = encodeURIComponent(`${origin}/github/callback`);
-  return `https://github.com/login/oauth/authorize?client_id=${clientId}&scope=repo,read:user&redirect_uri=${redirectUri}`;
+  const redirectUri =
+    process.env.NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI ??
+    `${origin}/github/callback`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: "repo read:user",
+    redirect_uri: redirectUri,
+  });
+
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
 }
 
 export {


### PR DESCRIPTION
﻿## 연관 이슈

Closes #166

## 변경 요약

- 백엔드 GitHub code exchange에서 저장소 연결용 OAuth client/secret을 별도로 사용할 수 있게 했습니다.
- 프론트 `/github` 연결 URL이 저장소 연결용 public client id와 callback URI를 우선 사용하도록 정리했습니다.
- 로컬 env example과 README에 로그인 OAuth App과 저장소 연결 OAuth App callback 기준을 분리해 기록했습니다.

## 왜 필요한가

GitHub OAuth App callback 제약 때문에 로그인 callback과 저장소 연결 callback을 같은 설정으로 쓰면 `/github` repo 연결이 `Invalid Redirect URI`에서 막힙니다.

## 테스트

실행 내용:

```text
cd backend && .\gradlew.bat test --tests "*RestGithubApiClientTest*" --tests "*GithubConnectionControllerTest*"
cd frontend && npm run lint
cd frontend && npm run build
git diff --check
```
