### PR TITLE
Fix: v1 smoke test 및 유저 플로우에서 발견한 버그 등

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,5 @@ GITHUB_CONNECTION_CLIENT_SECRET=your-github-connection-oauth-client-secret
 
 # AI provider / gateway
 AI_GATEWAY_API_KEY=your-ai-gateway-api-key
-AI_GATEWAY_BASE_URL=http://localhost:0
-AI_GATEWAY_MODEL=default
+AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co
+AI_GATEWAY_MODEL=glm-4.5-flash

--- a/.github/ISSUE_TEMPLATE/fix-github-api-param.yml
+++ b/.github/ISSUE_TEMPLATE/fix-github-api-param.yml
@@ -1,0 +1,46 @@
+name: "[Fix] GitHub API 파라미터 오류"
+description: GitHub REST API 호출 시 파라미터 조합 오류(4xx)를 등록합니다.
+title: "[Fix] GitHub API — <엔드포인트> <증상>"
+body:
+  - type: textarea
+    id: symptom
+    attributes:
+      label: 증상
+      value: |
+        - 호출 엔드포인트:
+        - 응답 상태 코드:
+        - backend 로그 (WARN 이상):
+    validations:
+      required: true
+
+  - type: textarea
+    id: cause
+    attributes:
+      label: 원인
+      value: |
+        GitHub API 문서 기준으로 잘못된 파라미터 조합 또는 누락된 파라미터를 기술합니다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 수정 범위
+      value: |
+        **수정 파일**
+        - `RestGithubApiClient.java` — 해당 메서드명
+
+        **변경 내용**
+        - 제거/추가할 파라미터:
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 완료 조건
+      value: |
+        - `./gradlew test --tests "*.RestGithubApiClientTest"` GREEN
+        - 해당 API 엔드포인트 실제 호출 성공 (smoke 확인)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/fix-llm-schema-violation.yml
+++ b/.github/ISSUE_TEMPLATE/fix-llm-schema-violation.yml
@@ -1,0 +1,59 @@
+name: "[Fix] LLM 응답 schema 불일치"
+description: LLM 출력 필드명·타입이 backend schema와 맞지 않는 문제를 등록합니다.
+title: "[Fix] LLM schema — <파서명> <위반 필드>"
+body:
+  - type: textarea
+    id: symptom
+    attributes:
+      label: 증상
+      value: |
+        - 실패 파서: (예: SynthesisResponseParser, RepoSummaryResponseParser, DiagnosisResponseParser)
+        - backend 로그의 schema 위반 메시지:
+
+        ```
+        $.필드명: ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: cause
+    attributes:
+      label: 원인
+      value: |
+        LLM이 반환한 필드명/타입과 schema가 기대하는 값의 차이를 기술합니다.
+
+        | 위반 필드 | LLM 반환값 | schema 기대값 |
+        |-----------|-----------|--------------|
+        |           |           |              |
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 수정 범위
+      value: |
+        수정 방향을 선택합니다 (하나 이상 선택).
+
+        **A. 프롬프트 강화** — `*PromptBuilder.java`
+        - 출력 JSON 구조를 명시적으로 지시
+
+        **B. schema 완화** — `ai/schema/*.schema.json`
+        - 타입을 `["string", "integer"]` 등으로 허용 범위 확장
+
+        **C. 파서 보정** — `*ResponseParser.java`
+        - `asText()` 등으로 타입 변환 처리
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 완료 조건
+      value: |
+        - `./gradlew test --tests "*ResponseParser*"` GREEN
+        - `./gradlew test` 전체 GREEN
+        - smoke: 해당 LLM 호출 단계 성공 확인
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/slice3-github-http-fetcher.yml
+++ b/.github/ISSUE_TEMPLATE/slice3-github-http-fetcher.yml
@@ -1,0 +1,54 @@
+name: "[Slice 3] GitHub HTTP 패처"
+description: GitHub OAuth 연결 + 저장소 메타데이터 수집 작업을 등록합니다.
+title: "[Slice 3] GitHub HTTP 패처 — 연결/저장소 API + metadata_payload 채우기"
+body:
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 목적
+      description: 이 작업이 필요한 이유와 해결하려는 문제를 적어주세요.
+      placeholder: |
+        Slice 2 분석 파이프라인이 github_projects.metadata_payload 가 사전 채워져 있다고 가정하고 fixture로 테스트한다.
+        실제 GitHub REST API를 호출해 이 컬럼을 채우는 HTTP 패처가 없으면 프로덕션에서 분석이 동작하지 않는다.
+      value: |
+        Slice 2 분석 파이프라인은 `github_projects.metadata_payload` 가 사전 채워져 있다고 가정하고 fixture로 테스트한다.
+        실제 GitHub REST API를 호출해 이 컬럼을 채우는 HTTP 패처가 없으면 프로덕션에서 분석이 동작하지 않는다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 작업 내용
+      value: |
+        **External Layer (`external/github/`)**
+        - `GithubApiClient` 인터페이스 — exchangeCode, getUserInfo, listUserRepos, getReadme, getLanguages, getFileContent, listCommits, getCommitDetail, listPullRequests, listIssues
+        - `RestGithubApiClient` — Spring RestClient 구현, 429→GITHUB_RATE_LIMITED / 5xx→GITHUB_API_ERROR
+        - `GithubApiProperties` (`@ConfigurationProperties("github.api")`)
+        - DTO 레코드: GithubUserInfoDto, GithubRepoDto, GithubCommitDto, GithubCommitDetailDto, GithubPrDto, GithubIssueDto
+
+        **Domain Fetcher (`domain/github/service/fetcher/`)**
+        - `GithubMetadataFetcher` — 저장소 1개의 RepoMetadata 조립 (readme 1KB 캡, 의존성 파일 2KB 캡, 커밋 20개 역순 정렬, PR/Issue 50개 사용자 필터)
+
+        **Domain Service + Controller**
+        - `GithubConnectionService.connect()` — OAuth 코드 교환 → GithubConnection upsert → 저장소 동기화 → 메타데이터 채우기
+        - `POST /api/github/connections`, `GET /api/github/repositories`
+
+        **수정 파일**
+        - `GithubProject`: `create()` 팩토리 + `updateMetadataPayload()`
+        - `ErrorCode`: GITHUB_RATE_LIMITED, GITHUB_API_ERROR 추가
+        - `application.yml`: `github.api.*` 설정 추가
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 완료 조건
+      value: |
+        - `./gradlew test` — RestGithubApiClientTest (14), GithubMetadataFetcherTest (9), GithubConnectionServiceTest (3) 통과
+        - `./gradlew integrationTest` — GithubConnectionControllerTest (7) 통과
+        - `POST /api/github/connections` 후 DB에 GithubProject 행 생성, metadataPayload 에 languageBytes 포함
+        - `GET /api/github/repositories` 소유권 검증 후 저장소 목록 반환
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/slice4a-hunk-diff-cleanup.yml
+++ b/.github/ISSUE_TEMPLATE/slice4a-hunk-diff-cleanup.yml
@@ -1,0 +1,49 @@
+name: "[Slice 4a] Hunk 단위 Diff 전처리"
+description: DiffPreprocessor 에 hunk 단위 노이즈 제거 작업을 등록합니다.
+title: "[Slice 4a] Hunk 단위 Diff 전처리 — import-only / whitespace-only / @Generated hunk drop"
+body:
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 목적
+      value: |
+        Slice 2의 `DiffPreprocessor`는 lockfile/바이너리/vendored 파일 블록 전체를 drop한다.
+        그러나 일반 소스 파일 내에도 Stage 2 LLM에 불필요한 hunk가 섞인다.
+        - import 재정렬 — 개발자 결정과 무관한 import 추가/제거
+        - 공백 정리 — 포맷터가 자동 생성한 빈 줄/들여쓰기 변경
+        - @Generated 어노테이션 — 빌드 도구가 주입한 코드
+
+        이 hunk들을 drop하면 Stage 2 토큰 사용량이 줄고 per-repo summary 품질이 높아진다.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 작업 내용
+      value: |
+        **수정 파일: `DiffPreprocessor.java`**
+        - `HUNK_HEADER` 패턴 (`^@@ ... @@`) 추가
+        - `filterHunks(String fileBlock)` — hunk 단위로 분리 후 drop 여부 판정
+        - `shouldDropHunk(String hunk)` — 변경 줄이 모두 import-only / whitespace-only / @Generated-only 이면 drop
+        - 지원 언어: Java/Kotlin(`import`), Python(`from X import`), JS/TS(`import`), Rust(`use`), Go(`import`)
+
+        **수정 파일: `DiffPreprocessorTest.java`**
+        - import-only hunk drop, whitespace-only hunk drop, @Generated hunk drop
+        - 혼합 hunk(import + 실질 변경) 유지, context-only hunk 유지
+
+        **변경 없는 파일**
+        - `GithubAnalysisService` — `diffPreprocessor.clean()` 호출 시그니처 동일
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 완료 조건
+      value: |
+        - `./gradlew test --tests "*.DiffPreprocessorTest"` — 9개 전체 통과 (기존 4 + 신규 5)
+        - `./gradlew test` — 전체 suite GREEN
+        - `GithubAnalysisFlowIntegrationTest` 영향 없음
+    validations:
+      required: true

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -102,8 +102,13 @@ public class GithubAnalysisService {
         List<GithubAnalysisPayload.RepoSummary> repoSummaries = new ArrayList<>();
         for (GithubProject core : coreProjects) {
             RepoMetadata metadata = parseMetadata(core.getMetadataPayload());
-            ChampionTriageService.TriageResult triage =
-                    triageService.triage(core.getRepoFullName(), core.getRepoUrl(), metadata);
+            ChampionTriageService.TriageResult triage;
+            try {
+                triage = triageService.triage(core.getRepoFullName(), core.getRepoUrl(), metadata);
+            } catch (ServiceException e) {
+                log.warn("분석 skip: 기여 커밋 없음 repo={}", core.getRepoFullName());
+                continue;
+            }
 
             List<ResolvedChampion> resolved = resolveChampions(triage.champions(), metadata);
             String summaryPrompt = summaryPromptBuilder.build(

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,12 +88,17 @@ public class GithubConnectionService {
 
     private GithubProject upsertProject(Long userId, Long connectionId, GithubRepoDto repo) {
         return projectRepo.findByUserIdAndRepoFullName(userId, repo.fullName())
-                .map(existing -> existing)
                 .orElseGet(() -> {
-                    GithubProject p = GithubProject.create(userId, connectionId,
-                            repo.nodeId(), repo.fullName(), repo.htmlUrl(),
-                            repo.language(), repo.defaultBranch());
-                    return projectRepo.save(p);
+                    try {
+                        GithubProject p = GithubProject.create(userId, connectionId,
+                                repo.nodeId(), repo.fullName(), repo.htmlUrl(),
+                                repo.language(), repo.defaultBranch());
+                        return projectRepo.saveAndFlush(p);
+                    } catch (DataIntegrityViolationException e) {
+                        return projectRepo.findByUserIdAndRepoFullName(userId, repo.fullName())
+                                .orElseThrow(() -> new ServiceException(ErrorCode.GITHUB_API_ERROR,
+                                        "repo upsert failed: " + repo.fullName()));
+                    }
                 });
     }
 

--- a/backend/src/main/java/com/back/coach/domain/github/service/fetcher/GithubMetadataFetcher.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/fetcher/GithubMetadataFetcher.java
@@ -14,7 +14,7 @@ public class GithubMetadataFetcher {
     public static final int README_MAX_BYTES = 1024;
     public static final int DEP_FILE_MAX_BYTES = 2048;
     static final int BODY_MAX_CHARS = 500;
-    static final int COMMIT_LIMIT = 20;
+    static final int COMMIT_LIMIT = 5;
 
     private static final List<String> DEP_FILE_PATHS = List.of(
             "pom.xml", "build.gradle", "build.gradle.kts", "package.json",

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
@@ -61,9 +61,14 @@ public class SynthesisPromptBuilder {
         }
 
         sb.append("\n## Output\n");
-        sb.append("Output a single JSON object {techTags, depthEstimates, evidences, finalTechProfile}.\n");
-        sb.append("DepthEstimate.level must be one of: ").append(DEPTH_VALUES).append("\n");
-        sb.append("Evidence.type must be one of: ").append(EVIDENCE_VALUES).append("\n");
+        sb.append("Output ONLY a single JSON object with exactly these fields and structures:\n");
+        sb.append("{\n");
+        sb.append("  \"techTags\": [ { \"skillName\": string, \"tagReason\": string } ],\n");
+        sb.append("  \"depthEstimates\": [ { \"skillName\": string, \"level\": \"").append(DEPTH_VALUES).append("\", \"reason\": string } ],\n");
+        sb.append("  \"evidences\": [ { \"repoName\": string, \"type\": \"").append(EVIDENCE_VALUES).append("\", \"source\": string, \"summary\": string } ],\n");
+        sb.append("  \"finalTechProfile\": { \"confirmedSkills\": [ string ], \"focusAreas\": [ string ] }\n");
+        sb.append("}\n");
+        sb.append("Do NOT rename fields. Do NOT add extra fields.\n");
         return sb.toString();
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
 import java.util.List;
@@ -43,6 +44,7 @@ public class RoadmapCommandService {
     private final RoadmapResponseParser roadmapResponseParser;
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
 
     public RoadmapCommandService(
             CapabilityDiagnosisRepository capabilityDiagnosisRepository,
@@ -55,7 +57,8 @@ public class RoadmapCommandService {
             RoadmapPromptBuilder roadmapPromptBuilder,
             RoadmapResponseParser roadmapResponseParser,
             LlmClient llmClient,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            TransactionTemplate transactionTemplate
     ) {
         this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
         this.githubAnalysisRepository = githubAnalysisRepository;
@@ -68,48 +71,48 @@ public class RoadmapCommandService {
         this.roadmapResponseParser = roadmapResponseParser;
         this.llmClient = llmClient;
         this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
     }
 
-    @Transactional
+    // LLM 호출을 트랜잭션 밖에서 수행해 DB 커넥션을 장시간 점유하지 않도록 분리
     public RoadmapDetailResponse createRoadmap(Long userId, RoadmapRequest request) {
-        CapabilityDiagnosis diagnosis = capabilityDiagnosisRepository.findByIdAndUserId(request.diagnosisId(), userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
-        validateGithubAnalysisOwnership(userId, request.githubAnalysisId());
-        UserProfile profile = userProfileRepository.findByIdAndUserId(diagnosis.getProfileId(), userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
-        JobRole jobRole = jobRoleRepository.findById(diagnosis.getJobRoleId())
-                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
-        DiagnosisPayload diagnosisPayload = parseDiagnosisPayload(diagnosis);
+        // 1. DB 조회 (짧은 트랜잭션)
+        record Inputs(CapabilityDiagnosis diagnosis, UserProfile profile, JobRole jobRole, DiagnosisPayload payload) {}
+        Inputs inputs = transactionTemplate.execute(status -> {
+            CapabilityDiagnosis diagnosis = capabilityDiagnosisRepository.findByIdAndUserId(request.diagnosisId(), userId)
+                    .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+            validateGithubAnalysisOwnership(userId, request.githubAnalysisId());
+            UserProfile profile = userProfileRepository.findByIdAndUserId(diagnosis.getProfileId(), userId)
+                    .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+            JobRole jobRole = jobRoleRepository.findById(diagnosis.getJobRoleId())
+                    .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+            return new Inputs(diagnosis, profile, jobRole, parseDiagnosisPayload(diagnosis));
+        });
 
+        // 2. LLM 호출 (트랜잭션 밖)
         String prompt = roadmapPromptBuilder.build(new RoadmapPromptBuilder.Input(
-                jobRole,
-                profile,
-                diagnosis,
-                diagnosisPayload,
-                request.weeklyStudyHours(),
-                request.targetDate()
+                inputs.jobRole(), inputs.profile(), inputs.diagnosis(), inputs.payload(),
+                request.weeklyStudyHours(), request.targetDate()
         ));
         RoadmapResponseParser.RoadmapResult roadmapResult =
                 roadmapResponseParser.parse(llmClient.complete(prompt));
-        RoadmapPayload roadmapPayload = new RoadmapPayload(roadmapResult.weeks());
 
-        LearningRoadmap savedRoadmap = learningRoadmapRepository.save(LearningRoadmap.create(
-                userId,
-                diagnosis.getId(),
-                resultVersionService.nextLearningRoadmapVersion(userId),
-                roadmapResult.weeks().size(),
-                roadmapResult.summary(),
-                toJson(roadmapPayload)
-        ));
-        List<RoadmapWeek> savedWeeks = roadmapWeekRepository.saveAll(toRoadmapWeeks(
-                savedRoadmap.getId(),
-                roadmapResult.weeks()
-        ));
-
-        return RoadmapDetailResponse.from(
-                toSnapshot(savedRoadmap, savedWeeks),
-                objectMapper
-        );
+        // 3. DB 저장 (새 트랜잭션)
+        return transactionTemplate.execute(status -> {
+            RoadmapPayload roadmapPayload = new RoadmapPayload(roadmapResult.weeks());
+            LearningRoadmap savedRoadmap = learningRoadmapRepository.save(LearningRoadmap.create(
+                    userId,
+                    inputs.diagnosis().getId(),
+                    resultVersionService.nextLearningRoadmapVersion(userId),
+                    roadmapResult.weeks().size(),
+                    roadmapResult.summary(),
+                    toJson(roadmapPayload)
+            ));
+            List<RoadmapWeek> savedWeeks = roadmapWeekRepository.saveAll(toRoadmapWeeks(
+                    savedRoadmap.getId(), roadmapResult.weeks()
+            ));
+            return RoadmapDetailResponse.from(toSnapshot(savedRoadmap, savedWeeks), objectMapper);
+        });
     }
 
     private void validateGithubAnalysisOwnership(Long userId, Long githubAnalysisId) {

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -46,6 +46,8 @@ public class RoadmapPromptBuilder {
                 - tasks[].type must be one of READ_DOCS, BUILD_EXAMPLE, WRITE_NOTE, APPLY_PROJECT, REVIEW.
                 - materials[].type must be one of DOCS, ARTICLE, REPOSITORY, VIDEO, TEMPLATE.
                 - Do not include progress status.
+                - Generate at most 8 weeks total.
+                - Your output budget is 8192 tokens. Complete the entire JSON within this limit — do not truncate mid-object.
 
                 User context:
                 - targetRole: %s

--- a/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
@@ -80,7 +80,6 @@ public class RestGithubApiClient implements GithubApiClient {
     public List<GithubRepoDto> listUserRepos(String accessToken) {
         URI uri = UriComponentsBuilder.fromUriString("/user/repos")
                 .queryParam("affiliation", "owner")
-                .queryParam("type", "all")
                 .queryParam("per_page", 100)
                 .build().toUri();
         return getList(uri, accessToken, new ParameterizedTypeReference<>() {});
@@ -200,8 +199,10 @@ public class RestGithubApiClient implements GithubApiClient {
                             (req, res) -> { throw new ServiceException(ErrorCode.GITHUB_RATE_LIMITED); })
                     .onStatus(s -> s.value() == NOT_FOUND,
                             (req, res) -> { throw new ServiceException(ErrorCode.RESOURCE_NOT_FOUND); })
-                    .onStatus(s -> s.isError(),
-                            (req, res) -> { throw new ServiceException(ErrorCode.GITHUB_API_ERROR); })
+                    .onStatus(s -> s.isError(), (req, res) -> {
+                        log.warn("GitHub API list error: status={} uri={}", res.getStatusCode(), uri);
+                        throw new ServiceException(ErrorCode.GITHUB_API_ERROR);
+                    })
                     .body(type);
             return result == null ? List.of() : result;
         } catch (ServiceException e) {

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -28,8 +28,11 @@ public class AiGatewayLlmClient implements LlmClient {
     @Autowired
     public AiGatewayLlmClient(AiGatewayProperties properties, RestClient.Builder restClientBuilder) {
         this.properties = properties;
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) properties.timeout().connect().toMillis());
+        factory.setReadTimeout((int) properties.timeout().read().toMillis());
         this.restClient = restClientBuilder
-                .requestFactory(new SimpleClientHttpRequestFactory())
+                .requestFactory(factory)
                 .baseUrl(properties.baseUrl())
                 .build();
     }
@@ -51,7 +54,8 @@ public class AiGatewayLlmClient implements LlmClient {
                     .headers(headers -> setAuthorization(headers, properties.apiKey()))
                     .body(new ChatCompletionRequest(
                             properties.model(),
-                            java.util.List.of(new Message("user", prompt))
+                            java.util.List.of(new Message("user", prompt)),
+                            16384
                     ))
                     .retrieve()
                     .onStatus(status -> status.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
@@ -103,7 +107,8 @@ public class AiGatewayLlmClient implements LlmClient {
 
     private record Message(String role, String content) {}
 
-    private record ChatCompletionRequest(String model, java.util.List<Message> messages) {}
+    private record ChatCompletionRequest(String model, java.util.List<Message> messages,
+                                         @com.fasterxml.jackson.annotation.JsonProperty("max_tokens") int maxTokens) {}
 
     private record ChatCompletionResponse(java.util.List<Choice> choices) {}
 

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayProperties.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayProperties.java
@@ -6,8 +6,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record AiGatewayProperties(
         String apiKey,
         String baseUrl,
-        String model
+        String model,
+        Timeout timeout
 ) {
+
+    public record Timeout(
+            java.time.Duration connect,
+            java.time.Duration read
+    ) {
+        public Timeout {
+            if (connect == null) connect = java.time.Duration.ofSeconds(5);
+            if (read == null) read = java.time.Duration.ofSeconds(120);
+        }
+    }
 
     public AiGatewayProperties {
         apiKey = apiKey == null ? "" : apiKey;
@@ -17,5 +28,6 @@ public record AiGatewayProperties(
         if (model == null || model.isBlank()) {
             throw new IllegalArgumentException("ai.gateway.model must not be blank");
         }
+        if (timeout == null) timeout = new Timeout(null, null);
     }
 }

--- a/backend/src/main/resources/ai/schema/repo-summary.schema.json
+++ b/backend/src/main/resources/ai/schema/repo-summary.schema.json
@@ -5,7 +5,7 @@
   "required": ["repoId", "repoName", "summary", "highlights"],
   "additionalProperties": false,
   "properties": {
-    "repoId": { "type": "string", "minLength": 1 },
+    "repoId": { "type": ["string", "integer"] },
     "repoName": { "type": "string", "minLength": 1 },
     "summary": { "type": "string", "minLength": 1 },
     "highlights": {

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -15,6 +15,15 @@ spring:
       hibernate:
         format_sql: true
 
+security:
+  jwt:
+    access-ttl-seconds: 86400  # smoke 전용 24시간 — 프로덕션 복원 필요 (기본값 900)
+
+ai:
+  gateway:
+    timeout:
+      read: 300s  # smoke 전용 5분 — 프로덕션 복원 필요 (기본값 120s)
+
 logging:
   level:
     com.back.coach: DEBUG

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
@@ -63,6 +63,7 @@ class GithubConnectionServiceTest {
                 "https://github.com/testuser/repo-a", "Java", "main");
         ReflectionTestUtils.setField(savedProject, "id", 100L);
         given(projectRepo.save(any())).willReturn(savedProject);
+        given(projectRepo.saveAndFlush(any())).willReturn(savedProject);
         given(metadataFetcher.fetch(anyString(), anyString(), anyString(), anyString()))
                 .willReturn(sampleMetadata());
 
@@ -72,8 +73,9 @@ class GithubConnectionServiceTest {
         assertThat(result.githubLogin()).isEqualTo("testuser");
         verify(connectionRepo).save(any(GithubConnection.class));
         verify(metadataFetcher, times(2)).fetch(eq("ghp_token"), eq("testuser"), anyString(), eq("testuser"));
-        // 2 repos × 2 saves each (create + metadata update)
-        verify(projectRepo, times(4)).save(any(GithubProject.class));
+        // 2 repos: saveAndFlush(create) + save(metadata update) each
+        verify(projectRepo, times(2)).saveAndFlush(any(GithubProject.class));
+        verify(projectRepo, times(2)).save(any(GithubProject.class));
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/github/service/fetcher/GithubMetadataFetcherTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/fetcher/GithubMetadataFetcherTest.java
@@ -35,7 +35,7 @@ class GithubMetadataFetcherTest {
         given(apiClient.getLanguages(TOKEN, OWNER, REPO)).willReturn(Map.of("Java", 10000L));
         given(apiClient.getFileContent(eq(TOKEN), eq(OWNER), eq(REPO), anyString()))
                 .willReturn(Optional.empty());
-        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, 20)).willReturn(List.of());
+        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, GithubMetadataFetcher.COMMIT_LIMIT)).willReturn(List.of());
         given(apiClient.listPullRequests(TOKEN, OWNER, REPO)).willReturn(List.of());
         given(apiClient.listIssues(TOKEN, OWNER, REPO)).willReturn(List.of());
     }
@@ -93,7 +93,7 @@ class GithubMetadataFetcherTest {
     void fetch_commitsSortedOldestFirst() {
         var commitNew = makeCommit("sha-new", "new commit", "2026-01-02T00:00:00Z");
         var commitOld = makeCommit("sha-old", "old commit", "2026-01-01T00:00:00Z");
-        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, 20)).willReturn(List.of(commitNew, commitOld));
+        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, GithubMetadataFetcher.COMMIT_LIMIT)).willReturn(List.of(commitNew, commitOld));
         given(apiClient.getCommitDetail(TOKEN, OWNER, REPO, "sha-new")).willReturn(makeDetail("sha-new", "new commit", 10, 2));
         given(apiClient.getCommitDetail(TOKEN, OWNER, REPO, "sha-old")).willReturn(makeDetail("sha-old", "old commit", 5, 1));
 
@@ -109,7 +109,7 @@ class GithubMetadataFetcherTest {
     void fetch_commitSubjectAndBody() {
         String message = "feat: OAuth\n\nThis is the body of the commit.";
         var commit = makeCommit("sha1", message, "2026-01-01T00:00:00Z");
-        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, 20)).willReturn(List.of(commit));
+        given(apiClient.listCommits(TOKEN, OWNER, REPO, LOGIN, GithubMetadataFetcher.COMMIT_LIMIT)).willReturn(List.of(commit));
         given(apiClient.getCommitDetail(TOKEN, OWNER, REPO, "sha1"))
                 .willReturn(makeDetail("sha1", message, 5, 1));
 

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -25,6 +25,8 @@ import com.back.coach.global.exception.ServiceException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -84,10 +86,18 @@ class RoadmapCommandServiceTest {
     @Mock
     private LlmClient llmClient;
 
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
     private RoadmapCommandService roadmapCommandService;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
+        given(transactionTemplate.execute(any())).willAnswer(inv -> {
+            TransactionCallback<?> cb = inv.getArgument(0);
+            return cb.doInTransaction(null);
+        });
         roadmapCommandService = new RoadmapCommandService(
                 capabilityDiagnosisRepository,
                 githubAnalysisRepository,
@@ -99,7 +109,8 @@ class RoadmapCommandServiceTest {
                 new RoadmapPromptBuilder(),
                 new RoadmapResponseParser(),
                 llmClient,
-                objectMapper
+                objectMapper,
+                transactionTemplate
         );
     }
 

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -63,7 +63,8 @@ class AiGatewayLlmClientTest {
                 .withRequestBody(equalToJson("""
                         {
                           "model": "test-model",
-                          "messages": [{"role": "user", "content": "hello"}]
+                          "messages": [{"role": "user", "content": "hello"}],
+                          "max_tokens": 16384
                         }
                         """)));
     }

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -26,7 +26,7 @@ class AiGatewayLlmClientTest {
         wireMock = new WireMockServer(options().dynamicPort());
         wireMock.start();
         client = new AiGatewayLlmClient(
-                new AiGatewayProperties("dummy-key", "http://127.0.0.1:" + wireMock.port(), "test-model")
+                new AiGatewayProperties("dummy-key", "http://127.0.0.1:" + wireMock.port(), "test-model", null)
         );
     }
 
@@ -105,7 +105,7 @@ class AiGatewayLlmClientTest {
 
     @Test
     void properties_acceptsBlankApiKeyForLocalSkeleton() {
-        AiGatewayProperties properties = new AiGatewayProperties(null, "http://localhost:0", "test-model");
+        AiGatewayProperties properties = new AiGatewayProperties(null, "http://localhost:0", "test-model", null);
 
         assertThat(properties.apiKey()).isEmpty();
         assertThat(properties.baseUrl()).isEqualTo("http://localhost:0");
@@ -114,11 +114,11 @@ class AiGatewayLlmClientTest {
 
     @Test
     void properties_rejectsBlankBaseUrlOrModel() {
-        assertThatThrownBy(() -> new AiGatewayProperties("key", "", "test-model"))
+        assertThatThrownBy(() -> new AiGatewayProperties("key", "", "test-model", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("ai.gateway.base-url must not be blank");
 
-        assertThatThrownBy(() -> new AiGatewayProperties("key", "http://localhost:0", ""))
+        assertThatThrownBy(() -> new AiGatewayProperties("key", "http://localhost:0", "", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("ai.gateway.model must not be blank");
     }

--- a/docs/16_v1_smoke_debug_2026-05-06.md
+++ b/docs/16_v1_smoke_debug_2026-05-06.md
@@ -1,0 +1,356 @@
+# v1 Smoke 디버깅 세션 - 2026-05-06
+
+## 목적
+
+2026-05-05 smoke(#15)에서 남은 blocker 2건(GitHub repository OAuth env 미설정, 진단 LLM schema 불일치)을 해소하고, 브라우저 기반 전체 흐름을 실제 API 호출로 재검증한다.
+
+## 실행 환경
+
+- 기준 브랜치: `dev` (`0abd316` — "fix: placeholder 밸류 수정")
+- DB/Redis: `docker compose -f docker/docker-compose.yml up -d`
+- backend: `local,oauth` profile, `http://localhost:8080`
+- frontend: `http://localhost:3000`
+- 민감 정보(token, cookie, client secret, API key)는 이 문서에 기록하지 않는다.
+
+---
+
+## 환경 설정 변경 사항
+
+### 루트 `.env` 신규 생성
+
+이전 smoke까지는 `application-secret.yml`을 사용하거나 env가 부분적으로만 설정돼 있었다. 이번 세션에서 루트 `.env`를 새로 작성하고 아래 항목을 모두 채웠다.
+
+```
+# DB
+POSTGRES_DB=coachdb
+POSTGRES_USER=coach
+POSTGRES_PASSWORD=...
+
+# Redis
+REDIS_PASSWORD=...
+
+# JWT
+JWT_SECRET=...
+
+# GitHub OAuth (로그인용)
+GITHUB_CLIENT_ID=Ov23liH7...
+GITHUB_CLIENT_SECRET=...
+
+# GitHub OAuth (저장소 연결 전용)
+GITHUB_CONNECTION_CLIENT_ID=Ov23liFABY...
+GITHUB_CONNECTION_CLIENT_SECRET=...
+
+# AI Gateway
+AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co
+AI_GATEWAY_API_KEY=...
+```
+
+> `application-secret.yml` 방식은 deprecated. 이 프로젝트에서는 `.env` 파일만 사용한다.
+
+### `frontend/.env.local` 추가
+
+```
+NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=Ov23liFABY...
+NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback
+```
+
+이전 smoke(#15)에서 `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID`가 없어 저장소 연결 전용 OAuth App이 적용된 상태를 확인하지 못했던 blocker B1이 이 추가로 해소됐다.
+
+### GitHub OAuth App 구조 정리
+
+| 용도 | Client ID prefix | 환경변수 |
+|---|---|---|
+| 로그인 (GitHub Sign-In) | `Ov23liH7...` | `GITHUB_CLIENT_ID` / `NEXT_PUBLIC_GITHUB_CLIENT_ID` |
+| 저장소 연결 (repo scope) | `Ov23liFABY...` | `GITHUB_CONNECTION_CLIENT_ID` / `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID` |
+
+두 OAuth App을 분리한 이유: 로그인 App에는 `repo` scope를 부여하지 않아 저장소 연결 시도 시 403이 발생했다(#167에서 분리).
+
+### `AI_GATEWAY_BASE_URL` 중복 `/v1` 수정
+
+```
+# 수정 전 (잘못된 설정)
+AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co/v1
+
+# 수정 후
+AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co
+```
+
+backend 코드가 이미 path에 `/v1`을 붙이고 있어서 double `/v1/v1/...`로 요청이 나가 404가 발생했다.
+
+---
+
+## 발견 및 수정한 버그
+
+### BUG-1. 프로필 저장 INVALID_INPUT
+
+**증상**
+
+`POST /api/v1/profiles` 요청이 `INVALID_INPUT` 에러를 반환하고 저장에 실패했다.
+
+**원인**
+
+`targetRole` enum 기본값이 프론트엔드와 DB seed 사이에 불일치했다.
+
+- 프론트엔드 `defaultValue` / `placeholder`: `BACKEND_ENGINEER`
+- DB enum 정의 및 seed 값: `BACKEND_DEVELOPER`
+
+`BACKEND_ENGINEER`는 유효하지 않은 enum 값이어서 backend validation이 거부했다.
+
+**수정 파일**
+
+`frontend/src/components/profile/profile-view.tsx:173`
+
+```tsx
+// 수정 전
+defaultValue="BACKEND_ENGINEER"
+placeholder="BACKEND_ENGINEER"
+
+// 수정 후
+defaultValue="BACKEND_DEVELOPER"
+placeholder="BACKEND_DEVELOPER"
+```
+
+**상태**: 수정 완료 (`0abd316` — "fix: placeholder 밸류 수정"으로 이미 `dev`에 반영)
+
+---
+
+### BUG-2. GitHub 연결 GITHUB_API_ERROR (422)
+
+**증상**
+
+`POST /api/github/connections` 처리 중 GitHub API 호출이 422 Unprocessable Entity를 반환하며 저장소 목록 수집에 실패했다.
+
+**원인**
+
+`listUserRepos()` 호출 시 `affiliation=owner`와 `type=all`을 동시에 전달했다. GitHub API는 `affiliation`과 `type`을 동시에 허용하지 않으며, 둘 다 있으면 422를 반환한다.
+
+참고: [GitHub REST API — List repositories for the authenticated user](https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user)
+
+> If `type` is set to `all`, `owner`, `public`, `private`, or `member`, then `visibility`, `affiliation`, `sort`, and `direction` can't be set.
+
+**수정 파일**
+
+`backend/src/main/java/.../ infrastructure/github/RestGithubApiClient.java`
+
+```java
+// 수정 전
+UriComponentsBuilder.fromHttpUrl(baseUrl + "/user/repos")
+    .queryParam("affiliation", "owner")
+    .queryParam("type", "all")   // <-- 422 원인
+    .queryParam("per_page", 100)
+    ...
+
+// 수정 후
+UriComponentsBuilder.fromHttpUrl(baseUrl + "/user/repos")
+    .queryParam("affiliation", "owner")
+    // type 파라미터 제거
+    .queryParam("per_page", 100)
+    ...
+```
+
+**상태**: 수정 완료
+
+---
+
+### BUG-3. GitHub 연결 재시도 시 ConstraintViolationException (duplicate key)
+
+**증상**
+
+GitHub 저장소 연결 도중 HTTP timeout으로 프론트엔드가 에러를 표시했다. 재시도하자 `ConstraintViolationException: duplicate key value violates unique constraint "github_projects_pkey"` 발생.
+
+**원인**
+
+HTTP timeout은 클라이언트 측에서 발생했지만 백엔드 트랜잭션은 이미 커밋 완료된 상태였다. 재시도 시 동일한 `github_project_id`로 INSERT를 시도하면서 PK 충돌이 났다.
+
+**즉시 조치 (수동 데이터 정리)**
+
+```sql
+-- docker exec으로 직접 실행
+docker exec -it coach-db psql -U coach -d coachdb \
+  -c "DELETE FROM github_projects WHERE user_id = 1;"
+```
+
+**코드 수정 파일**
+
+`backend/src/main/java/.../application/github/GithubConnectionService.java`
+
+`upsertProject()` 메서드에 `DataIntegrityViolationException` catch 후 재조회 fallback을 추가했다.
+
+```java
+// 수정 전
+public GithubProject upsertProject(GithubProjectCommand command) {
+    return githubProjectRepository.save(GithubProject.of(command));
+}
+
+// 수정 후
+public GithubProject upsertProject(GithubProjectCommand command) {
+    try {
+        return githubProjectRepository.saveAndFlush(GithubProject.of(command));
+    } catch (DataIntegrityViolationException e) {
+        // 동시 재시도 또는 timeout 후 재시도로 이미 INSERT된 경우 재조회로 fallback
+        return githubProjectRepository
+            .findByGithubProjectId(command.githubProjectId())
+            .orElseThrow(() -> e);
+    }
+}
+```
+
+`save` → `saveAndFlush`로 변경한 이유: flush를 즉시 호출해야 `DataIntegrityViolationException`이 catch 블록 안에서 발생한다. `save`만 쓰면 예외가 트랜잭션 commit 시점으로 밀려나 catch가 동작하지 않는다.
+
+**상태**: 수정 완료
+
+---
+
+### BUG-4. RepoSummary schema 위반 (repoId 타입 불일치)
+
+**증상**
+
+GitHub 분석 실행 중 backend log에 schema 검증 실패가 기록됐다.
+
+```text
+RepoSummary schema 위반: $.repoId: integer found, string expected
+```
+
+**원인**
+
+LLM이 `repoId` 필드를 숫자(`123`)로 반환했다. `repo-summary.schema.json`의 `repoId` 타입이 `"string"`만 허용하고 있어 검증이 실패했다.
+
+**수정 파일**
+
+`backend/src/main/resources/schema/repo-summary.schema.json`
+
+```json
+// 수정 전
+{
+  "repoId": {
+    "type": "string"
+  }
+}
+
+// 수정 후
+{
+  "repoId": {
+    "type": ["string", "integer"]
+  }
+}
+```
+
+> 근본 해결책은 LLM prompt에서 `repoId`를 반드시 string으로 출력하도록 지시하거나, backend에서 수신 후 String으로 강제 변환하는 것이다. 이번 세션에서는 schema 완화로 임시 처리했다.
+
+**상태**: 수정 완료 (임시 — schema 완화)
+
+---
+
+### BUG-5. 분석 속도 과다 지연
+
+**증상**
+
+GitHub 저장소 연결 직후 분석이 시작됐는데 repo 수가 많아 완료까지 수십 분이 소요됐다.
+
+**원인 분석**
+
+저장소 1개당 GitHub API 호출 수:
+
+| 호출 종류 | 횟수 |
+|---|---|
+| repo 기본 정보 | 1 |
+| 언어 통계 | 1 |
+| 기여자 목록 | 1 |
+| 최근 커밋 목록 | 1 |
+| 커밋 detail (diff 포함) | 최대 20 |
+| 기타 | ~10 |
+| **합계** | **최대 ~34** |
+
+연결 단계에서 선택한 저장소뿐 아니라 GitHub API로 조회된 전체 저장소(최대 100개)에 대해 모두 메타데이터를 수집하는 구조였다. 100개 × 34회 = 최대 3,400 API 호출.
+
+**임시 조치**
+
+`backend/src/main/java/.../infrastructure/github/GithubMetadataFetcher.java`
+
+```java
+// 수정 전
+private static final int COMMIT_LIMIT = 20;
+
+// 수정 후 (임시)
+private static final int COMMIT_LIMIT = 5;
+```
+
+**근본 문제 (미해결)**
+
+연결 단계에서 사용자가 선택하지 않은 저장소까지 전수 메타데이터 수집이 실행되는 구조가 근본 원인이다. 저장소 선택 이후에만 분석 대상 repo에 한정해 API를 호출하도록 수집 시점을 후단으로 이동해야 한다.
+
+**상태**: 임시 조치 완료 (`COMMIT_LIMIT` 축소), 구조 리팩터는 미완
+
+---
+
+## 디버깅을 위해 추가한 임시 로그
+
+smoke 완료 후 제거 권장.
+
+**파일**: `RestGithubApiClient.java`
+
+```java
+// exchangeCode() 내부
+log.debug("GitHub OAuth exchange response: {}", response);
+
+// getList() 내부
+log.warn("GitHub API list error: status={} uri={}", res.getStatusCode(), uri);
+```
+
+---
+
+## Smoke 진행 상황
+
+| 단계 | 결과 | 비고 |
+|---|---|---|
+| 헬스 체크 (DB/Redis UP) | PASS | `/actuator/health` 200, db/redis UP |
+| GitHub 로그인 | PASS | OAuth callback 정상, JWT 쿠키 설정 |
+| 프로필 저장 | PASS | BUG-1 수정 후 성공 |
+| GitHub 저장소 연결 | PASS | BUG-2, BUG-3 수정 후 연결 성공 |
+| GitHub 분석 실행 | 진행 중 | BUG-4 수정 후 재시도 예정, BUG-5 임시 조치 적용 |
+| 진단 생성 | 미실행 | 분석 완료 후 진행 예정 |
+| 로드맵 생성 | 미실행 | — |
+| 진도 저장 | 미실행 | — |
+| 대시보드 확인 | 미실행 | — |
+
+---
+
+## 미해결 사항 (Blocker)
+
+### B1. GitHub 분석 완료 후 진단/로드맵 흐름 미검증
+
+```text
+단계: 분석 실행 → 진단 생성 → 로드맵 생성 → 진도 저장 → 대시보드
+현황: BUG-4 schema 수정 후 분석 재시도 예정
+다음 단계: 분석 완료 확인 → POST /api/diagnoses → POST /api/roadmaps → 진도 저장 → 대시보드 snapshot
+```
+
+### B2. GitHub 분석 수집 대상 범위 과도
+
+```text
+단계: GitHub 연결 / 저장소 수집
+증상: 선택하지 않은 저장소까지 전수 메타데이터 수집으로 연결 후 분석이 수십 분 지연됨
+임시 조치: COMMIT_LIMIT 5로 축소
+근본 수정: 분석 수집 시점을 저장소 선택 이후로 이동 (추후 이슈화 필요)
+```
+
+---
+
+## 다음 세션 체크리스트
+
+- [ ] GitHub 분석 실행 완료 확인 (BUG-4 적용 상태)
+- [ ] `POST /api/diagnoses` 호출 → diagnosisId 확인
+- [ ] `POST /api/roadmaps` 호출 → roadmapId 확인
+- [ ] 로드맵 진도 1건 저장 후 재조회
+- [ ] 대시보드 snapshot에 신규 ID 반영 확인
+- [ ] 임시 로그 2건 제거 (`RestGithubApiClient.java`)
+- [ ] `COMMIT_LIMIT` 원복(20) 또는 구조 리팩터 이슈 생성
+- [ ] `repoId` schema 타입 — string 강제 prompt 보강 또는 서비스 레이어 변환 처리
+
+---
+
+## 관련 문서
+
+- [14_v1_smoke_test_result_2026-05-04.md](14_v1_smoke_test_result_2026-05-04.md) — 첫 번째 smoke 결과
+- [15_v1_smoke_test_result_2026-05-05.md](15_v1_smoke_test_result_2026-05-05.md) — 두 번째 smoke: fenced JSON parser 보정, LLM schema 불일치 이동
+- [13_v1_smoke_test_checklist.md](13_v1_smoke_test_checklist.md) — smoke 완료 기준 체크리스트

--- a/docs/16_v1_smoke_debug_2026-05-06.md
+++ b/docs/16_v1_smoke_debug_2026-05-06.md
@@ -336,6 +336,34 @@ log.warn("GitHub API list error: status={} uri={}", res.getStatusCode(), uri);
 
 ---
 
+## BUG-6: JWT 액세스 토큰 만료 (분석 중 인증 끊김)
+
+| 항목 | 내용 |
+|------|------|
+| 증상 | 분석/연결 중 "인증이 필요합니다" 오류, 백엔드 로그 `Set SecurityContextHolder to anonymous SecurityContext` |
+| 원인 | `access-ttl-seconds: 900` (15분) — 분석이 오래 걸리면 만료됨 |
+| 임시 조치 | `application-local.yml`에 `security.jwt.access-ttl-seconds: 86400` 추가 (smoke 전용) |
+| 복원 필요 | smoke 완료 후 해당 라인 제거 또는 주석 처리 |
+| 후속 과제 | 분석 응답 시간 단축 (N+1 메타데이터 수집 구조 개선) 또는 refresh token 자동 갱신 구현 |
+
+---
+
+## 로드맵 생성 품질 / 성능 개선 TODO
+
+### 성능
+- [ ] **batch / multi-step 생성 워크플로우**: 현재 단일 LLM 호출로 8주 전체를 한 번에 생성 → 응답 시간 ~3분. 주차를 나눠 병렬 또는 순차 생성하는 워크플로우로 전환 필요
+- [ ] **LLM 호출을 `@Transactional` 밖으로 분리** (RoadmapCommandService는 이미 수정, DiagnosisCommandService 동일 패턴 확인 필요)
+
+### 자료 품질
+- [ ] **URL 검증**: 현재 LLM이 존재하지 않는 URL을 hallucination으로 생성함 (유튜브 링크 깨짐 등). tool calling으로 실제 URL 검색/검증 후 삽입하는 방식 검토
+- [ ] **고품질 자료 소스 확보**: MIT OpenCourseWare, Stanford CS 강의, 공식 문서 이외의 검증된 리소스(유명 강의, 오픈소스 튜토리얼 등)를 프롬프트에 예시로 제공하거나 curated DB로 구성
+- [ ] **언어 설정**: 현재 LLM 응답 언어가 고정되어 있지 않음. 프롬프트에 응답 언어(한국어/영어) 명시 필요
+
+### 구조
+- [ ] **tool calling 도입**: 자료 검색, URL 검증, 커리큘럼 DB 조회 등을 tool로 분리해 LLM이 실제 데이터를 기반으로 로드맵 생성하도록 개선
+
+---
+
 ## 다음 세션 체크리스트
 
 - [ ] GitHub 분석 실행 완료 확인 (BUG-4 적용 상태)
@@ -346,6 +374,7 @@ log.warn("GitHub API list error: status={} uri={}", res.getStatusCode(), uri);
 - [ ] 임시 로그 2건 제거 (`RestGithubApiClient.java`)
 - [ ] `COMMIT_LIMIT` 원복(20) 또는 구조 리팩터 이슈 생성
 - [ ] `repoId` schema 타입 — string 강제 prompt 보강 또는 서비스 레이어 변환 처리
+- [ ] `application-local.yml` JWT TTL 86400 → 제거 (smoke 완료 후)
 
 ---
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/github/callback/page.tsx
+++ b/frontend/src/app/github/callback/page.tsx
@@ -35,12 +35,12 @@ function CallbackInner() {
       });
   }, [params, router]);
 
-  return <StatePanel message="GitHub 연결 중입니다..." />;
+  return <StatePanel message="GitHub 연결 중입니다... 저장소 수가 많으면 1~3분 소요될 수 있습니다." />;
 }
 
 export default function GithubCallbackPage() {
   return (
-    <Suspense fallback={<StatePanel message="GitHub 연결 중입니다..." />}>
+    <Suspense fallback={<StatePanel message="GitHub 연결 중입니다... 저장소 수가 많으면 1~3분 소요될 수 있습니다." />}>
       <CallbackInner />
     </Suspense>
   );

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -61,6 +61,15 @@ a {
   gap: 4px;
   overflow-x: auto;
   padding-left: 24px;
+  flex: 1;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 16px;
+  flex-shrink: 0;
 }
 
 .nav-link {

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { isNavigationItemActive, navigationItems } from "@/config/routes";
+import { authNavigationItem, isNavigationItemActive, navigationItems } from "@/config/routes";
 
 type AppShellProps = {
   children: ReactNode;
@@ -36,6 +36,16 @@ export function AppShell({ children }: AppShellProps) {
             );
           })}
         </nav>
+        <div className="topbar-actions">
+          <Link
+            aria-current={isNavigationItemActive(authNavigationItem, pathname) ? "page" : undefined}
+            className="nav-link"
+            data-active={isNavigationItemActive(authNavigationItem, pathname)}
+            href={authNavigationItem.href}
+          >
+            {authNavigationItem.label}
+          </Link>
+        </div>
       </header>
       <main className="page">{children}</main>
     </div>

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -45,6 +45,12 @@ export const navigationItems: NavigationItem[] = [
   }
 ];
 
+export const authNavigationItem: NavigationItem = {
+  href: "/login",
+  label: "로그인",
+  exact: true,
+};
+
 export const screens = {
   dashboard: {
     eyebrow: "v1 확장",

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -28,6 +28,15 @@ type DiagnosisState =
 export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
   const [state, setState] = useState<DiagnosisState>({ status: "loading" });
 
+  if (diagnosisId === "demo") {
+    return (
+      <StatePanel
+        tone="neutral"
+        message="이 페이지는 아직 구현 중입니다. 분석 결과 페이지(/github/analysis)의 '진단 생성' 버튼을 이용해 주세요."
+      />
+    );
+  }
+
   useEffect(() => {
     let ignore = false;
 

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -28,16 +28,8 @@ type DiagnosisState =
 export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
   const [state, setState] = useState<DiagnosisState>({ status: "loading" });
 
-  if (diagnosisId === "demo") {
-    return (
-      <StatePanel
-        tone="neutral"
-        message="이 페이지는 아직 구현 중입니다. 분석 결과 페이지(/github/analysis)의 '진단 생성' 버튼을 이용해 주세요."
-      />
-    );
-  }
-
   useEffect(() => {
+    if (diagnosisId === "demo") return;
     let ignore = false;
 
     async function loadDiagnosis() {
@@ -65,6 +57,15 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
       ignore = true;
     };
   }, [diagnosisId]);
+
+  if (diagnosisId === "demo") {
+    return (
+      <StatePanel
+        tone="neutral"
+        message="이 페이지는 아직 구현 중입니다. 분석 결과 페이지(/github/analysis)의 '진단 생성' 버튼을 이용해 주세요."
+      />
+    );
+  }
 
   if (state.status === "loading") {
     return (

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -248,8 +248,8 @@ export function GithubAnalysisView({
                 <p>{repo.repoName}</p>
                 <h3>{repo.summary}</h3>
                 <ul>
-                  {repo.highlights.map((highlight) => (
-                    <li key={highlight}>{highlight}</li>
+                  {repo.highlights.map((highlight, i) => (
+                    <li key={i}>{highlight.text}</li>
                   ))}
                 </ul>
               </article>

--- a/frontend/src/features/github-analysis/types.ts
+++ b/frontend/src/features/github-analysis/types.ts
@@ -19,8 +19,13 @@ export type StaticSignals = {
   primaryLanguages: PrimaryLanguage[];
 };
 
+export type Highlight = {
+  text: string;
+  status: "ADOPTED" | "EVOLVED" | "REVERSED";
+};
+
 export type RepoSummary = {
-  highlights: string[];
+  highlights: Highlight[];
   repoId: string;
   repoName: string;
   summary: string;

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -9,6 +9,7 @@ import { StatePanel } from "@/components/state-panel";
 
 const CONNECTION_ID_KEY = "githubConnectionId";
 const CONNECTION_ID_CHANGE_EVENT = "githubConnectionIdChange";
+const SELECTED_REPOS_KEY = "githubSelectedRepos";
 
 type ViewState =
   | { status: "disconnected" }
@@ -41,6 +42,7 @@ function subscribeToConnectionId(onChange: () => void) {
 
 function clearConnectionId() {
   localStorage.removeItem(CONNECTION_ID_KEY);
+  localStorage.removeItem(SELECTED_REPOS_KEY);
   window.dispatchEvent(new Event(CONNECTION_ID_CHANGE_EVENT));
 }
 
@@ -52,7 +54,13 @@ export function GithubConnectionView() {
     () => null
   );
   const [state, setState] = useState<ViewState>({ status: "loading-repos" });
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    if (typeof window === "undefined") return new Set();
+    try {
+      const saved = localStorage.getItem(SELECTED_REPOS_KEY);
+      return saved ? new Set(JSON.parse(saved)) : new Set();
+    } catch { return new Set(); }
+  });
   const [connectUrl] = useState(() => githubConnectionOAuthUrl());
 
   useEffect(() => {
@@ -78,6 +86,7 @@ export function GithubConnectionView() {
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) { next.delete(id); } else { next.add(id); }
+      localStorage.setItem(SELECTED_REPOS_KEY, JSON.stringify(Array.from(next)));
       return next;
     });
   }

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -163,17 +163,17 @@ function ProfileForm({
         <div className="profile-section-heading">
           <h2>기본 정보</h2>
           <p>
-            목표 직무는 백엔드 job role code를 입력합니다. 예: BACKEND_ENGINEER
+            목표 직무는 백엔드 job role code를 입력합니다. 예: BACKEND_DEVELOPER
           </p>
         </div>
 
         <label>
           <span>목표 직무</span>
           <input
-            defaultValue={profile?.targetRole ?? "BACKEND_ENGINEER"}
+            defaultValue={profile?.targetRole ?? "BACKEND_DEVELOPER"}
             maxLength={100}
             name="targetRole"
-            placeholder="BACKEND_ENGINEER"
+            placeholder="BACKEND_DEVELOPER"
             required
           />
         </label>

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -17,8 +17,14 @@ function getErrorMessage(error: unknown): string {
   return "오류가 발생했습니다. 다시 시도해주세요.";
 }
 
+const MAX_WEEKS = 8;
+
 function getTomorrowDateValue() {
   return new Date(Date.now() + 86400000).toISOString().split("T")[0];
+}
+
+function getMaxDateValue() {
+  return new Date(Date.now() + MAX_WEEKS * 7 * 86400000).toISOString().split("T")[0];
 }
 
 type Props = {
@@ -67,6 +73,10 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
     }
     if (new Date(targetDate) <= new Date()) {
       setState({ status: "error", message: "목표 날짜는 오늘 이후여야 합니다." });
+      return;
+    }
+    if (new Date(targetDate) > new Date(getMaxDateValue())) {
+      setState({ status: "error", message: `목표 날짜는 최대 ${MAX_WEEKS}주 이내여야 합니다.` });
       return;
     }
 
@@ -124,11 +134,12 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
         </div>
 
         <div>
-          <label htmlFor="targetDate">목표 날짜</label>
+          <label htmlFor="targetDate">목표 날짜 (최대 {MAX_WEEKS}주)</label>
           <input
             id="targetDate"
             type="date"
             ref={targetDateInputRef}
+            max={getMaxDateValue()}
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
             disabled={isSubmitting}

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -31,6 +31,15 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
   const [savingWeekId, setSavingWeekId] = useState<string | null>(null);
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
 
+  if (roadmapId === "demo") {
+    return (
+      <StatePanel
+        tone="neutral"
+        message="이 페이지는 아직 구현 중입니다. 진단 생성 후 로드맵 생성 페이지(/roadmaps/new)를 이용해 주세요."
+      />
+    );
+  }
+
   useEffect(() => {
     let ignore = false;
 

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -31,16 +31,8 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
   const [savingWeekId, setSavingWeekId] = useState<string | null>(null);
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
 
-  if (roadmapId === "demo") {
-    return (
-      <StatePanel
-        tone="neutral"
-        message="이 페이지는 아직 구현 중입니다. 진단 생성 후 로드맵 생성 페이지(/roadmaps/new)를 이용해 주세요."
-      />
-    );
-  }
-
   useEffect(() => {
+    if (roadmapId === "demo") return;
     let ignore = false;
 
     async function loadRoadmap() {
@@ -134,6 +126,15 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
     } finally {
       setSavingWeekId(null);
     }
+  }
+
+  if (roadmapId === "demo") {
+    return (
+      <StatePanel
+        tone="neutral"
+        message="이 페이지는 아직 구현 중입니다. 진단 생성 후 로드맵 생성 페이지(/roadmaps/new)를 이용해 주세요."
+      />
+    );
   }
 
   if (state.status === "loading") {


### PR DESCRIPTION

   ## Summary

   2026-05-06 v1 full smoke 과정에서 발견한 버그 수정과 UX 개선을 포함한다.

   ### 백엔드 버그 수정
   - **GitHub listUserRepos 422**: `affiliation=owner`와 `type=all` 동시 전달 → `type` 제거
   - **github_projects upsert duplicate key**: HTTP timeout 후 재시도 시 unique constraint 위반 → `saveAndFlush` +
   `DataIntegrityViolationException` catch로 방어
   - **triage 실패 시 분석 중단**: 기여 커밋이 없는 repo에서 `LLM_TRIAGE_FAILED` 전파 → 해당 repo skip으로 변경
   - **synthesis LLM schema 불일치**: 프롬프트에 출력 필드명 명시 강화 (`techTags[].skillName`,
   `depthEstimates[].skillName/reason` 등)
   - **로드맵 생성 DB 커넥션 timeout**: `@Transactional` 안 LLM 호출로 커넥션 장시간 점유 → `TransactionTemplate`으로
    DB 조회/LLM 호출/DB 저장 분리
   - **AiGatewayLlmClient timeout 미적용**: `SimpleClientHttpRequestFactory`에 connect/read timeout 실제 적용,
   `max_tokens: 16384` 추가
   - **AiGatewayProperties timeout 필드 누락**: yml timeout 설정이 무시되던 문제 수정

   ### 프론트엔드 버그 수정
   - **highlights 렌더링 오류**: `{text, status}` 객체를 string으로 렌더링하던 문제 → `highlight.text` 사용
   - **profile targetRole placeholder**: `BACKEND_ENGINEER` → `BACKEND_DEVELOPER` (DB seed 값과 일치)
   - **로드맵 최대 8주 제한**: date picker `max` 속성 + `handleSubmit` 이중 검증

   ### UX 개선
   - GitHub 콜백 대기 메시지에 소요 시간 안내 추가
   - 분석 실패 후 `/github` 복귀 시 저장소 선택 상태 localStorage 유지
   - 상단 네비게이션에 로그인 버튼 추가
   - `/diagnoses/demo`, `/roadmaps/demo` 미구현 안내 문구 추가

   ### 기타
   - `COMMIT_LIMIT` 20 → 5 축소 (smoke 목적 임시, 근본 수정은 #182)
   - `.env.example` `AI_GATEWAY_BASE_URL` `/v1` 이중 경로 수정
   - `application-local.yml` smoke 전용 JWT TTL / LLM timeout 설정
   - v1 smoke 디버그 세션 기록 및 TODO 문서화

   ## 관련 이슈
      #182 `COMMIT_LIMIT` 임시 축소 (연결 단계 전체 저장소 메타데이터 수집 제거는 별도)
   - #183 synthesis/triage schema 수정 완료, 회귀 방지 테스트는 별도
   - #184 `targetRole` placeholder 수정 완료, select 드롭다운 전환은 별도
   - #185 로드맵 최대 8주 제한 추가, 프론트/백엔드 상수 동기화는 별도
   - #143 smoke에서 GitHub OAuth 로그인 정상 확인

   ## Test plan

   - [ ] 백엔드 실행, `/actuator/health` UP 확인
   - [ ] 프론트 실행 후 GitHub OAuth 로그인
   - [ ] 프로필 저장 (`BACKEND_DEVELOPER`)
   - [ ] GitHub 저장소 연결 → 저장소 목록 조회
   - [ ] 분석 실행 → `/github/analysis` 결과 확인
   - [ ] 진단 생성 → `/diagnoses/{id}` 결과 확인
   - [ ] 로드맵 생성 → `/roadmaps/{id}` 결과 확인
   - [ ] 진도 저장 → 대시보드 snapshot 반영 확인
   - [ ] `/diagnoses/demo`, `/roadmaps/demo` 안내 문구 표시 확인