### PR TITLE
docs(context): v2 감지 패턴 계약 정리

### DIFF
--- a/docs/00_bundle_index.md
+++ b/docs/00_bundle_index.md
@@ -30,3 +30,4 @@
 - 16_v2_context_snapshot_contract.md: v2 Context Snapshot payload, 원본 참조, version/active 규칙
 - 17_v2_context_tier_assembly.md: v2 3-Tier Context 조립 기준과 템플릿별 기본 Tier
 - 18_v2_session_version_policy.md: v2 Coach 세션의 snapshot version 고정과 새 version 반영 정책
+- 19_v2_detected_patterns_contract.md: v2 Pattern Detector 감지 원본과 activeSignals 요약 계약

--- a/docs/01_service_design_aligned.md
+++ b/docs/01_service_design_aligned.md
@@ -113,7 +113,7 @@ v2는 v1 기능이 안정적으로 동작한 뒤, 그 결과를 재사용해 멀
 v2의 핵심 확장
 - Analyzer, Planner, Coach 역할 분리
 - Context Manager 기반 상태 관리
-- Pattern Detector + user_signals 기반 자율 피드백 루프
+- Pattern Detector + detected_patterns 기반 자율 피드백 루프
 - Pattern Detector 기반 재분석 또는 재계획
 - 일일 코치 대화
 - Function Calling 기반 검증 자료 결합

--- a/docs/02_data_model_aligned.md
+++ b/docs/02_data_model_aligned.md
@@ -288,11 +288,11 @@
 ### 3.17 DetectedPattern (v2)
 
 목적
-- Pattern Detector가 SQL 배치로 감지한 신호를 저장한다 (user_signals 테이블).
+- Pattern Detector가 SQL 배치로 감지한 패턴 원본을 저장한다 (`detected_patterns` 테이블).
 
 설명
 - Pattern Detector가 @Scheduled 배치에서 SQL 카운팅·임계치 검사 후 row를 insert한다.
-- Coach가 매 turn 진입 시 미처리 row(acknowledgedAt IS NULL)를 조회하고, 사용자 발화와 종합 판단 후 `acknowledgedAt`을 마킹한다.
+- Coach가 매 turn 진입 시 Context Manager가 요약한 미처리 row(processedAt IS NULL)를 읽고, 사용자 발화와 종합 판단 후 `processedAt`을 마킹한다.
 - 이 테이블은 이벤트를 발행하지 않는다. Coach를 직접 트리거하지 않는다.
 
 주요 속성
@@ -301,7 +301,7 @@
 - patternType
 - severity
 - metadata
-- acknowledgedAt
+- processedAt
 - createdAt
 
 ## 4. 정리된 제외 엔티티

--- a/docs/04_function_spec_aligned.md
+++ b/docs/04_function_spec_aligned.md
@@ -341,19 +341,19 @@ GitHub 기반 실제 사용 기술 분석
 - 최신 진단 결과
 - 최신 로드맵
 - 최근 대화 이력
-- 패턴 감지 이벤트
+- 감지 패턴 요약
 
 ### 7.4 처리
 
 1. 세션 생성 시 `profileVersion`, `roadmapVersion` 고정
-2. Context Manager에서 처리 경로에 맞는 템플릿으로 컨텍스트 조회 (`user_signals` 미처리 신호는 `COACH_FULL_CONTEXT` 시에만 포함)
+2. Context Manager에서 처리 경로에 맞는 템플릿으로 컨텍스트 조회 (`detected_patterns` 미처리 row에서 요약한 `activeSignals`는 `COACH_FULL_CONTEXT` 시에만 포함)
 3. 의도 분류 및 처리 경로 결정:
    - 단순 질문/조언 → `COACH_LIGHTWEIGHT` 템플릿으로 자체 응답
    - 캐시된 결과 조회 요청 → Context Manager에서 최신 진단/로드맵 조회 후 응답
    - 명시적 재분석/재계획 요청 → 사용자 확인 후 Analyzer/Planner 동기 호출
-   - 자율 트리거 → `user_signals` 신호 + 사용자 발화 종합 판단, 재계획 제안 또는 dismiss
+   - 자율 트리거 → `activeSignals` + 사용자 발화 종합 판단, 재계획 제안 또는 dismiss
 4. 자연어 응답 생성
