### PR TITLE
fix(llm): fenced JSON 응답 파싱 보정

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
@@ -65,6 +65,7 @@ public class DiagnosisPromptBuilder {
         prompt.append("missingSkills[].priorityOrder starts at 1 and must be sorted by learning priority.\n");
         prompt.append("strengths should include skills supported by user input or GitHub confirmed skills.\n");
         prompt.append("recommendations should be concrete next learning priorities.\n");
+        prompt.append("Do not wrap JSON in Markdown code fences.\n");
         return prompt.toString();
     }
 

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParser.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.diagnosis.service;
 
 import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
 import com.back.coach.global.code.DiagnosisSeverity;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -33,7 +34,7 @@ public class DiagnosisResponseParser {
     public DiagnosisResult parse(String llmJson) {
         JsonNode root;
         try {
-            root = mapper.readTree(llmJson);
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
         } catch (IOException ex) {
             log.warn("Diagnosis 응답 JSON 파싱 실패: {}", ex.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParser.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.github.service.summary;
 
 import com.back.coach.global.code.HighlightStatus;
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
@@ -33,7 +34,7 @@ public class RepoSummaryResponseParser {
     public GithubAnalysisPayload.RepoSummary parse(String llmJson) {
         JsonNode root;
         try {
-            root = mapper.readTree(llmJson);
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
         } catch (IOException e) {
             log.warn("RepoSummary 응답 JSON 파싱 실패: {}", e.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParser.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.github.service.synthesis;
 
 import com.back.coach.global.code.GithubDepthLevel;
 import com.back.coach.global.code.GithubEvidenceType;
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
@@ -34,7 +35,7 @@ public class SynthesisResponseParser {
     public SynthesisResult parse(String llmJson) {
         JsonNode root;
         try {
-            root = mapper.readTree(llmJson);
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
         } catch (IOException e) {
             log.warn("Synthesis 응답 JSON 파싱 실패: {}", e.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);

--- a/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageResponseParser.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service.triage;
 
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.service.Champion;
@@ -34,7 +35,7 @@ public class ChampionTriageResponseParser {
     public List<Champion> parse(String llmJson) {
         JsonNode root;
         try {
-            root = mapper.readTree(llmJson);
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
         } catch (IOException e) {
             log.warn("Triage 응답 JSON 파싱 실패: {}", e.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -27,6 +27,7 @@ public class RoadmapPromptBuilder {
 
                 Rules:
                 - Return JSON only.
+                - Do not wrap JSON in Markdown code fences.
                 - The JSON must match this shape:
                   {
                     "summary": "short roadmap summary",

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapResponseParser.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.roadmap.service;
 
 import com.back.coach.domain.roadmap.dto.RoadmapPayload;
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
 import com.back.coach.global.code.MaterialType;
 import com.back.coach.global.code.RoadmapTaskType;
 import com.back.coach.global.exception.ErrorCode;
@@ -36,7 +37,7 @@ public class RoadmapResponseParser {
     public RoadmapResult parse(String llmJson) {
         JsonNode root;
         try {
-            root = mapper.readTree(llmJson);
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
         } catch (IOException ex) {
             log.warn("Roadmap 응답 JSON 파싱 실패: {}", ex.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);

--- a/backend/src/main/java/com/back/coach/external/llm/LlmJsonResponseExtractor.java
+++ b/backend/src/main/java/com/back/coach/external/llm/LlmJsonResponseExtractor.java
@@ -1,0 +1,121 @@
+package com.back.coach.external.llm;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public final class LlmJsonResponseExtractor {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private LlmJsonResponseExtractor() {
+    }
+
+    public static String extractJson(String response) {
+        if (response == null || response.isBlank()) {
+            throw invalidResponse();
+        }
+
+        String text = stripWrappingFence(response.trim());
+        String json = findFirstValidJson(text);
+        if (json == null) {
+            throw invalidResponse();
+        }
+        return json;
+    }
+
+    private static String stripWrappingFence(String text) {
+        if (!text.startsWith("```")) {
+            return text;
+        }
+
+        int firstLineEnd = text.indexOf('\n');
+        if (firstLineEnd < 0) {
+            return text;
+        }
+
+        int closingFence = text.indexOf("```", firstLineEnd + 1);
+        if (closingFence < 0) {
+            return text;
+        }
+
+        return text.substring(firstLineEnd + 1, closingFence).trim();
+    }
+
+    private static String findFirstValidJson(String text) {
+        for (int start = 0; start < text.length(); start++) {
+            char current = text.charAt(start);
+            if (current != '{' && current != '[') {
+                continue;
+            }
+
+            String candidate = scanJsonValue(text, start);
+            if (candidate != null && isJson(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static String scanJsonValue(String text, int start) {
+        Deque<Character> expectedClosers = new ArrayDeque<>();
+        pushExpectedCloser(expectedClosers, text.charAt(start));
+
+        boolean inString = false;
+        boolean escaped = false;
+        for (int index = start + 1; index < text.length(); index++) {
+            char current = text.charAt(index);
+
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+
+            if (current == '"') {
+                inString = true;
+                continue;
+            }
+            if (current == '{' || current == '[') {
+                pushExpectedCloser(expectedClosers, current);
+                continue;
+            }
+            if (current == '}' || current == ']') {
+                if (expectedClosers.isEmpty() || expectedClosers.pop() != current) {
+                    return null;
+                }
+                if (expectedClosers.isEmpty()) {
+                    return text.substring(start, index + 1).trim();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void pushExpectedCloser(Deque<Character> expectedClosers, char opener) {
+        expectedClosers.push(opener == '{' ? '}' : ']');
+    }
+
+    private static boolean isJson(String candidate) {
+        try {
+            MAPPER.readTree(candidate);
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    private static ServiceException invalidResponse() {
+        return new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
@@ -25,6 +25,22 @@ class DiagnosisResponseParserTest {
     }
 
     @Test
+    void parse_whenResponseIsFencedJson_returnsDiagnosisResult() {
+        DiagnosisResponseParser.DiagnosisResult result = parser.parse(fencedJson(validJson()));
+
+        assertThat(result.summary()).isEqualTo("Redis 보완 필요");
+        assertThat(result.missingSkills()).hasSize(1);
+    }
+
+    @Test
+    void parse_whenResponseHasTextAroundJson_returnsDiagnosisResult() {
+        DiagnosisResponseParser.DiagnosisResult result = parser.parse(textWrappedJson(validJson()));
+
+        assertThat(result.summary()).isEqualTo("Redis 보완 필요");
+        assertThat(result.strengths()).containsExactly("Spring Boot");
+    }
+
+    @Test
     void parse_whenSeverityIsInvalid_throwsLlmInvalidResponse() {
         String json = validJson().replace("\"HIGH\"", "\"CRITICAL\"");
 
@@ -76,5 +92,13 @@ class DiagnosisResponseParserTest {
                   "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
                 }
                 """;
+    }
+
+    private String fencedJson(String json) {
+        return "```json\n" + json + "\n```";
+    }
+
+    private String textWrappedJson(String json) {
+        return "분석 결과입니다.\n" + json + "\n검토해주세요.";
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
@@ -40,6 +40,28 @@ class RepoSummaryResponseParserTest {
     }
 
     @Test
+    @DisplayName("fenced JSON 응답도 RepoSummary로 파싱한다")
+    void parse_fencedJsonResponse() {
+        String json = """
+                ```json
+                {
+                  "repoId": "1",
+                  "repoName": "user/cool-app",
+                  "summary": "Spring Boot 백엔드 + OAuth 도입",
+                  "highlights": [
+                    {"text": "OAuth2 핸들러", "status": "ADOPTED"}
+                  ]
+                }
+                ```
+                """;
+
+        GithubAnalysisPayload.RepoSummary summary = parser.parse(json);
+
+        assertThat(summary.repoName()).isEqualTo("user/cool-app");
+        assertThat(summary.highlights().get(0).status()).isEqualTo(HighlightStatus.ADOPTED);
+    }
+
+    @Test
     @DisplayName("REVERSED 상태의 highlight도 정상 파싱한다")
     void parse_reversedHighlight() {
         String json = """

--- a/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
@@ -35,6 +35,26 @@ class SynthesisResponseParserTest {
     }
 
     @Test
+    @DisplayName("fenced JSON 응답도 SynthesisResult로 파싱한다")
+    void parse_fencedJsonResponse() {
+        String json = """
+                ```json
+                {
+                  "techTags": [{"skillName": "Spring Boot", "tagReason": "주요 백엔드"}],
+                  "depthEstimates": [{"skillName": "Spring Boot", "level": "PRACTICAL", "reason": "여러 repo"}],
+                  "evidences": [{"repoName": "user/a", "type": "COMMIT", "source": "abc123", "summary": "OAuth 핸들러"}],
+                  "finalTechProfile": {"confirmedSkills": ["Spring Boot"], "focusAreas": ["Kubernetes"]}
+                }
+                ```
+                """;
+
+        SynthesisResponseParser.SynthesisResult result = parser.parse(json);
+
+        assertThat(result.techTags()).hasSize(1);
+        assertThat(result.finalTechProfile().focusAreas()).contains("Kubernetes");
+    }
+
+    @Test
     @DisplayName("DepthEstimate.level이 enum 외 값이면 LLM_INVALID_RESPONSE")
     void parse_invalidLevel_throws() {
         String json = """

--- a/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageResponseParserTest.java
@@ -38,6 +38,25 @@ class ChampionTriageResponseParserTest {
     }
 
     @Test
+    @DisplayName("fenced JSON 응답도 champion 목록으로 파싱한다")
+    void parse_fencedJsonResponse() {
+        String json = """
+                ```json
+                {
+                  "champions": [
+                    {"kind": "COMMIT", "ref": "abc123", "reason": "OAuth 도입"}
+                  ]
+                }
+                ```
+                """;
+
+        List<Champion> champions = parser.parse(json);
+
+        assertThat(champions).hasSize(1);
+        assertThat(champions.get(0).kind()).isEqualTo(Champion.Kind.COMMIT);
+    }
+
+    @Test
     @DisplayName("champion이 0개면 LLM_INVALID_RESPONSE를 던진다 (minItems=1)")
     void parse_emptyChampions_throws() {
         String json = "{\"champions\": []}";

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapResponseParserTest.java
@@ -25,6 +25,14 @@ class RoadmapResponseParserTest {
     }
 
     @Test
+    void parse_whenResponseIsFencedJson_returnsRoadmapResult() {
+        RoadmapResponseParser.RoadmapResult result = parser.parse(fencedJson(validResponse()));
+
+        assertThat(result.summary()).isEqualTo("Redis 중심 로드맵");
+        assertThat(result.weeks()).hasSize(2);
+    }
+
+    @Test
     void parse_whenTaskTypeIsInvalid_throwsLlmInvalidResponse() {
         String invalidResponse = validResponse().replace("READ_DOCS", "UNKNOWN_TASK");
 
@@ -105,5 +113,9 @@ class RoadmapResponseParserTest {
                   ]
                 }
                 """;
+    }
+
+    private String fencedJson(String json) {
+        return "```json\n" + json + "\n```";
     }
 }

--- a/backend/src/test/java/com/back/coach/external/llm/LlmJsonResponseExtractorTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/LlmJsonResponseExtractorTest.java
@@ -1,0 +1,92 @@
+package com.back.coach.external.llm;
+
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LlmJsonResponseExtractorTest {
+
+    @Test
+    void extractJson_whenPureObject_returnsObject() {
+        String response = "{\"summary\":\"ok\"}";
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("{\"summary\":\"ok\"}");
+    }
+
+    @Test
+    void extractJson_whenResponseHasWhitespace_returnsTrimmedJson() {
+        String response = "  \n {\"summary\":\"ok\"} \n ";
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("{\"summary\":\"ok\"}");
+    }
+
+    @Test
+    void extractJson_whenResponseIsJsonFence_returnsObjectInsideFence() {
+        String response = """
+                ```json
+                {"summary":"ok"}
+                ```
+                """;
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("{\"summary\":\"ok\"}");
+    }
+
+    @Test
+    void extractJson_whenResponseIsPlainFence_returnsObjectInsideFence() {
+        String response = """
+                ```
+                {"summary":"ok"}
+                ```
+                """;
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("{\"summary\":\"ok\"}");
+    }
+
+    @Test
+    void extractJson_whenResponseHasTextAroundJson_returnsJsonOnly() {
+        String response = """
+                Here is the result:
+                {"summary":"ok","reason":"uses {cache} safely"}
+                Done.
+                """;
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("{\"summary\":\"ok\",\"reason\":\"uses {cache} safely\"}");
+    }
+
+    @Test
+    void extractJson_whenResponseHasArray_returnsArray() {
+        String response = "result: [{\"name\":\"Redis\"}]";
+
+        assertThat(LlmJsonResponseExtractor.extractJson(response))
+                .isEqualTo("[{\"name\":\"Redis\"}]");
+    }
+
+    @Test
+    void extractJson_whenResponseIsBlank_throwsLlmInvalidResponse() {
+        assertInvalidResponse("   ");
+    }
+
+    @Test
+    void extractJson_whenResponseHasNoJson_throwsLlmInvalidResponse() {
+        assertInvalidResponse("JSON 생성에 실패했습니다.");
+    }
+
+    @Test
+    void extractJson_whenResponseHasIncompleteJson_throwsLlmInvalidResponse() {
+        assertInvalidResponse("{\"summary\":\"ok\"");
+    }
+
+    private void assertInvalidResponse(String response) {
+        assertThatThrownBy(() -> LlmJsonResponseExtractor.extractJson(response))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
+}

--- a/docs/14_v1_smoke_test_result_2026-05-04.md
+++ b/docs/14_v1_smoke_test_result_2026-05-04.md
@@ -161,6 +161,11 @@ backend traceId: 23b831b0-5d4f-4c1f-a071-eb334e476fe3
 후속: LLM 응답 shape 확인과 parser/프롬프트 보정 필요
 ```
 
+후속 재검증 기준:
+- parser 보정 후에도 필드 누락, enum 오류, schema 위반은 계속 `LLM_INVALID_RESPONSE`로 실패해야 한다.
+- Markdown fenced JSON은 code fence를 제거한 뒤 기존 schema 검증을 통과해야 한다.
+- 실제 AI Gateway로 `POST /api/diagnoses`를 재호출해 seed 없이 `diagnosisId`가 생성되는지 재확인해야 한다.
+
 ## 결론
 
 v1 저장/재조회 tail 흐름은 local seed 기준으로 통과했다. 프로필 저장, GitHub 분석 보정 저장, 진단/로드맵 상세 재조회, 진도 저장, 대시보드 최신 snapshot 반영은 확인됐다.


### PR DESCRIPTION
## 연관 이슈

Closes #168

## 변경 요약

- LLM 응답에서 실제 JSON object/array만 추출하는 공통 전처리를 추가했습니다.
- 진단/로드맵/GitHub 분석 parser가 fenced JSON 응답도 기존 schema 검증으로 처리하도록 연결했습니다.
- 진단/로드맵 프롬프트와 smoke 문서에 Markdown code fence 기준을 보강했습니다.

## 왜 필요한가

AI Gateway가 JSON을 Markdown code fence로 감싸면 기존 parser가 첫 백틱에서 실패해 v1 진단 생성 smoke가 중단됩니다.

## 테스트

- `cd backend && .\gradlew.bat test --tests *LlmJsonResponseExtractorTest --tests *ResponseParserTest --tests *PromptBuilderTest`
- `cd backend && .\gradlew.bat test --tests *DiagnosisCommandServiceTest --tests *RoadmapCommandServiceTest`
- `git diff --check`