### PR TITLE
feat(context): Context Snapshot 저장 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/context/entity/UserContextSnapshot.java
+++ b/backend/src/main/java/com/back/coach/domain/context/entity/UserContextSnapshot.java
@@ -1,0 +1,71 @@
+package com.back.coach.domain.context.entity;
+
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "user_context_snapshots")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserContextSnapshot extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "context_type", nullable = false, length = 30)
+    private ContextType contextType;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", nullable = false, columnDefinition = "jsonb")
+    private String payload;
+
+    @Column(name = "valid_from", nullable = false)
+    private Instant validFrom;
+
+    @Column(name = "valid_to")
+    private Instant validTo;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static UserContextSnapshot create(
+            Long userId,
+            ContextType contextType,
+            Integer version,
+            String payload,
+            Instant validFrom
+    ) {
+        UserContextSnapshot snapshot = new UserContextSnapshot();
+        snapshot.userId = userId;
+        snapshot.contextType = contextType;
+        snapshot.version = version;
+        snapshot.payload = payload;
+        snapshot.validFrom = validFrom;
+        return snapshot;
+    }
+
+    public void close(Instant validTo) {
+        this.validTo = validTo;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/context/repository/UserContextSnapshotRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/context/repository/UserContextSnapshotRepository.java
@@ -1,0 +1,41 @@
+package com.back.coach.domain.context.repository;
+
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.global.code.ContextType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserContextSnapshotRepository extends JpaRepository<UserContextSnapshot, Long> {
+
+    Optional<UserContextSnapshot> findTopByUserIdAndContextTypeAndValidToIsNullOrderByVersionDesc(
+            Long userId,
+            ContextType contextType
+    );
+
+    Optional<UserContextSnapshot> findTopByUserIdAndContextTypeOrderByVersionDescCreatedAtDesc(
+            Long userId,
+            ContextType contextType
+    );
+
+    default Optional<UserContextSnapshot> findActiveByUserIdAndContextType(Long userId, ContextType contextType) {
+        return findTopByUserIdAndContextTypeAndValidToIsNullOrderByVersionDesc(userId, contextType);
+    }
+
+    default Optional<UserContextSnapshot> findLatestByUserIdAndContextType(Long userId, ContextType contextType) {
+        return findTopByUserIdAndContextTypeOrderByVersionDescCreatedAtDesc(userId, contextType);
+    }
+
+    @Query("""
+            select max(s.version)
+            from UserContextSnapshot s
+            where s.userId = :userId
+              and s.contextType = :contextType
+            """)
+    Integer findMaxVersionByUserIdAndContextType(
+            @Param("userId") Long userId,
+            @Param("contextType") ContextType contextType
+    );
+}

--- a/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotStorageService.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotStorageService.java
@@ -1,0 +1,89 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContextSnapshotStorageService {
+
+    private final UserContextSnapshotRepository userContextSnapshotRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public UserContextSnapshot createSnapshot(Long userId, ContextType contextType, String payload) {
+        validateRequest(userId, contextType, payload);
+
+        Instant now = Instant.now();
+        userContextSnapshotRepository.findActiveByUserIdAndContextType(userId, contextType)
+                .ifPresent(activeSnapshot -> activeSnapshot.close(now));
+
+        int nextVersion = nextVersion(
+                userContextSnapshotRepository.findMaxVersionByUserIdAndContextType(userId, contextType)
+        );
+        UserContextSnapshot snapshot = UserContextSnapshot.create(userId, contextType, nextVersion, payload, now);
+        return userContextSnapshotRepository.save(snapshot);
+    }
+
+    public Optional<UserContextSnapshot> findActiveSnapshot(Long userId, ContextType contextType) {
+        return userContextSnapshotRepository.findActiveByUserIdAndContextType(userId, contextType);
+    }
+
+    public Optional<UserContextSnapshot> findLatestSnapshot(Long userId, ContextType contextType) {
+        return userContextSnapshotRepository.findLatestByUserIdAndContextType(userId, contextType);
+    }
+
+    private int nextVersion(Integer currentMaxVersion) {
+        if (currentMaxVersion == null) {
+            return 1;
+        }
+        return currentMaxVersion + 1;
+    }
+
+    private void validateRequest(Long userId, ContextType contextType, String payload) {
+        if (userId == null || userId < 1) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "userId는 양수여야 합니다.");
+        }
+        if (contextType == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "contextType은 필수입니다.");
+        }
+        if (payload == null || payload.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "payload는 필수입니다.");
+        }
+        validatePayload(contextType, payload);
+    }
+
+    private void validatePayload(ContextType contextType, String payload) {
+        JsonNode root = readPayload(payload);
+        if (!root.isObject()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "Context Snapshot payload는 JSON object여야 합니다.");
+        }
+        if (!contextType.code().equals(root.path("contextType").asText(null))) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "payload.contextType이 contextType과 일치해야 합니다.");
+        }
+        if (!root.path("sourceRefs").isObject()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "payload.sourceRefs는 필수 object입니다.");
+        }
+    }
+
+    private JsonNode readPayload(String payload) {
+        try {
+            return objectMapper.readTree(payload);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "payload는 유효한 JSON이어야 합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/ContextType.java
+++ b/backend/src/main/java/com/back/coach/global/code/ContextType.java
@@ -1,0 +1,12 @@
+package com.back.coach.global.code;
+
+public enum ContextType implements CodeEnum {
+    PROFILE,
+    PLAN,
+    CONVERSATION;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotStorageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotStorageServiceIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.support.IntegrationTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class ContextSnapshotStorageServiceIntegrationTest {
+
+    @Autowired
+    private ContextSnapshotStorageService contextSnapshotStorageService;
+
+    @Autowired
+    private UserContextSnapshotRepository userContextSnapshotRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Context Snapshot은 context_type별 active/latest 기준으로 조회된다")
+    void contextSnapshotActiveAndLatestAreScopedByContextType() {
+        Long userId = createUser();
+
+        UserContextSnapshot profileV1 = contextSnapshotStorageService.createSnapshot(
+                userId,
+                ContextType.PROFILE,
+                payload(ContextType.PROFILE, """
+                        {
+                          "profileId": "1",
+                          "diagnosisVersion": 1
+                        }
+                        """)
+        );
+        UserContextSnapshot planV1 = contextSnapshotStorageService.createSnapshot(
+                userId,
+                ContextType.PLAN,
+                payload(ContextType.PLAN, """
+                        {
+                          "roadmapId": "7",
+                          "roadmapVersion": 1
+                        }
+                        """)
+        );
+        UserContextSnapshot profileV2 = contextSnapshotStorageService.createSnapshot(
+                userId,
+                ContextType.PROFILE,
+                payload(ContextType.PROFILE, """
+                        {
+                          "profileId": "2",
+                          "diagnosisVersion": 2
+                        }
+                        """)
+        );
+
+        assertThat(contextSnapshotStorageService.findActiveSnapshot(userId, ContextType.PROFILE))
+                .hasValueSatisfying(snapshot -> {
+                    assertThat(snapshot.getId()).isEqualTo(profileV2.getId());
+                    assertThat(snapshot.getVersion()).isEqualTo(2);
+                    assertThat(snapshot.getValidTo()).isNull();
+                });
+        assertThat(contextSnapshotStorageService.findLatestSnapshot(userId, ContextType.PROFILE))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.getId()).isEqualTo(profileV2.getId()));
+        assertThat(contextSnapshotStorageService.findActiveSnapshot(userId, ContextType.PLAN))
+                .hasValueSatisfying(snapshot -> {
+                    assertThat(snapshot.getId()).isEqualTo(planV1.getId());
+                    assertThat(snapshot.getVersion()).isEqualTo(1);
+                    assertThat(snapshot.getValidTo()).isNull();
+                });
+
+        UserContextSnapshot closedProfile = userContextSnapshotRepository.findById(profileV1.getId()).orElseThrow();
+        assertThat(closedProfile.getValidTo()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Context Snapshot payload는 v1 원본 참조를 sourceRefs에 보존한다")
+    void contextSnapshotPayloadPreservesSourceRefs() throws Exception {
+        Long userId = createUser();
+
+        UserContextSnapshot saved = contextSnapshotStorageService.createSnapshot(
+                userId,
+                ContextType.PROFILE,
+                payload(ContextType.PROFILE, """
+                        {
+                          "profileId": "10",
+                          "githubAnalysisId": "20",
+                          "githubAnalysisVersion": 3,
+                          "diagnosisId": "30",
+                          "diagnosisVersion": 4
+                        }
+                        """)
+        );
+
+        UserContextSnapshot reloaded = userContextSnapshotRepository.findById(saved.getId()).orElseThrow();
+
+        assertThat(objectMapper.readTree(reloaded.getPayload()).path("sourceRefs").path("profileId").asText())
+                .isEqualTo("10");
+        assertThat(objectMapper.readTree(reloaded.getPayload()).path("sourceRefs").path("githubAnalysisVersion").asInt())
+                .isEqualTo(3);
+        assertThat(objectMapper.readTree(reloaded.getPayload()).path("sourceRefs").path("diagnosisVersion").asInt())
+                .isEqualTo(4);
+    }
+
+    private Long createUser() {
+        String key = UUID.randomUUID().toString();
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "context-" + key, "context-" + key + "@example.com")
+        );
+        return user.getId();
+    }
+
+    private String payload(ContextType contextType, String sourceRefs) {
+        return """
+                {
+                  "contextType": "%s",
+                  "generatedAt": "2026-05-07T00:00:00Z",
+                  "sourceRefs": %s
+                }
+                """.formatted(contextType.code(), sourceRefs);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotStorageServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotStorageServiceTest.java
@@ -1,0 +1,131 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class ContextSnapshotStorageServiceTest {
+
+    @Mock
+    private UserContextSnapshotRepository userContextSnapshotRepository;
+
+    private ContextSnapshotStorageService contextSnapshotStorageService;
+
+    @BeforeEach
+    void setUp() {
+        contextSnapshotStorageService = new ContextSnapshotStorageService(
+                userContextSnapshotRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void createSnapshot_whenNoPreviousSnapshot_startsWithVersionOne() {
+        given(userContextSnapshotRepository.findActiveByUserIdAndContextType(1L, ContextType.PROFILE))
+                .willReturn(Optional.empty());
+        given(userContextSnapshotRepository.findMaxVersionByUserIdAndContextType(1L, ContextType.PROFILE))
+                .willReturn(null);
+        given(userContextSnapshotRepository.save(any(UserContextSnapshot.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        UserContextSnapshot snapshot = contextSnapshotStorageService.createSnapshot(
+                1L,
+                ContextType.PROFILE,
+                payload(ContextType.PROFILE)
+        );
+
+        assertThat(snapshot.getUserId()).isEqualTo(1L);
+        assertThat(snapshot.getContextType()).isEqualTo(ContextType.PROFILE);
+        assertThat(snapshot.getVersion()).isEqualTo(1);
+        assertThat(snapshot.getValidFrom()).isNotNull();
+        assertThat(snapshot.getValidTo()).isNull();
+    }
+
+    @Test
+    void createSnapshot_whenActiveSnapshotExists_closesPreviousAndCreatesNextVersion() {
+        UserContextSnapshot activeSnapshot = UserContextSnapshot.create(
+                1L,
+                ContextType.PROFILE,
+                1,
+                payload(ContextType.PROFILE),
+                Instant.parse("2026-05-06T00:00:00Z")
+        );
+        given(userContextSnapshotRepository.findActiveByUserIdAndContextType(1L, ContextType.PROFILE))
+                .willReturn(Optional.of(activeSnapshot));
+        given(userContextSnapshotRepository.findMaxVersionByUserIdAndContextType(1L, ContextType.PROFILE))
+                .willReturn(1);
+        given(userContextSnapshotRepository.save(any(UserContextSnapshot.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        UserContextSnapshot snapshot = contextSnapshotStorageService.createSnapshot(
+                1L,
+                ContextType.PROFILE,
+                payload(ContextType.PROFILE)
+        );
+
+        assertThat(snapshot.getVersion()).isEqualTo(2);
+        assertThat(snapshot.getValidTo()).isNull();
+        assertThat(activeSnapshot.getValidTo()).isEqualTo(snapshot.getValidFrom());
+    }
+
+    @Test
+    void createSnapshot_whenPayloadContextTypeMismatch_throwsInvalidInput() {
+        assertThatThrownBy(() -> contextSnapshotStorageService.createSnapshot(
+                1L,
+                ContextType.PROFILE,
+                payload(ContextType.PLAN)
+        )).isInstanceOfSatisfying(ServiceException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+
+        then(userContextSnapshotRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void createSnapshot_whenPayloadSourceRefsMissing_throwsInvalidInput() {
+        String payload = """
+                {
+                  "contextType": "PROFILE",
+                  "generatedAt": "2026-05-07T00:00:00Z"
+                }
+                """;
+
+        assertThatThrownBy(() -> contextSnapshotStorageService.createSnapshot(
+                1L,
+                ContextType.PROFILE,
+                payload
+        )).isInstanceOfSatisfying(ServiceException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+
+        then(userContextSnapshotRepository).shouldHaveNoInteractions();
+    }
+
+    private String payload(ContextType contextType) {
+        return """
+                {
+                  "contextType": "%s",
+                  "generatedAt": "2026-05-07T00:00:00Z",
+                  "sourceRefs": {
+                    "profileId": "1"
+                  }
+                }
+                """.formatted(contextType.code());
+    }
+}


### PR DESCRIPTION
﻿## 변경 요약
- `ContextType` enum과 `user_context_snapshots` Entity/Repository를 추가했습니다.
- Context Snapshot 저장 시 context_type별 version 증가와 기존 active row 종료 규칙을 구현했습니다.
- payload의 `contextType` 일치와 `sourceRefs` 존재를 검증했습니다.

## 왜 필요한가
- Coach/Analyzer/Planner가 v1 원본을 매번 직접 해석하지 않고 같은 snapshot 기준을 읽게 하기 위한 저장 기반입니다.
- 예를 들어 Coach 세션이 `PROFILE` v3, `PLAN` v2를 기준으로 시작하면 대화 중 최신 원본이 바뀌어도 응답 기준이 흔들리지 않습니다.

## 검증
- `cd backend && .\gradlew.bat test --tests "*ContextSnapshot*"`
- `cd backend && .\gradlew.bat integrationTest --tests "*ContextSnapshot*"`
- `git diff --check`

Closes #200