-5. 처리한 `user_signals` 신호에 `processed_at` 마킹
+5. 처리한 원본 `detected_patterns` row에 `processed_at` 마킹
 6. 무거운 재실행(Analyzer/Planner)이 필요한 경우 `coach.requested_reanalysis` 또는 `coach.requested_replan` 이벤트 발행
 
 ### 7.5 출력

--- a/docs/05_architecture_aligned.md
+++ b/docs/05_architecture_aligned.md
@@ -121,14 +121,14 @@ Analyzer/Planner 재실행 같은 무거운 작업의 비동기 처리는 별도
   - 단순 질문/조언 → `COACH_LIGHTWEIGHT` 템플릿으로 컨텍스트 조립 후 자체 응답
   - 진도 점검 / 캐시 조회 → `COACH_PROGRESS_CHECK` 템플릿으로 조립 후 응답
   - 명시적 재분석/재계획 요청 → `COACH_FULL_CONTEXT` 템플릿 + 사용자 확인 후 Analyzer/Planner 동기 호출
-  - 자율 트리거 → `COACH_FULL_CONTEXT` 템플릿으로 `user_signals` 신호 + 사용자 발화를 종합해 재계획 제안 여부 판단
+  - 자율 트리거 → `COACH_FULL_CONTEXT` 템플릿으로 `activeSignals` + 사용자 발화를 종합해 재계획 제안 여부 판단
 - Coach는 수치 기반 패턴(연속 미달성, 반복 실패 등)을 직접 감지하지 않는다. 이는 Pattern Detector의 책임이며, Coach는 감지된 신호를 사용자 발화와 종합해 언어적으로 해석하는 역할만 담당한다.
 - Coach는 사용자 동의(명시적 요청 또는 Coach 제안에 대한 확인) 없이 Analyzer 또는 Planner를 호출하지 않는다.
 
 #### Pattern Detector
 - 반복 실패, 연속 미달성, 관심사 변화 같은 수치 기반 패턴을 SQL로 감지한다.
-- LLM을 호출하지 않는다. 매일 정기 배치(@Scheduled)로 SQL 기반 카운팅·임계치 검사를 수행하고, 감지된 신호를 `user_signals` 테이블에 row로 insert한다.
-- 신호 insert 후 후속 처리는 없다. 이벤트를 발행하거나 Coach를 직접 트리거하지 않는다.
+- LLM을 호출하지 않는다. 매일 정기 배치(@Scheduled)로 SQL 기반 카운팅·임계치 검사를 수행하고, 감지된 패턴을 `detected_patterns` 테이블에 row로 insert한다.
+- 패턴 row insert 후 후속 처리는 없다. 이벤트를 발행하거나 Coach를 직접 트리거하지 않는다.
 - LLM 비용·지연이 불필요한 수치 패턴은 SQL로, 언어적 해석(왜 힘들어 보이는지, 어떻게 제안할지)은 Coach LLM이 담당한다.
 - 구체 트리거 기준은 별도 정책 문서에서 정의하며, 임계치는 운영 중 조정 가능하도록 설정을 분리한다.
 
@@ -173,7 +173,7 @@ Context Manager는 호출 컴포넌트(Coach, Analyzer, Planner)와 처리 경�
 |--------|----------|-----------|----------------|
 | `COACH_LIGHTWEIGHT` | 단순 질문/조언 | 기본 프로필(목표 직무, 현재 수준) + 현재 주차 태스크 + 최근 진도 상태 | ~500 |
 | `COACH_PROGRESS_CHECK` | 진도 점검 / 캐시 조회 | LIGHTWEIGHT 슬롯 + 전체 로드맵 개요 + 최근 N주 진도 이력 + 역량 진단 요약 | ~1000 |
-| `COACH_FULL_CONTEXT` | 재분석/재계획 요청, 자율 트리거 판단 | PROGRESS_CHECK 슬롯 + 최근 대화 이력 + `user_signals` 미처리 신호 + GitHub 분석 요약 + 상세 진단 결과 | ~2000 |
+| `COACH_FULL_CONTEXT` | 재분석/재계획 요청, 자율 트리거 판단 | PROGRESS_CHECK 슬롯 + 최근 대화 이력 + `detected_patterns` 기반 `activeSignals` + GitHub 분석 요약 + 상세 진단 결과 | ~2000 |
 
 **Analyzer 템플릿**
 
