### PR TITLE
feat(pattern): Pattern Detector 중복 방지 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
@@ -2,6 +2,8 @@ package com.back.coach.domain.pattern.repository;
 
 import com.back.coach.domain.pattern.entity.DetectedPattern;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,23 @@ public interface DetectedPatternRepository extends JpaRepository<DetectedPattern
     }
 
     Optional<DetectedPattern> findByIdAndUserId(Long id, Long userId);
+
+    @Query(value = """
+            SELECT *
+            FROM detected_patterns
+            WHERE user_id = :userId
+              AND pattern_type = :patternType
+              AND metadata ->> 'targetType' = :targetType
+              AND metadata ->> 'targetId' = :targetId
+              AND metadata ->> 'windowDays' = :windowDays
+            ORDER BY created_at DESC
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<DetectedPattern> findDuplicateCandidate(
+            @Param("userId") Long userId,
+            @Param("patternType") String patternType,
+            @Param("targetType") String targetType,
+            @Param("targetId") String targetId,
+            @Param("windowDays") String windowDays
+    );
 }

--- a/backend/src/main/java/com/back/coach/domain/pattern/service/DetectedPatternStorageService.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/service/DetectedPatternStorageService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +32,18 @@ public class DetectedPatternStorageService {
             PatternSeverity severity,
             String metadata
     ) {
-        validateCreateRequest(userId, patternType, severity, metadata);
+        DuplicateKey duplicateKey = validateCreateRequest(userId, patternType, severity, metadata);
 
+        Optional<DetectedPattern> duplicate = detectedPatternRepository.findDuplicateCandidate(
+                userId,
+                patternType.code(),
+                duplicateKey.targetType(),
+                duplicateKey.targetId(),
+                duplicateKey.windowDays()
+        );
+        if (duplicate.isPresent()) {
+            return duplicate.get();
+        }
         DetectedPattern pattern = DetectedPattern.create(userId, patternType, severity, metadata);
         return detectedPatternRepository.save(pattern);
     }
@@ -55,7 +66,7 @@ public class DetectedPatternStorageService {
         return pattern;
     }
 
-    private void validateCreateRequest(
+    private DuplicateKey validateCreateRequest(
             Long userId,
             PatternType patternType,
             PatternSeverity severity,
@@ -71,7 +82,7 @@ public class DetectedPatternStorageService {
         if (metadata == null || metadata.isBlank()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 필수입니다.");
         }
-        validateMetadata(metadata);
+        return validateMetadata(metadata);
     }
 
     private void validateUserId(Long userId) {
@@ -80,11 +91,29 @@ public class DetectedPatternStorageService {
         }
     }
 
-    private void validateMetadata(String metadata) {
+    private DuplicateKey validateMetadata(String metadata) {
         JsonNode root = readMetadata(metadata);
         if (!root.isObject()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 JSON object여야 합니다.");
         }
+        return new DuplicateKey(
+                requiredMetadataValue(root, "targetType"),
+                requiredMetadataValue(root, "targetId"),
+                requiredMetadataValue(root, "windowDays")
+        );
+    }
+
+    private String requiredMetadataValue(JsonNode root, String fieldName) {
+        JsonNode value = root.get(fieldName);
+        if (value == null || value.isNull() || !value.isValueNode()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata." + fieldName + "는 필수 값입니다.");
+        }
+
+        String text = value.asText();
+        if (text == null || text.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata." + fieldName + "는 필수 값입니다.");
+        }
+        return text;
     }
 
     private JsonNode readMetadata(String metadata) {
@@ -93,5 +122,8 @@ public class DetectedPatternStorageService {
         } catch (JsonProcessingException e) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "metadata는 유효한 JSON이어야 합니다.");
         }
+    }
+
+    private record DuplicateKey(String targetType, String targetId, String windowDays) {
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceIntegrationTest.java
@@ -95,6 +95,88 @@ class DetectedPatternStorageServiceIntegrationTest {
         assertThat(detectedPatternStorageService.findUnprocessedPatterns(userId)).isEmpty();
     }
 
+    @Test
+    @DisplayName("같은 사용자/패턴/대상/windowDays 재실행은 중복 insert하지 않는다")
+    void createPatternWhenDuplicateKeyMatchesReturnsExistingPattern() {
+        Long userId = createUser();
+        DetectedPattern first = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+
+        DetectedPattern second = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.HIGH,
+                """
+                        {
+                          "count": 5,
+                          "windowDays": 7,
+                          "targetType": "roadmap_week",
+                          "targetId": 12,
+                          "lastDetectedAt": "2026-05-07T00:00:00Z"
+                        }
+                        """
+        );
+
+        assertThat(second.getId()).isEqualTo(first.getId());
+        assertThat(countPatterns(userId)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("처리 완료된 패턴도 같은 중복 키면 재삽입하지 않는다")
+    void createPatternWhenProcessedDuplicateExistsReturnsExistingPattern() {
+        Long userId = createUser();
+        DetectedPattern first = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+        detectedPatternStorageService.markProcessed(userId, first.getId());
+
+        DetectedPattern second = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+
+        assertThat(second.getId()).isEqualTo(first.getId());
+        assertThat(second.getProcessedAt()).isNotNull();
+        assertThat(countPatterns(userId)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("다른 대상 또는 다른 pattern_type은 별도 row로 저장한다")
+    void createPatternWhenTargetOrPatternTypeDiffersPersistsSeparateRows() {
+        Long userId = createUser();
+        DetectedPattern first = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+        DetectedPattern differentTarget = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata(13)
+        );
+        DetectedPattern differentPatternType = detectedPatternStorageService.createPattern(
+                userId,
+                PatternType.CONSECUTIVE_DELAY,
+                PatternSeverity.MEDIUM,
+                metadata(12)
+        );
+
+        assertThat(differentTarget.getId()).isNotEqualTo(first.getId());
+        assertThat(differentPatternType.getId()).isNotEqualTo(first.getId());
+        assertThat(countPatterns(userId)).isEqualTo(3);
+    }
+
     private Long createUser() {
         String key = UUID.randomUUID().toString();
         User user = userRepository.save(
@@ -111,6 +193,14 @@ class DetectedPatternStorageServiceIntegrationTest {
                 VALUES (?, 'REPEATED_INCOMPLETE', 'MEDIUM', ?::jsonb, ?::timestamptz, ?::timestamptz)
                 RETURNING id
                 """, Long.class, userId, metadata(targetId), processedAt, createdAt);
