### PR TITLE
chore(config): smoke 전용 JWT TTL override 제거 (#192)

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -15,14 +15,10 @@ spring:
       hibernate:
         format_sql: true
 
-security:
-  jwt:
-    access-ttl-seconds: 86400  # smoke 전용 24시간 — 프로덕션 복원 필요 (기본값 900)
-
 ai:
   gateway:
     timeout:
-      read: 300s  # smoke 전용 5분 — 프로덕션 복원 필요 (기본값 120s)
+      read: 300s  # 로컬 LLM 응답 지연 대비 길게 유지
 
 logging:
   level:


### PR DESCRIPTION
Closes #192

## Summary
- application-local.yml에서 `security.jwt.access-ttl-seconds: 86400` 블록 제거 → application.yml 기본값 900s 적용
- AI gateway read timeout(300s)은 로컬 LLM 응답 지연 대비 유지, 주석에서 'smoke 전용 — 복원 필요' 표현 제거 (굳이 더 짧은시간 유지할 필요없음
## Test plan
- [ ] 로컬에서 백엔드 실행
- [ ] 로그인 후 access token TTL 15분 적용 확인 (브라우저 쿠키 만료 시각 또는 /actuator/info 확인)