@@ -187,7 +187,7 @@ Context Manager는 호출 컴포넌트(Coach, Analyzer, Planner)와 처리 경�
 | 템플릿 | 처리 경로 | 포함 슬롯 | 권장 토큰 예산 |
 |--------|----------|-----------|----------------|
 | `PLANNER_INITIAL` | 로드맵 최초 생성 | 역량 진단 결과(전체) + 코딩테스트 분석 요약(선택) + 학습 가능 시간 + 목표 날짜 | ~1500 |
-| `PLANNER_REPLAN` | 로드맵 재생성 (v2) | 역량 진단 결과(최신) + 현재 로드맵 + 전체 진도 이력 + `user_signals` 트리거 신호 + 학습 가능 시간 | ~2000 |
+| `PLANNER_REPLAN` | 로드맵 재생성 (v2) | 역량 진단 결과(최신) + 현재 로드맵 + 전체 진도 이력 + `detected_patterns` 기반 trigger summary + 학습 가능 시간 | ~2000 |
 
 슬롯별 캐싱 정책
 
@@ -200,7 +200,7 @@ Context Manager는 호출 컴포넌트(Coach, Analyzer, Planner)와 처리 경�
 | GitHub 정적 분석 결과 | 24h | `analysis.completed` |
 | GitHub LLM 요약 | 24h | `analysis.completed` |
 | 최근 대화 이력 | 1h | 매 턴 갱신 |
-| `user_signals` 미처리 신호 | 캐싱 없음 | 매 턴 DB 직접 조회 |
+| `detected_patterns` 미처리 row | 캐싱 없음 | 매 턴 DB 직접 조회 |
 | 저장소 메타데이터 (README 등) | 6h | `user.portfolio.updated` |
 
 토큰 예산은 기준값이며 운영 중 비용·품질 trade-off를 관찰하며 조정한다. 슬롯 구성은 팀 협의로 추가하거나 변경할 수 있다.
@@ -243,7 +243,7 @@ contextManager.assemble(userId, [SLOT.PROFILE, SLOT.CURRENT_WEEK, SLOT.SIGNALS])
 |------|------|-----------|
 | Tier 1 | 기본 프로필 + 현재 주차 태스크 + 최근 진도 | ~500 |
 | Tier 2 | Tier 1 + 전체 로드맵 + 진단 요약 | ~1000 |
