### PR TITLE
test(validation): enum 입력 검증 회귀 테스트 추가

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapProgressControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapProgressControllerTest.java
@@ -112,6 +112,21 @@ class RoadmapProgressControllerTest {
     }
 
     @Test
+    void appendProgress_whenStatusUnsupported_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "roadmapWeekId", 100L,
+                                "status", "BLOCKED"
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(roadmapProgressCommandService);
+    }
+
+    @Test
     void appendProgress_whenNoteIsTooLong_returnsInvalidInput() throws Exception {
         mockMvc.perform(post("/api/roadmaps/{roadmapId}/progress", 10L)
                         .principal(authentication(1L))

--- a/backend/src/test/java/com/back/coach/domain/user/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/user/controller/ProfileControllerTest.java
@@ -161,6 +161,51 @@ class ProfileControllerTest {
     }
 
     @Test
+    void saveProfile_whenCurrentLevelUnsupported_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetRole": "BACKEND_ENGINEER",
+                                  "currentLevel": "SENIOR",
+                                  "skills": [
+                                    {
+                                      "skillName": "Spring Boot"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(profileService);
+    }
+
+    @Test
+    void saveProfile_whenSkillProficiencyUnsupported_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/profiles")
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "targetRole": "BACKEND_ENGINEER",
+                                  "currentLevel": "JUNIOR",
+                                  "skills": [
+                                    {
+                                      "skillName": "Spring Boot",
+                                      "proficiencyLevel": "EXPERT"
+                                    }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(profileService);
+    }
+
+    @Test
     void saveProfile_whenSkillsEmpty_returnsInvalidInput() throws Exception {
         mockMvc.perform(post("/api/profiles")
                         .principal(authentication(1L))


### PR DESCRIPTION
## 변경 사항
- `ProfileControllerTest`에 unsupported `currentLevel`, `skills[].proficiencyLevel` 요청 검증을 추가했다.
- `RoadmapProgressControllerTest`에 unsupported `status` 요청 검증을 추가했다.

## 필요한 이유
- 문서화된 enum 계약과 실제 API 검증 동작이 어긋나는 회귀를 막기 위해 필요하다.

## 검증 결과
- `git diff --check`
- `cd backend && .\gradlew.bat test --tests *ProfileControllerTest --tests *RoadmapProgressControllerTest --tests *CodeEnumsTest`

Closes #186