### PR TITLE
feat(api): GET /api/job-roles 활성 직무 목록 endpoint추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/jobrole/controller/JobRoleController.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/controller/JobRoleController.java
@@ -1,0 +1,27 @@
+package com.back.coach.domain.jobrole.controller;
+
+import com.back.coach.domain.jobrole.dto.JobRoleResponse;
+import com.back.coach.domain.jobrole.service.JobRoleService;
+import com.back.coach.global.response.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/api/job-roles", produces = MediaType.APPLICATION_JSON_VALUE)
+public class JobRoleController {
+
+    private final JobRoleService jobRoleService;
+
+    public JobRoleController(JobRoleService jobRoleService) {
+        this.jobRoleService = jobRoleService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<JobRoleResponse>> listJobRoles() {
+        return ApiResponse.success(jobRoleService.listActive());
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/dto/JobRoleResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/dto/JobRoleResponse.java
@@ -1,0 +1,17 @@
+package com.back.coach.domain.jobrole.dto;
+
+import com.back.coach.domain.jobrole.entity.JobRole;
+
+public record JobRoleResponse(
+        String roleCode,
+        String roleName,
+        String description
+) {
+    public static JobRoleResponse from(JobRole jobRole) {
+        return new JobRoleResponse(
+                jobRole.getRoleCode(),
+                jobRole.getRoleName(),
+                jobRole.getDescription()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/repository/JobRoleRepository.java
@@ -3,9 +3,12 @@ package com.back.coach.domain.jobrole.repository;
 import com.back.coach.domain.jobrole.entity.JobRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JobRoleRepository extends JpaRepository<JobRole, Long> {
 
     Optional<JobRole> findByRoleCodeAndActiveTrue(String roleCode);
+
+    List<JobRole> findAllByActiveTrueOrderByRoleNameAsc();
 }

--- a/backend/src/main/java/com/back/coach/domain/jobrole/service/JobRoleService.java
+++ b/backend/src/main/java/com/back/coach/domain/jobrole/service/JobRoleService.java
@@ -1,0 +1,25 @@
+package com.back.coach.domain.jobrole.service;
+
+import com.back.coach.domain.jobrole.dto.JobRoleResponse;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class JobRoleService {
+
+    private final JobRoleRepository jobRoleRepository;
+
+    public JobRoleService(JobRoleRepository jobRoleRepository) {
+        this.jobRoleRepository = jobRoleRepository;
+    }
+
+    public List<JobRoleResponse> listActive() {
+        return jobRoleRepository.findAllByActiveTrueOrderByRoleNameAsc().stream()
+                .map(JobRoleResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/jobrole/controller/JobRoleControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/jobrole/controller/JobRoleControllerTest.java
@@ -1,0 +1,65 @@
+package com.back.coach.domain.jobrole.controller;
+
+import com.back.coach.domain.jobrole.dto.JobRoleResponse;
+import com.back.coach.domain.jobrole.service.JobRoleService;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class JobRoleControllerTest {
+
+    @Mock
+    private JobRoleService jobRoleService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new JobRoleController(jobRoleService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void listJobRoles_returnsActiveRoles() throws Exception {
+        given(jobRoleService.listActive()).willReturn(List.of(
+                new JobRoleResponse("BACKEND_DEVELOPER", "백엔드 개발자", "서버 사이드 개발"),
+                new JobRoleResponse("FRONTEND_DEVELOPER", "프론트엔드 개발자", "웹 UI 개발")
+        ));
+
+        mockMvc.perform(get("/api/job-roles").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].roleCode").value("BACKEND_DEVELOPER"))
+                .andExpect(jsonPath("$.data[0].roleName").value("백엔드 개발자"))
+                .andExpect(jsonPath("$.data[0].description").value("서버 사이드 개발"))
+                .andExpect(jsonPath("$.data[1].roleCode").value("FRONTEND_DEVELOPER"))
+                .andExpect(jsonPath("$.meta").isMap());
+    }
+
+    @Test
+    void listJobRoles_whenEmpty_returnsEmptyArray() throws Exception {
+        given(jobRoleService.listActive()).willReturn(List.of());
+
+        mockMvc.perform(get("/api/job-roles").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+}


### PR DESCRIPTION
## 연관 이슈

  Closes #193

## 변경 요약
  - `GET /api/job-roles` 엔드포인트 — `JobRole.active=true`인 row를 `role_name` 알파벳순ㅇ으로 반환
  - 응답: `ApiResponse<List<JobRoleResponse>>` (`roleCode`, `roleName`, `description`)
  - 인증 필수 (`/api/**` 기존 보안 정책 적용)
  - 프로필 입력 select dropdown(#194)에서 사용 예정
## 테스트
  - [x] `JobRoleControllerTest` (standalone MockMvc) 2케이스 GREEN