-| Tier 3 | Tier 2 + 대화 이력 + user_signals + GitHub 요약 | ~2000 |
+| Tier 3 | Tier 2 + 대화 이력 + activeSignals + GitHub 요약 | ~2000 |
 
 ```
 contextManager.load(userId, tier=2)
@@ -297,15 +297,15 @@ contextManager.load(userId, tier=2)
 
 ## 7. 신호 및 이벤트 설계
 
-### 7.1 Pattern Detector 신호 (user_signals 테이블)
+### 7.1 Pattern Detector 감지 패턴 (detected_patterns 테이블)
 
-Pattern Detector는 이벤트를 발행하지 않는다. 감지된 신호는 `user_signals` 테이블에 row로 insert되며, Coach가 매 turn 진입 시 `COACH_FULL_CONTEXT` 템플릿을 통해 미처리 신호(processed_at IS NULL)를 조회한다.
+Pattern Detector는 이벤트를 발행하지 않는다. 감지된 패턴은 `detected_patterns` 테이블에 row로 insert되며, Context Manager가 매 turn 진입 시 미처리 row(processed_at IS NULL)를 `activeSignals`로 요약한다. Coach는 `COACH_FULL_CONTEXT` 템플릿을 통해 이 요약을 조회한다.
 
 Coach는 사용자 발화와 누적 신호를 종합해 판단한다:
 - "오늘 사용자가 '힘들다' + 3일 미달성 신호 있음 → 재계획 제안"
 - "오늘 사용자가 '재밌다' + DP 5회 실패 신호 있음 → 도전 욕구로 해석, 신호 dismiss"
 
-Coach가 신호를 처리한 후 `processed_at`을 마킹한다.
+Coach가 신호를 처리한 후 원본 `detected_patterns.processed_at`을 마킹한다.
 
 ### 7.2 명시 요청 이벤트 (AgentEvent 테이블)
 
@@ -324,7 +324,7 @@ Coach가 신호를 처리한 후 `processed_at`을 마킹한다.
 - Planner가 Coach에게 직접 메시지를 보내지 않고, 다음 턴 로딩 시 새 버전을 읽게 한다.
 - 동일 사용자에 대한 재분석, 재계획은 쿨다운과 변경 임계치를 둔다.
 - 큰 변경은 사용자 확인 후 반영한다.
-- `pattern.detected` 이벤트는 사용하지 않는다. Pattern Detector의 자율 감지 신호는 `user_signals` 테이블 row로 처리한다.
+- `pattern.detected` 이벤트는 사용하지 않는다. Pattern Detector의 자율 감지 결과는 `detected_patterns` 테이블 row로 처리한다.
 
 ## 8. 운영 및 관측
 
@@ -342,7 +342,7 @@ Coach가 신호를 처리한 후 `processed_at`을 마킹한다.
 - 캐시 히트율
 - snapshot 조회 성능
 - 재분석 / 재계획 트리거 빈도
-- 사용자당 일일/주간 `user_signals` 누적 수 (Pattern Detector 활성도 지표)
+- 사용자당 일일/주간 `detected_patterns` 누적 수 (Pattern Detector 활성도 지표)
 - Coach의 재계획 제안 → 사용자 거절 비율 (Pattern Detector 정확도 지표)
 - 동일 사용자 재계획 → 즉시 재재계획 발생 빈도 (안정성 지표)
 
@@ -377,7 +377,7 @@ LLM 호출 계층은 Spring AI 기반으로 구현한다. GLM 등 비표준 모�
 
 ### 10.4 채택하지 않는 Spring AI 기능 (근거 명시)
 
-- `AutoMemoryTools`: 단일 사용자 CLI용 설계, multi-user SaaS에 보안 위험. 본 서비스의 JSONB 기반 Context Manager + `user_signals` 구조가 더 적합.
+- `AutoMemoryTools`: 단일 사용자 CLI용 설계, multi-user SaaS에 보안 위험. 본 서비스의 JSONB 기반 Context Manager + `detected_patterns` 구조가 더 적합.
 - `Subagent Orchestration` (spring-ai-agent-utils, org.springaicommunity): v0.4.x community org 라이브러리. GLM 어댑터 호환 미검증. 핵심 경로 도입 전 spike test 필요. 본 서비스의 신호 기반 구조와 패러다임 차이 있음.
 - `Orchestrator-Workers 동기 패턴`: Coach를 동기 Orchestrator로 구성하면 "사용자 개입 없는 자율 피드백 루프"가 불가능해짐. Coach는 동기 Orchestrator가 아니라 turn-time 판단 허브다.
 

--- a/docs/06_requirements_aligned.md
+++ b/docs/06_requirements_aligned.md
@@ -79,7 +79,7 @@
 
 - Analyzer, Planner, Coach 역할 분리
 - Context Manager 기반 상태 관리
-- Pattern Detector + user_signals 기반 피드백 루프
+- Pattern Detector + detected_patterns 기반 피드백 루프
 - AI 코치 채팅 (Coach)
 - Pattern Detector 기반 재분석 / 재계획
 - Planner의 Function Calling 기반 검증 자료 결합 (v2 후순위)
@@ -149,8 +149,8 @@
 - 세션 생성 시점의 `profileVersion`, `roadmapVersion`은 고정돼야 한다
 - AI 코치는 최신 진단 결과와 로드맵을 읽어 오늘의 할 일과 진도 점검을 제공해야 한다
 - Coach는 사용자 발화 의도에 따라 경량 응답, 캐시 조회, 동기 재분석, 자율 트리거 4가지 처리 경로를 분기해야 한다
-- Pattern Detector는 LLM을 사용하지 않고 SQL 기반 배치(@Scheduled)로 패턴을 감지하여 `user_signals` 테이블에 저장해야 한다
-- Coach는 수치 기반 패턴을 직접 감지하지 않는다. `user_signals` 미처리 신호를 매 turn 조회하여 사용자 발화와 종합해 판단해야 한다
+- Pattern Detector는 LLM을 사용하지 않고 SQL 기반 배치(@Scheduled)로 패턴을 감지하여 `detected_patterns` 테이블에 저장해야 한다
+- Coach는 수치 기반 패턴을 직접 감지하지 않는다. Context Manager가 `detected_patterns` 미처리 row를 요약한 `activeSignals`를 매 turn 조회하여 사용자 발화와 종합해 판단해야 한다
 - 재계획 결과가 생성되어도 진행 중인 세션은 자동으로 새 버전으로 전환되지 않아야 한다
 - LLM 호출 계층은 Spring AI 기반으로 구현하며, 도구 선택은 아키텍처 적합성을 기준으로 유동적으로 결정한다
 
@@ -236,7 +236,7 @@ v1에서는 아래 기능을 필수 범위에서 제외한다.
 ### 9.2 v2 성공 기준
 
 - AI 코치가 진단 결과와 로드맵을 바탕으로 대화할 수 있다
-- Pattern Detector와 재계획이 이벤트 기반으로 연결된다
+- Pattern Detector 감지 결과와 재계획 판단이 Context Manager pull 기반으로 연결된다
 - 상태 관리와 결과 이력 관리가 분리된 구조로 동작한다
 - 세션이 시작 시점의 버전을 고정해 읽는다
 - Planner가 검증된 자료 결합 원칙에 따라 로드맵을 확장할 수 있다

--- a/docs/08_db_physical_schema.md
+++ b/docs/08_db_physical_schema.md
@@ -353,7 +353,7 @@
 | pattern_type | VARCHAR(50) | N | 계약 부록 enum |
 | severity | VARCHAR(30) | N | 계약 부록 enum |
 | metadata | JSONB | N | DEFAULT '{}'::jsonb |
-| acknowledged_at | TIMESTAMPTZ | Y |  |
+| processed_at | TIMESTAMPTZ | Y | Coach/Context Manager 처리 완료 시각 |
 | created_at | TIMESTAMPTZ | N | DEFAULT now() |
 
 인덱스

--- a/docs/09_contract_appendix.md
+++ b/docs/09_contract_appendix.md
@@ -311,9 +311,14 @@ shape
 {
   "count": 3,
   "windowDays": 7,
+  "targetType": "roadmap_week",
+  "targetId": 12,
+  "skill": "Redis",
   "lastDetectedAt": "2026-04-24T09:00:00Z"
 }
 ```
