### PR TITLE
test(context): v2 저장 테이블 계약 검증 추가

### DIFF
--- a/backend/src/test/java/com/back/coach/global/jpa/DbContractIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/global/jpa/DbContractIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +42,21 @@ class DbContractIntegrationTest {
             "agent_events"
     );
 
+    private static final Map<String, Set<String>> V5_REQUIRED_COLUMNS = Map.of(
+            "user_context_snapshots",
+            Set.of("user_id", "context_type", "version", "payload", "valid_from", "valid_to", "created_at"),
+            "chat_sessions",
+            Set.of("user_id", "profile_version", "roadmap_version", "status", "started_at", "ended_at"),
+            "coach_conversations",
+            Set.of("session_id", "user_id", "role", "message_text", "route", "detected_intent", "created_at"),
+            "replan_proposals",
+            Set.of("session_id", "user_id", "message_id", "reason", "status", "expires_at", "resolved_at", "created_at"),
+            "detected_patterns",
+            Set.of("user_id", "pattern_type", "severity", "metadata", "processed_at", "created_at"),
+            "agent_events",
+            Set.of("user_id", "session_id", "source_agent", "target_agent", "event_type", "event_data", "processed_at", "created_at")
+    );
+
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
@@ -61,6 +77,16 @@ class DbContractIntegrationTest {
             assertThat(tableExists(table))
                     .as("table %s should exist", table)
                     .isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("Flyway v5 migration이 v2 저장 테이블의 핵심 컬럼을 생성한다")
+    void flywayCreatesV5TableColumns() {
+        for (Map.Entry<String, Set<String>> entry : V5_REQUIRED_COLUMNS.entrySet()) {
+            assertThat(columns(entry.getKey()))
+                    .as("table %s should contain required columns", entry.getKey())
+                    .containsAll(entry.getValue());
         }
     }
 


### PR DESCRIPTION
## 변경 요약
- V5 v2 저장 테이블별 핵심 컬럼 계약을 `DbContractIntegrationTest`에 추가했습니다.
- 기존 테이블 생성 여부 검증에 더해 `user_context_snapshots`, `chat_sessions`, `coach_conversations`, `replan_proposals`, `detected_patterns`, `agent_events`의 필수 컬럼을 확인합니다.

## 왜 필요한가
- v2 Context/Coach/Pattern 구현 전에 저장 원본 테이블이 이름뿐 아니라 필요한 컬럼까지 안정적으로 생성되는지 고정하기 위해 필요합니다.

## 검증
- `git diff --check`
- `cd backend && .\gradlew.bat testClasses`
- `cd backend && .\gradlew.bat integrationTest --tests "*DbContractIntegrationTest"`

Closes #199