### PR TITLE
feat(pattern): detected_patterns 저장 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/pattern/entity/DetectedPattern.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/entity/DetectedPattern.java
@@ -1,0 +1,71 @@
+package com.back.coach.domain.pattern.entity;
+
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "detected_patterns")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DetectedPattern extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pattern_type", nullable = false, length = 50)
+    private PatternType patternType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false, length = 20)
+    private PatternSeverity severity;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata", nullable = false, columnDefinition = "jsonb")
+    private String metadata;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static DetectedPattern create(
+            Long userId,
+            PatternType patternType,
+            PatternSeverity severity,
+            String metadata
+    ) {
+        DetectedPattern pattern = new DetectedPattern();
+        pattern.userId = userId;
+        pattern.patternType = patternType;
+        pattern.severity = severity;
+        pattern.metadata = metadata;
+        return pattern;
+    }
+
+    public void markProcessed(Instant processedAt) {
+        if (this.processedAt != null) {
+            return;
+        }
+        this.processedAt = processedAt;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
@@ -1,0 +1,18 @@
+package com.back.coach.domain.pattern.repository;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DetectedPatternRepository extends JpaRepository<DetectedPattern, Long> {
+
+    List<DetectedPattern> findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(Long userId);
+
+    default List<DetectedPattern> findUnprocessedByUserId(Long userId) {
+        return findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(userId);
+    }
+
+    Optional<DetectedPattern> findByIdAndUserId(Long id, Long userId);
+}

--- a/backend/src/main/java/com/back/coach/domain/pattern/service/DetectedPatternStorageService.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/service/DetectedPatternStorageService.java
@@ -1,0 +1,97 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DetectedPatternStorageService {
+
+    private final DetectedPatternRepository detectedPatternRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public DetectedPattern createPattern(
+            Long userId,
+            PatternType patternType,
+            PatternSeverity severity,
+            String metadata
+    ) {
+        validateCreateRequest(userId, patternType, severity, metadata);
+
+        DetectedPattern pattern = DetectedPattern.create(userId, patternType, severity, metadata);
+        return detectedPatternRepository.save(pattern);
+    }
+
+    public List<DetectedPattern> findUnprocessedPatterns(Long userId) {
+        validateUserId(userId);
+        return detectedPatternRepository.findUnprocessedByUserId(userId);
+    }
+
+    @Transactional
+    public DetectedPattern markProcessed(Long userId, Long patternId) {
+        validateUserId(userId);
+        if (patternId == null || patternId < 1) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "patternId는 양수여야 합니다.");
+        }
+
+        DetectedPattern pattern = detectedPatternRepository.findByIdAndUserId(patternId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND, "감지 패턴을 찾을 수 없습니다."));
+        pattern.markProcessed(Instant.now());
+        return pattern;
+    }
+
+    private void validateCreateRequest(
+            Long userId,
+            PatternType patternType,
+            PatternSeverity severity,
+            String metadata
+    ) {
+        validateUserId(userId);
+        if (patternType == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "patternType은 필수입니다.");
+        }
+        if (severity == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "severity는 필수입니다.");
+        }
+        if (metadata == null || metadata.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 필수입니다.");
+        }
+        validateMetadata(metadata);
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null || userId < 1) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "userId는 양수여야 합니다.");
+        }
+    }
+
+    private void validateMetadata(String metadata) {
+        JsonNode root = readMetadata(metadata);
+        if (!root.isObject()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 JSON object여야 합니다.");
+        }
+    }
+
+    private JsonNode readMetadata(String metadata) {
+        try {
+            return objectMapper.readTree(metadata);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 유효한 JSON이어야 합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/PatternSeverity.java
+++ b/backend/src/main/java/com/back/coach/global/code/PatternSeverity.java
@@ -1,0 +1,12 @@
+package com.back.coach.global.code;
+
+public enum PatternSeverity implements CodeEnum {
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/PatternType.java
+++ b/backend/src/main/java/com/back/coach/global/code/PatternType.java
@@ -1,0 +1,13 @@
+package com.back.coach.global.code;
+
+public enum PatternType implements CodeEnum {
+    REPEATED_INCOMPLETE,
+    CONSECUTIVE_DELAY,
+    SKILL_REPEATED_FAILURE,
+    GOAL_DRIFT_CANDIDATE;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.support.IntegrationTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class DetectedPatternStorageServiceIntegrationTest {
+
+    @Autowired
+    private DetectedPatternStorageService detectedPatternStorageService;
+
+    @Autowired
+    private DetectedPatternRepository detectedPatternRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("detected_patterns에 패턴을 저장하고 metadata를 보존한다")
+    void createPatternPersistsMetadata() throws Exception {
+        Long userId = createUser();
+
+        DetectedPattern saved = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+
+        DetectedPattern reloaded = detectedPatternRepository.findById(saved.getId()).orElseThrow();
+
+        assertThat(reloaded.getUserId()).isEqualTo(userId);
+        assertThat(reloaded.getPatternType()).isEqualTo(PatternType.REPEATED_INCOMPLETE);
+        assertThat(reloaded.getSeverity()).isEqualTo(PatternSeverity.MEDIUM);
+        assertThat(reloaded.getProcessedAt()).isNull();
+        assertThat(reloaded.getCreatedAt()).isNotNull();
+        assertThat(objectMapper.readTree(reloaded.getMetadata()).path("targetId").asInt()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("미처리 패턴은 사용자별로 최신 생성 순서로 조회한다")
+    void findUnprocessedPatternsFiltersByUserAndProcessedAt() {
+        Long userId = createUser();
+        Long otherUserId = createUser();
+        Long olderId = insertPattern(userId, null, "2026-05-07T00:00:00Z", 1);
+        Long processedId = insertPattern(userId, "2026-05-07T00:20:00Z", "2026-05-07T00:10:00Z", 2);
+        Long newerId = insertPattern(userId, null, "2026-05-07T00:30:00Z", 3);
+        Long otherUserPatternId = insertPattern(otherUserId, null, "2026-05-07T00:40:00Z", 4);
+
+        List<DetectedPattern> patterns = detectedPatternStorageService.findUnprocessedPatterns(userId);
+
+        assertThat(patterns)
+                .extracting(DetectedPattern::getId)
+                .containsExactly(newerId, olderId);
+        assertThat(List.of(processedId, otherUserPatternId)).doesNotContainNull();
+    }
+
+    @Test
+    @DisplayName("처리 완료 마킹 후 미처리 목록에서 제외된다")
+    void markProcessedRemovesPatternFromUnprocessedCandidates() {
+        Long userId = createUser();
+        DetectedPattern saved = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.CONSECUTIVE_DELAY,
+                PatternSeverity.HIGH,
+                metadata(21)
+        );
+
+        DetectedPattern processed = detectedPatternStorageService.markProcessed(userId, saved.getId());
+
+        assertThat(processed.getProcessedAt()).isNotNull();
+        assertThat(detectedPatternRepository.findById(saved.getId()).orElseThrow().getProcessedAt()).isNotNull();
+        assertThat(detectedPatternStorageService.findUnprocessedPatterns(userId)).isEmpty();
+    }
+
+    private Long createUser() {
+        String key = UUID.randomUUID().toString();
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "pattern-" + key, "pattern-" + key + "@example.com")
+        );
+        return user.getId();
+    }
+
+    private Long insertPattern(Long userId, String processedAt, String createdAt, int targetId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO detected_patterns (
+                    user_id, pattern_type, severity, metadata, processed_at, created_at
+                )
+                VALUES (?, 'REPEATED_INCOMPLETE', 'MEDIUM', ?::jsonb, ?::timestamptz, ?::timestamptz)
+                RETURNING id
+                """, Long.class, userId, metadata(targetId), processedAt, createdAt);
+    }
+
+    private String metadata(int targetId) {
+        return """
+                {
+                  "count": 3,
+                  "windowDays": 7,
+                  "targetType": "roadmap_week",
+                  "targetId": %d
+                }
+                """.formatted(targetId);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceTest.java
@@ -1,0 +1,115 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class DetectedPatternStorageServiceTest {
+
+    @Mock
+    private DetectedPatternRepository detectedPatternRepository;
+
+    private DetectedPatternStorageService detectedPatternStorageService;
+
+    @BeforeEach
+    void setUp() {
+        detectedPatternStorageService = new DetectedPatternStorageService(
+                detectedPatternRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void createPattern_persistsPatternFieldsAndMetadata() {
+        given(detectedPatternRepository.save(any(DetectedPattern.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        DetectedPattern pattern = detectedPatternStorageService.createPattern(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata()
+        );
+
+        assertThat(pattern.getUserId()).isEqualTo(1L);
+        assertThat(pattern.getPatternType()).isEqualTo(PatternType.REPEATED_INCOMPLETE);
+        assertThat(pattern.getSeverity()).isEqualTo(PatternSeverity.MEDIUM);
+        assertThat(pattern.getMetadata()).contains("\"targetType\": \"roadmap_week\"");
+        assertThat(pattern.getProcessedAt()).isNull();
+    }
+
+    @Test
+    void createPattern_whenMetadataIsNotJsonObject_throwsInvalidInput() {
+        assertThatThrownBy(() -> detectedPatternStorageService.createPattern(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                "[]"
+        )).isInstanceOfSatisfying(ServiceException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+
+        then(detectedPatternRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void markProcessed_setsProcessedAtWhenUnprocessed() {
+        DetectedPattern pattern = DetectedPattern.create(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata()
+        );
+        given(detectedPatternRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.of(pattern));
+
+        DetectedPattern processed = detectedPatternStorageService.markProcessed(1L, 10L);
+
+        assertThat(processed.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    void markProcessed_whenAlreadyProcessed_keepsOriginalProcessedAt() {
+        DetectedPattern pattern = DetectedPattern.create(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata()
+        );
+        Instant firstProcessedAt = Instant.parse("2026-05-07T00:00:00Z");
+        pattern.markProcessed(firstProcessedAt);
+        given(detectedPatternRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.of(pattern));
+
+        DetectedPattern processed = detectedPatternStorageService.markProcessed(1L, 10L);
+
+        assertThat(processed.getProcessedAt()).isEqualTo(firstProcessedAt);
+    }
+
+    private String metadata() {
+        return """
+                {
+                  "count": 3,
+                  "windowDays": 7,
+                  "targetType": "roadmap_week",
+                  "targetId": 12
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/code/CodeEnumsTest.java
+++ b/backend/src/test/java/com/back/coach/global/code/CodeEnumsTest.java
@@ -46,6 +46,10 @@ class CodeEnumsTest {
         assertCodes(MaterialType.class, "DOCS", "ARTICLE", "REPOSITORY", "VIDEO", "TEMPLATE");
         assertCodes(JobStatus.class, "REQUESTED", "RUNNING", "SUCCEEDED", "FAILED");
         assertCodes(HighlightStatus.class, "ADOPTED", "EVOLVED", "REVERSED");
+        assertCodes(ContextType.class, "PROFILE", "PLAN", "CONVERSATION");
+        assertCodes(PatternType.class, "REPEATED_INCOMPLETE", "CONSECUTIVE_DELAY",
+                "SKILL_REPEATED_FAILURE", "GOAL_DRIFT_CANDIDATE");
+        assertCodes(PatternSeverity.class, "LOW", "MEDIUM", "HIGH");
     }
 
     @SafeVarargs


### PR DESCRIPTION
﻿## 변경 요약
- `PatternType`, `PatternSeverity` enum을 추가했습니다.
- `detected_patterns` Entity/Repository/StorageService를 추가했습니다.
- 미처리 패턴 조회와 처리 완료 마킹 기반을 구현했습니다.
- metadata는 JSON object만 저장되도록 검증했습니다.

## 왜 필요한가
- Pattern Detector 감지 결과를 Coach 메시지에 바로 섞지 않고 원본 row로 남기기 위한 기반입니다.
- 예를 들어 최근 7일 Redis 과제 반복 미완료가 감지되면 `detected_patterns`에 저장하고, Context Manager가 미처리 row만 읽어 `activeSignals`로 요약할 수 있습니다.

## 검증
- `cd backend && .\gradlew.bat test --tests "*DetectedPattern*"`
- `cd backend && .\gradlew.bat integrationTest --tests "*DetectedPattern*"`
- `cd backend && .\gradlew.bat test --tests "*CodeEnumsTest"`
- `git diff --check`

Closes #201