+
+`detected_patterns`는 Pattern Detector의 공식 원본 저장소다. Coach 대화용 신호는 Context Manager가 미처리 row(`processed_at IS NULL`)를 `CONVERSATION.activeSignals`로 요약해 전달한다.
 
 ## 5. validation 규칙
 

--- a/docs/10_project_proposal.md
+++ b/docs/10_project_proposal.md
@@ -218,8 +218,8 @@ Context Manager → Redis/PostgreSQL (캐시 조회/저장)
 
 신호 및 이벤트 흐름
 
-Pattern Detector (cron 배치) → user_signals 테이블 (row insert, 이벤트 발행 없음)
-Coach (매 turn 진입) → user_signals 미처리 신호 polling → 사용자 발화와 종합 판단
+Pattern Detector (cron 배치) → detected_patterns 테이블 (row insert, 이벤트 발행 없음)
+Coach (매 turn 진입) → detected_patterns 기반 activeSignals polling → 사용자 발화와 종합 판단
 Coach → AgentEvent 테이블 (사용자 명시 요청 시) → Analyzer/Planner 재실행 트리거
 Analyzer/Planner 장기 작업 완료 → analysis.completed / roadmap.updated 이벤트 → Coach가 다음 턴에 반영
 
@@ -707,7 +707,7 @@ Spring Boot API 서버
 - Analyzer, Planner, Coach 구조 확장
 - Planner의 구조 생성 + 검증된 자료 결합 방식 검토
 - AI 코치, 패턴 감지, 개인화 피드백 흐름 고도화
-- Redis, user_signals 기반 신호 처리, Context Manager 확장 등 기술 심화 적용
+- Redis, detected_patterns 기반 신호 처리, Context Manager 확장 등 기술 심화 적용
 
 ### 4주차
 