+    }
+
+    private Long countPatterns(Long userId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT count(*)
+                FROM detected_patterns
+                WHERE user_id = ?
+                """, Long.class, userId);
     }
 
     private String metadata(int targetId) {

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/DetectedPatternStorageServiceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class DetectedPatternStorageServiceTest {
@@ -40,6 +41,13 @@ class DetectedPatternStorageServiceTest {
 
     @Test
     void createPattern_persistsPatternFieldsAndMetadata() {
+        given(detectedPatternRepository.findDuplicateCandidate(
+                1L,
+                PatternType.REPEATED_INCOMPLETE.code(),
+                "roadmap_week",
+                "12",
+                "7"
+        )).willReturn(Optional.empty());
         given(detectedPatternRepository.save(any(DetectedPattern.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -58,12 +66,60 @@ class DetectedPatternStorageServiceTest {
     }
 
     @Test
+    void createPattern_whenDuplicateExists_returnsExistingPatternWithoutSaving() {
+        DetectedPattern existing = DetectedPattern.create(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata()
+        );
+        given(detectedPatternRepository.findDuplicateCandidate(
+                1L,
+                PatternType.REPEATED_INCOMPLETE.code(),
+                "roadmap_week",
+                "12",
+                "7"
+        )).willReturn(Optional.of(existing));
+
+        DetectedPattern pattern = detectedPatternStorageService.createPattern(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.HIGH,
+                metadata()
+        );
+
+        assertThat(pattern).isSameAs(existing);
+        then(detectedPatternRepository).should(never()).save(any(DetectedPattern.class));
+    }
+
+    @Test
     void createPattern_whenMetadataIsNotJsonObject_throwsInvalidInput() {
         assertThatThrownBy(() -> detectedPatternStorageService.createPattern(
                 1L,
                 PatternType.REPEATED_INCOMPLETE,
                 PatternSeverity.MEDIUM,
                 "[]"
+        )).isInstanceOfSatisfying(ServiceException.class,
+                exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+
+        then(detectedPatternRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void createPattern_whenDuplicateKeyFieldMissing_throwsInvalidInput() {
+        String metadata = """
+                {
+                  "count": 3,
+                  "targetType": "roadmap_week",
+                  "targetId": 12
+                }
+                """;
+
+        assertThatThrownBy(() -> detectedPatternStorageService.createPattern(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                metadata
         )).isInstanceOfSatisfying(ServiceException.class,
                 exception -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
 


### PR DESCRIPTION
﻿## 변경 요약
- `detected_patterns` 저장 시 `user_id + pattern_type + targetType + targetId + windowDays` 기준으로 기존 row를 재사용하도록 변경했습니다.
- JSONB metadata 기반 중복 조회 query를 추가했습니다.
- metadata에 `targetType`, `targetId`, `windowDays`가 없으면 저장을 거절하도록 검증을 보강했습니다.

## 왜 필요한가
- Pattern Detector 배치가 같은 패턴을 매일 다시 감지해도 동일 조건이면 새 row를 쌓지 않기 위해 필요합니다.
- 예를 들어 Redis 2주차 과제의 7일 반복 미완료 신호가 계속 감지돼도 Coach가 같은 문제를 새 신호처럼 반복 제안하지 않게 합니다.

## 검증
- `cd backend && .\gradlew.bat test --tests "*DetectedPattern*"`
- `cd backend && .\gradlew.bat integrationTest --tests "*DetectedPattern*"`
- `git diff --check`

Closes #202
