### PR TITLE
fix(diagnosis): 진단 LLM 출력 schema 지시 강화

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
@@ -61,8 +61,28 @@ public class DiagnosisPromptBuilder {
                 .append("\n"));
 
         prompt.append("\n## Output Rules\n");
+        prompt.append("Return exactly this JSON shape; use these field names only:\n");
+        prompt.append("""
+                {
+                  "summary": "short diagnosis summary",
+                  "missingSkills": [
+                    {
+                      "skillName": "skill name",
+                      "severity": "HIGH",
+                      "reason": "why this skill is missing based on user input, GitHub final profile, or job requirements",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["skill or strength supported by user input or GitHub confirmed skills"],
+                  "recommendations": ["concrete next learning priority"]
+                }
+                """);
+        prompt.append("Do not add any fields other than summary, missingSkills, strengths, recommendations.\n");
+        prompt.append("missingSkills[] must contain only skillName, severity, reason, priorityOrder.\n");
+        prompt.append("Do not use alias field names like skill, name, description, priority, rationale.\n");
         prompt.append("missingSkills[].severity must be one of: ").append(SEVERITY_VALUES).append("\n");
         prompt.append("missingSkills[].priorityOrder starts at 1 and must be sorted by learning priority.\n");
+        prompt.append("missingSkills[].reason must be a non-empty explanation tied to the input evidence.\n");
         prompt.append("strengths should include skills supported by user input or GitHub confirmed skills.\n");
         prompt.append("recommendations should be concrete next learning priorities.\n");
         prompt.append("Do not wrap JSON in Markdown code fences.\n");

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilderTest.java
@@ -1,0 +1,79 @@
+package com.back.coach.domain.diagnosis.service;
+
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.entity.SkillRequirement;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.ProficiencyLevel;
+import com.back.coach.global.code.SkillSourceType;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class DiagnosisPromptBuilderTest {
+
+    private final DiagnosisPromptBuilder builder = new DiagnosisPromptBuilder();
+
+    @Test
+    void build_includesStrictDiagnosisJsonShapeAndFieldNameRules() {
+        String prompt = builder.build(new DiagnosisPromptBuilder.Input(
+                jobRole(),
+                profile(),
+                List.of(UserSkill.create(1L, "Spring Boot", ProficiencyLevel.WORKING, SkillSourceType.USER_INPUT)),
+                List.of(skillRequirement("Redis", 5)),
+                new GithubAnalysisPayload.FinalTechProfile(List.of("Spring Boot"), List.of("Redis"))
+        ));
+
+        assertThat(prompt).contains(
+                "\"summary\"",
+                "\"missingSkills\"",
+                "\"skillName\"",
+                "\"severity\"",
+                "\"reason\"",
+                "\"priorityOrder\"",
+                "\"strengths\"",
+                "\"recommendations\""
+        );
+        assertThat(prompt).contains("missingSkills[] must contain only skillName, severity, reason, priorityOrder");
+        assertThat(prompt).contains("Do not use alias field names like skill, name, description, priority, rationale");
+        assertThat(prompt).contains("missingSkills[].reason must be a non-empty explanation");
+        assertThat(prompt).contains("LOW, MEDIUM, HIGH");
+        assertThat(prompt).contains("Do not wrap JSON in Markdown code fences.");
+    }
+
+    private JobRole jobRole() {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn("BACKEND_DEVELOPER");
+        given(jobRole.getRoleName()).willReturn("백엔드 개발자");
+        given(jobRole.getDescription()).willReturn("Java와 Spring Boot 기반 백엔드 직무");
+        return jobRole;
+    }
+
+    private UserProfile profile() {
+        return UserProfile.create(
+                1L,
+                10L,
+                CurrentLevel.JUNIOR,
+                8,
+                LocalDate.of(2099, 12, 31),
+                "[]",
+                null,
+                null
+        );
+    }
+
+    private SkillRequirement skillRequirement(String skillName, int importance) {
+        SkillRequirement requirement = mock(SkillRequirement.class);
+        given(requirement.getSkillName()).willReturn(skillName);
+        given(requirement.getCategory()).willReturn("BACKEND");
+        given(requirement.getImportance()).willReturn(importance);
+        return requirement;
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisResponseParserTest.java
@@ -76,6 +76,29 @@ class DiagnosisResponseParserTest {
                 .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
     }
 
+    @Test
+    void parse_whenMissingSkillUsesSkillAlias_throwsLlmInvalidResponse() {
+        String json = """
+                {
+                  "summary": "Redis 보완 필요",
+                  "missingSkills": [
+                    {
+                      "skill": "Redis",
+                      "severity": "HIGH",
+                      "priorityOrder": 1
+                    }
+                  ],
+                  "strengths": ["Spring Boot"],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
     private String validJson() {
         return """
                 {


### PR DESCRIPTION
## 연관 이슈

Closes #172

## 변경 요약

- 진단 LLM prompt에 backend diagnosis schema와 같은 JSON shape 예시를 추가했습니다.
- `missingSkills[]`가 `skillName`, `severity`, `reason`, `priorityOrder`만 사용하도록 명시했습니다.
- `skill` alias 응답은 계속 `LLM_INVALID_RESPONSE`로 실패하는 회귀 테스트를 추가했습니다.

## 왜 필요한가

AI Gateway가 `skill`처럼 schema와 다른 필드명을 반환하면 진단 저장이 막혀 로드맵 생성과 v1 full smoke를 끝까지 확인할 수 없습니다.

## 테스트

- `cd backend && .\gradlew.bat test --tests *DiagnosisPromptBuilderTest --tests *DiagnosisResponseParserTest --tests *DiagnosisCommandServiceTest*`
- `git diff --check`

## 실제 재검증

- Docker Desktop engine 재기동 후 `docker compose -f docker/docker-compose.yml up -d`
- backend `local,oauth` profile 실행 후 `/actuator/health` 200, db/redis UP 확인
- 로컬 JWT 기준 `/api/v1/auth/me` 200, `userId=1` 확인
- 기존 `profileId=1`, `githubAnalysisId=1`로 `POST /api/diagnoses` 재호출 PASS
- 신규 `diagnosisId=2`, `missingSkillCount=7` 생성 확인