--- a/docs/16_v2_context_snapshot_contract.md
+++ b/docs/16_v2_context_snapshot_contract.md
@@ -19,9 +19,8 @@ Coach 세션에서 snapshot version을 고정하고 새 version을 반영하는 
 제외 범위
 - DB migration, Entity, Repository, API 구현
 - 실제 멀티 에이전트, Event System, Context Manager 구현
-- Pattern Detector 저장소 명칭 정리
 
-`user_signals`와 `detected_patterns` 명칭은 문서 간 정렬이 필요하다. 이 문서는 `CONVERSATION.activeSignals`를 "활성 신호 요약"으로만 정의하고, 실제 원본 테이블명은 별도 계약 정리에서 확정한다.
+Pattern Detector 저장 원본과 `CONVERSATION.activeSignals` 요약 관계는 `docs/19_v2_detected_patterns_contract.md`를 따른다.
 
 ## 3. 공통 원칙
 
@@ -180,7 +179,8 @@ Coach 세션에서 snapshot version을 고정하고 새 version을 반영하는 
   },
   "activeSignals": [
     {
-      "signalType": "CONSECUTIVE_INCOMPLETE",
+      "sourcePatternId": 31,
+      "patternType": "CONSECUTIVE_INCOMPLETE",
       "severity": "MEDIUM",
       "summary": "최근 3일 동안 계획 대비 완료율이 낮음",
       "detectedAt": "2026-05-06T00:00:00Z"

--- a/docs/17_v2_context_tier_assembly.md
+++ b/docs/17_v2_context_tier_assembly.md
@@ -140,4 +140,6 @@ Tier 축소
 - Context Manager 구현
 - Redis key naming 구현
 - DB migration, Entity, Repository, API 구현
-- Pattern Detector 신호 테이블명 정리
+- Pattern Detector 임계치 정책 상세
+
+Pattern Detector 저장 원본과 `activeSignals` 요약 관계는 `docs/19_v2_detected_patterns_contract.md`를 따른다.

--- a/docs/19_v2_detected_patterns_contract.md
+++ b/docs/19_v2_detected_patterns_contract.md
@@ -1,0 +1,122 @@
+# v2 detected_patterns 계약
+
+## 1. 목적
+
+이 문서는 v2 Pattern Detector가 감지한 사용자 행동 패턴을 어떤 원본 구조로 저장하고, Coach가 이를 어떤 읽기 맥락으로 사용하는지 정리한다.
+
+핵심 결정은 다음과 같다.
+
+- 공식 저장 원본은 `detected_patterns`다.
+- `user_signals`는 공식 테이블명이 아니라 Coach 대화 맥락에서 해석된 "사용자 신호" 표현으로만 사용한다.
+- `CONVERSATION.activeSignals`는 `detected_patterns` 원본 row를 대화에 맞게 요약한 읽기 payload다.
+- Pattern Detector는 이벤트를 발행하지 않는다. `pattern.detected` 이벤트는 사용하지 않는다.
+
+## 2. 역할 분리
+
+### Pattern Detector
+
+Pattern Detector는 SQL 배치 기반으로 사용자 학습 행동의 반복 패턴을 감지한다.
+
+예시 패턴:
+
+- 반복 미완료
+- 연속 진도 지연
+- 특정 기술 학습 반복 실패
+- 관심사 또는 목표 변화 후보
+
+Pattern Detector는 LLM을 호출하지 않는다.
+정기 배치에서 카운팅, 임계치 검사, 최근 활동 비교를 수행하고 감지 결과를 `detected_patterns`에 저장한다.
+
+### Context Manager
+
+Context Manager는 Coach가 대화에 사용할 수 있도록 미처리 `detected_patterns`를 읽어 `CONVERSATION.activeSignals`로 요약한다.
+
+이 요약은 원본을 대체하지 않는다.
+패턴 정확도, 빈도, 재계획 전환 여부 같은 분석 기준은 항상 `detected_patterns` 원본 row를 따른다.
+
+### Coach
+
+Coach는 수치 기반 패턴을 직접 감지하지 않는다.
+Coach는 Context Manager가 전달한 `activeSignals`를 사용자 발화와 함께 해석해 다음 중 하나를 수행한다.
+
+- 재계획 제안
+- 보충 학습 제안
+- 단순 안내
+- dismiss 처리
+
+Coach 또는 Context Manager가 해당 패턴을 대화 판단에 반영했거나 dismiss 처리하면 `detected_patterns.processed_at`을 기록한다.
+
+## 3. detected_patterns 최소 계약
+
+`detected_patterns`는 v2 draft 테이블이며 실제 DB migration, Entity, Repository 구현은 이 문서 범위에 포함하지 않는다.
+
+최소 필드:
+
+| 필드 | 설명 |
+| --- | --- |
+| `id` | 감지 패턴 식별자 |
+| `user_id` | 사용자 식별자 |
+| `pattern_type` | 감지된 패턴 유형 |
+| `severity` | 패턴 심각도 |
+| `metadata` | 감지 근거 JSONB |
+| `processed_at` | Coach/Context Manager 처리 완료 시각 |
+| `created_at` | 감지 시각 |
+
+`processed_at`은 사용자 확인 시각이 아니라 시스템이 해당 패턴을 대화 판단에 반영했거나 dismiss 처리한 시각이다.
+
+## 4. metadata 예시
+
+반복 미완료 패턴 예시:
+
+```json
+{
+  "count": 3,
+  "windowDays": 7,
+  "targetType": "roadmap_week",
+  "targetId": 12,
+  "skill": "Redis",
+  "lastDetectedAt": "2026-05-06T00:00:00Z"
+}
+```
+
+metadata는 감지 원인과 후속 분석에 필요한 근거만 담는다.
+Coach 응답 문장이나 LLM 해석 결과를 원본 metadata에 저장하지 않는다.
+
+## 5. activeSignals 요약 계약
+
+`CONVERSATION.activeSignals`는 Coach가 읽는 대화용 요약이다.
+원본 `detected_patterns` row에서 필요한 최소 정보만 추려 snapshot payload에 포함한다.
+
+최소 필드:
+
+```json
+{
+  "sourcePatternId": 31,
+  "patternType": "REPEATED_INCOMPLETE_TASK",
+  "severity": "MEDIUM",
+  "summary": "Redis 2주차 과제가 최근 3회 미완료 상태로 남아 있음",
+  "detectedAt": "2026-05-06T00:00:00Z"
+}
+```
+
+규칙:
+
+- `sourcePatternId`는 원본 `detected_patterns.id`를 참조한다.
+- `summary`는 Coach 대화에 필요한 짧은 요약이며 원본 근거는 `metadata`에 남긴다.
+- `processed_at IS NULL`인 row만 active signal 후보가 된다.
+- active signal로 요약됐다는 이유만으로 원본 row를 수정하지 않는다.
+
+## 6. Event System 관계
+
+Pattern Detector는 `pattern.detected` 이벤트를 발행하지 않는다.
+감지 결과는 `detected_patterns` row로 남기고, Coach가 다음 turn에 Context Manager를 통해 pull 한다.
+
+무거운 재분석 또는 재계획은 사용자의 명시 요청이나 Coach 제안에 대한 사용자 확인 후 `coach.requested_reanalysis`, `coach.requested_replan` 이벤트로 연결한다.
+
+## 7. 제외 범위
+
+- DB migration
+- Entity, Repository, API 구현
+- Context Manager 구현
+- Pattern Detector 임계치 정책 상세
+- Coach LLM prompt/schema 변경


### PR DESCRIPTION
## 변경 사항
- `docs/19_v2_detected_patterns_contract.md` 추가
- Pattern Detector 저장 원본을 `detected_patterns`로 정리
- `activeSignals` 요약, `processed_at` 처리 기준, 기존 문서 참조 정렬

## 필요한 이유
- 감지 원본을 분석 가능한 형태로 남기고, Coach 대화 반영과 장기 고도화 기준을 분리하기 위해 필요합니다.

## 검증
- `git diff --check`
- `detected_patterns`, `user_signals`, `activeSignals`, `pattern.detected`, `processed_at`, `acknowledged_at` 참조 검색
- 문서 변경만 있어 backend/frontend build는 실행하지 않음

Closes #180