### PR TITLE
feat(pattern): progress 기반 패턴 감지 쿼리 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/pattern/repository/ProgressPatternQueryRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/repository/ProgressPatternQueryRepository.java
@@ -1,0 +1,149 @@
+package com.back.coach.domain.pattern.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public class ProgressPatternQueryRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ProgressPatternQueryRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<RepeatedIncompleteCandidate> findRepeatedIncompleteCandidates(
+            Long userId,
+            Instant cutoff,
+            int threshold,
+            int windowDays
+    ) {
+        return jdbcTemplate.query("""
+                WITH latest_logs AS (
+                    SELECT DISTINCT ON (pl.roadmap_week_id)
+                           pl.user_id,
+                           pl.roadmap_week_id,
+                           pl.status,
+                           pl.created_at
+                    FROM progress_logs pl
+                    WHERE pl.user_id = ?
+                    ORDER BY pl.roadmap_week_id, pl.created_at DESC, pl.id DESC
+                ),
+                candidate_counts AS (
+                    SELECT pl.user_id,
+                           pl.roadmap_week_id,
+                           COUNT(*) AS signal_count,
+                           MAX(pl.created_at) AS last_detected_at
+                    FROM progress_logs pl
+                    WHERE pl.user_id = ?
+                      AND pl.status IN ('IN_PROGRESS', 'SKIPPED')
+                      AND pl.created_at >= ?
+                    GROUP BY pl.user_id, pl.roadmap_week_id
+                    HAVING COUNT(*) >= ?
+                )
+                SELECT cc.user_id,
+                       rw.roadmap_id,
+                       cc.roadmap_week_id,
+                       rw.week_number,
+                       cc.signal_count,
+                       cc.last_detected_at
+                FROM candidate_counts cc
+                JOIN latest_logs latest
+                  ON latest.user_id = cc.user_id
+                 AND latest.roadmap_week_id = cc.roadmap_week_id
+                 AND latest.status IN ('IN_PROGRESS', 'SKIPPED')
+                JOIN roadmap_weeks rw
+                  ON rw.id = cc.roadmap_week_id
+                JOIN learning_roadmaps lr
+                  ON lr.id = rw.roadmap_id
+                 AND lr.user_id = cc.user_id
+                ORDER BY cc.signal_count DESC, cc.last_detected_at DESC, cc.roadmap_week_id
+                """, (rs, rowNum) -> new RepeatedIncompleteCandidate(
+                rs.getLong("user_id"),
+                rs.getLong("roadmap_id"),
+                rs.getLong("roadmap_week_id"),
+                rs.getInt("week_number"),
+                rs.getLong("signal_count"),
+                windowDays,
+                rs.getTimestamp("last_detected_at").toInstant()
+        ), userId, userId, Timestamp.from(cutoff), threshold);
+    }
+
+    public List<ConsecutiveDelayCandidate> findConsecutiveDelayCandidates(Long userId, int windowDays) {
+        return jdbcTemplate.query("""
+                WITH latest_logs AS (
+                    SELECT DISTINCT ON (pl.roadmap_week_id)
+                           pl.user_id,
+                           pl.roadmap_week_id,
+                           pl.status,
+                           pl.created_at
+                    FROM progress_logs pl
+                    WHERE pl.user_id = ?
+                    ORDER BY pl.roadmap_week_id, pl.created_at DESC, pl.id DESC
+                ),
+                stalled_weeks AS (
+                    SELECT latest.user_id,
+                           rw.roadmap_id,
+                           rw.id AS roadmap_week_id,
+                           rw.week_number,
+                           latest.created_at
+                    FROM latest_logs latest
+                    JOIN roadmap_weeks rw
+                      ON rw.id = latest.roadmap_week_id
+                    JOIN learning_roadmaps lr
+                      ON lr.id = rw.roadmap_id
+                     AND lr.user_id = latest.user_id
+                    WHERE latest.status IN ('IN_PROGRESS', 'SKIPPED')
+                )
+                SELECT first.user_id,
+                       first.roadmap_id,
+                       first.roadmap_week_id AS first_roadmap_week_id,
+                       second.roadmap_week_id AS second_roadmap_week_id,
+                       first.week_number AS first_week_number,
+                       second.week_number AS second_week_number,
+                       GREATEST(first.created_at, second.created_at) AS last_detected_at
+                FROM stalled_weeks first
+                JOIN stalled_weeks second
+                  ON second.user_id = first.user_id
+                 AND second.roadmap_id = first.roadmap_id
+                 AND second.week_number = first.week_number + 1
+                ORDER BY last_detected_at DESC, first.roadmap_id, first.week_number
+                """, (rs, rowNum) -> new ConsecutiveDelayCandidate(
+                rs.getLong("user_id"),
+                rs.getLong("roadmap_id"),
+                rs.getLong("first_roadmap_week_id"),
+                rs.getLong("second_roadmap_week_id"),
+                rs.getInt("first_week_number"),
+                rs.getInt("second_week_number"),
+                windowDays,
+                rs.getTimestamp("last_detected_at").toInstant()
+        ), userId);
+    }
+
+    public record RepeatedIncompleteCandidate(
+            Long userId,
+            Long roadmapId,
+            Long roadmapWeekId,
+            Integer weekNumber,
+            Long count,
+            Integer windowDays,
+            Instant lastDetectedAt
+    ) {
+    }
+
+    public record ConsecutiveDelayCandidate(
+            Long userId,
+            Long roadmapId,
+            Long firstRoadmapWeekId,
+            Long secondRoadmapWeekId,
+            Integer firstWeekNumber,
+            Integer secondWeekNumber,
+            Integer windowDays,
+            Instant lastDetectedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorService.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorService.java
@@ -1,0 +1,113 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository.ConsecutiveDelayCandidate;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository.RepeatedIncompleteCandidate;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+public class ProgressPatternDetectorService {
+
+    private static final int WINDOW_DAYS = 7;
+    private static final int REPEATED_INCOMPLETE_THRESHOLD = 2;
+
+    private final ProgressPatternQueryRepository progressPatternQueryRepository;
+    private final DetectedPatternStorageService detectedPatternStorageService;
+    private final ObjectMapper objectMapper;
+
+    public ProgressPatternDetectorService(
+            ProgressPatternQueryRepository progressPatternQueryRepository,
+            DetectedPatternStorageService detectedPatternStorageService,
+            ObjectMapper objectMapper
+    ) {
+        this.progressPatternQueryRepository = progressPatternQueryRepository;
+        this.detectedPatternStorageService = detectedPatternStorageService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public List<DetectedPattern> detectAndStore(Long userId) {
+        validateUserId(userId);
+
+        List<DetectedPattern> detectedPatterns = new ArrayList<>();
+        Instant cutoff = Instant.now().minus(Duration.ofDays(WINDOW_DAYS));
+
+        for (RepeatedIncompleteCandidate candidate : progressPatternQueryRepository.findRepeatedIncompleteCandidates(
+                userId, cutoff, REPEATED_INCOMPLETE_THRESHOLD, WINDOW_DAYS
+        )) {
+            detectedPatterns.add(detectedPatternStorageService.createPattern(
+                    userId,
+                    PatternType.REPEATED_INCOMPLETE,
+                    PatternSeverity.MEDIUM,
+                    repeatedIncompleteMetadata(candidate)
+            ));
+        }
+
+        for (ConsecutiveDelayCandidate candidate : progressPatternQueryRepository.findConsecutiveDelayCandidates(
+                userId, WINDOW_DAYS
+        )) {
+            detectedPatterns.add(detectedPatternStorageService.createPattern(
+                    userId,
+                    PatternType.CONSECUTIVE_DELAY,
+                    PatternSeverity.MEDIUM,
+                    consecutiveDelayMetadata(candidate)
+            ));
+        }
+
+        return detectedPatterns;
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null || userId < 1) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "userId는 양수여야 합니다.");
+        }
+    }
+
+    private String repeatedIncompleteMetadata(RepeatedIncompleteCandidate candidate) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("targetType", "roadmap_week");
+        metadata.put("targetId", candidate.roadmapWeekId());
+        metadata.put("windowDays", candidate.windowDays());
+        metadata.put("count", candidate.count());
+        metadata.put("roadmapId", candidate.roadmapId());
+        metadata.put("weekNumber", candidate.weekNumber());
+        metadata.put("lastDetectedAt", candidate.lastDetectedAt().toString());
+        return toJson(metadata);
+    }
+
+    private String consecutiveDelayMetadata(ConsecutiveDelayCandidate candidate) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("targetType", "roadmap");
+        metadata.put("targetId", candidate.roadmapId());
+        metadata.put("windowDays", candidate.windowDays());
+        metadata.put("count", 2);
+        metadata.put("weekNumbers", List.of(candidate.firstWeekNumber(), candidate.secondWeekNumber()));
+        metadata.put("roadmapWeekIds", List.of(candidate.firstRoadmapWeekId(), candidate.secondRoadmapWeekId()));
+        metadata.put("lastDetectedAt", candidate.lastDetectedAt().toString());
+        return toJson(metadata);
+    }
+
+    private String toJson(Map<String, Object> metadata) {
+        try {
+            return objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorServiceIntegrationTest.java
@@ -1,0 +1,234 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.support.IntegrationTest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class ProgressPatternDetectorServiceIntegrationTest {
+
+    @Autowired
+    private ProgressPatternDetectorService progressPatternDetectorService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("최근 7일 같은 주차의 미완료 로그 누적으로 반복 미완료 패턴을 저장한다")
+    void detectsRepeatedIncompletePatternFromRecentProgressLogs() throws Exception {
+        Long userId = insertUser();
+        Long roadmapId = insertLearningRoadmapGraph(userId);
+        Long roadmapWeekId = insertRoadmapWeek(roadmapId, 2);
+        insertProgressLog(userId, roadmapWeekId, "IN_PROGRESS", Instant.now().minus(2, ChronoUnit.DAYS));
+        insertProgressLog(userId, roadmapWeekId, "SKIPPED", Instant.now().minus(1, ChronoUnit.DAYS));
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(userId);
+
+        assertThat(detectedPatterns)
+                .extracting(DetectedPattern::getPatternType)
+                .contains(PatternType.REPEATED_INCOMPLETE);
+        Long patternId = findDetectedPatternId(userId, "REPEATED_INCOMPLETE");
+        JsonNode metadata = readMetadata(patternId);
+        assertThat(metadata.path("targetType").asText()).isEqualTo("roadmap_week");
+        assertThat(metadata.path("targetId").asLong()).isEqualTo(roadmapWeekId);
+        assertThat(metadata.path("windowDays").asInt()).isEqualTo(7);
+        assertThat(metadata.path("count").asLong()).isEqualTo(2L);
+
+        progressPatternDetectorService.detectAndStore(userId);
+
+        assertThat(countDetectedPatterns(userId, "REPEATED_INCOMPLETE")).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("인접 주차 최신 상태가 미완료이면 연속 지연 패턴을 저장한다")
+    void detectsConsecutiveDelayPatternFromAdjacentLatestStatuses() throws Exception {
+        Long userId = insertUser();
+        Long roadmapId = insertLearningRoadmapGraph(userId);
+        Long firstWeekId = insertRoadmapWeek(roadmapId, 1);
+        Long secondWeekId = insertRoadmapWeek(roadmapId, 2);
+        insertRoadmapWeek(roadmapId, 3);
+        insertProgressLog(userId, firstWeekId, "IN_PROGRESS", Instant.now().minus(2, ChronoUnit.DAYS));
+        insertProgressLog(userId, secondWeekId, "SKIPPED", Instant.now().minus(1, ChronoUnit.DAYS));
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(userId);
+
+        assertThat(detectedPatterns)
+                .extracting(DetectedPattern::getPatternType)
+                .contains(PatternType.CONSECUTIVE_DELAY);
+        Long patternId = findDetectedPatternId(userId, "CONSECUTIVE_DELAY");
+        JsonNode metadata = readMetadata(patternId);
+        assertThat(metadata.path("targetType").asText()).isEqualTo("roadmap");
+        assertThat(metadata.path("targetId").asLong()).isEqualTo(roadmapId);
+        assertThat(metadata.path("weekNumbers")).extracting(JsonNode::asInt).containsExactly(1, 2);
+        assertThat(metadata.path("roadmapWeekIds")).extracting(JsonNode::asLong)
+                .containsExactly(firstWeekId, secondWeekId);
+    }
+
+    @Test
+    @DisplayName("최신 상태가 DONE이거나 다른 사용자 데이터이면 감지하지 않는다")
+    void ignoresDoneLatestStatusAndOtherUserData() {
+        Long userId = insertUser();
+        Long roadmapId = insertLearningRoadmapGraph(userId);
+        Long roadmapWeekId = insertRoadmapWeek(roadmapId, 1);
+        insertProgressLog(userId, roadmapWeekId, "IN_PROGRESS", Instant.now().minus(3, ChronoUnit.DAYS));
+        insertProgressLog(userId, roadmapWeekId, "SKIPPED", Instant.now().minus(2, ChronoUnit.DAYS));
+        insertProgressLog(userId, roadmapWeekId, "DONE", Instant.now().minus(1, ChronoUnit.DAYS));
+
+        Long otherUserId = insertUser();
+        Long otherRoadmapId = insertLearningRoadmapGraph(otherUserId);
+        Long otherRoadmapWeekId = insertRoadmapWeek(otherRoadmapId, 1);
+        insertProgressLog(otherUserId, otherRoadmapWeekId, "IN_PROGRESS", Instant.now().minus(2, ChronoUnit.DAYS));
+        insertProgressLog(otherUserId, otherRoadmapWeekId, "SKIPPED", Instant.now().minus(1, ChronoUnit.DAYS));
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(userId);
+
+        assertThat(detectedPatterns).isEmpty();
+        assertThat(countDetectedPatterns(userId, "REPEATED_INCOMPLETE")).isZero();
+        assertThat(countDetectedPatterns(userId, "CONSECUTIVE_DELAY")).isZero();
+    }
+
+    private Long insertUser() {
+        String key = UUID.randomUUID().toString();
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO users (email, password_hash, auth_provider, is_active)
+                VALUES (?, 'hash', 'LOCAL', true)
+                RETURNING id
+                """, Long.class, "progress-pattern-" + key + "@example.com");
+    }
+
+    private Long insertLearningRoadmapGraph(Long userId) {
+        Long githubConnectionId = insertGithubConnection(userId);
+        Long jobRoleId = findBackendDeveloperRoleId();
+        Long profileId = insertUserProfile(userId, jobRoleId);
+        Long githubAnalysisId = insertGithubAnalysis(userId, githubConnectionId);
+        Long diagnosisId = insertCapabilityDiagnosis(userId, profileId, githubAnalysisId, jobRoleId);
+        return insertLearningRoadmap(userId, diagnosisId);
+    }
+
+    private Long insertGithubConnection(Long userId) {
+        String githubUserId = "progress-pattern-" + UUID.randomUUID();
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO github_connections (user_id, github_user_id, github_login, access_type)
+                VALUES (?, ?, 'progress-pattern-user', 'OAUTH')
+                RETURNING id
+                """, Long.class, userId, githubUserId);
+    }
+
+    private Long findBackendDeveloperRoleId() {
+        return jdbcTemplate.queryForObject("""
+                SELECT id
+                FROM job_roles
+                WHERE role_code = 'BACKEND_DEVELOPER'
+                """, Long.class);
+    }
+
+    private Long insertUserProfile(Long userId, Long jobRoleId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO user_profiles (user_id, job_role_id, current_level, interest_areas_json)
+                VALUES (?, ?, 'JUNIOR', '[]'::jsonb)
+                RETURNING id
+                """, Long.class, userId, jobRoleId);
+    }
+
+    private Long insertGithubAnalysis(Long userId, Long githubConnectionId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO github_analyses (
+                    user_id, github_connection_id, version, summary, analysis_payload
+                )
+                VALUES (?, ?, 1, 'GitHub analysis', '{}'::jsonb)
+                RETURNING id
+                """, Long.class, userId, githubConnectionId);
+    }
+
+    private Long insertCapabilityDiagnosis(Long userId, Long profileId, Long githubAnalysisId, Long jobRoleId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO capability_diagnoses (
+                    user_id,
+                    profile_id,
+                    github_analysis_id,
+                    job_role_id,
+                    version,
+                    current_level,
+                    summary,
+                    diagnosis_payload
+                )
+                VALUES (?, ?, ?, ?, 1, 'JUNIOR', 'Capability diagnosis', '{}'::jsonb)
+                RETURNING id
+                """, Long.class, userId, profileId, githubAnalysisId, jobRoleId);
+    }
+
+    private Long insertLearningRoadmap(Long userId, Long diagnosisId) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO learning_roadmaps (
+                    user_id, diagnosis_id, version, total_weeks, summary, roadmap_payload
+                )
+                VALUES (?, ?, 1, 4, 'Learning roadmap', '{}'::jsonb)
+                RETURNING id
+                """, Long.class, userId, diagnosisId);
+    }
+
+    private Long insertRoadmapWeek(Long roadmapId, int weekNumber) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO roadmap_weeks (
+                    roadmap_id, week_number, topic, reason_text, tasks_json, materials_json, estimated_hours
+                )
+                VALUES (?, ?, ?, 'Reason', '[]'::jsonb, '[]'::jsonb, 4.0)
+                RETURNING id
+                """, Long.class, roadmapId, weekNumber, "Week " + weekNumber);
+    }
+
+    private Long insertProgressLog(Long userId, Long roadmapWeekId, String status, Instant createdAt) {
+        Timestamp completedAt = "DONE".equals(status) ? Timestamp.from(createdAt) : null;
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO progress_logs (user_id, roadmap_week_id, status, note, completed_at, created_at)
+                VALUES (?, ?, ?, null, ?, ?)
+                RETURNING id
+                """, Long.class, userId, roadmapWeekId, status, completedAt, Timestamp.from(createdAt));
+    }
+
+    private Long findDetectedPatternId(Long userId, String patternType) {
+        return jdbcTemplate.queryForObject("""
+                SELECT id
+                FROM detected_patterns
+                WHERE user_id = ?
+                  AND pattern_type = ?
+                ORDER BY created_at DESC
+                LIMIT 1
+                """, Long.class, userId, patternType);
+    }
+
+    private JsonNode readMetadata(Long patternId) throws Exception {
+        String metadata = jdbcTemplate.queryForObject("""
+                SELECT metadata::text
+                FROM detected_patterns
+                WHERE id = ?
+                """, String.class, patternId);
+        return objectMapper.readTree(metadata);
+    }
+
+    private Long countDetectedPatterns(Long userId, String patternType) {
+        return jdbcTemplate.queryForObject("""
+                SELECT count(*)
+                FROM detected_patterns
+                WHERE user_id = ?
+                  AND pattern_type = ?
+                """, Long.class, userId, patternType);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/pattern/service/ProgressPatternDetectorServiceTest.java
@@ -1,0 +1,154 @@
+package com.back.coach.domain.pattern.service;
+
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository.ConsecutiveDelayCandidate;
+import com.back.coach.domain.pattern.repository.ProgressPatternQueryRepository.RepeatedIncompleteCandidate;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class ProgressPatternDetectorServiceTest {
+
+    @Mock
+    private ProgressPatternQueryRepository progressPatternQueryRepository;
+
+    @Mock
+    private DetectedPatternStorageService detectedPatternStorageService;
+
+    private ObjectMapper objectMapper;
+    private ProgressPatternDetectorService progressPatternDetectorService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        progressPatternDetectorService = new ProgressPatternDetectorService(
+                progressPatternQueryRepository,
+                detectedPatternStorageService,
+                objectMapper
+        );
+    }
+
+    @Test
+    void detectAndStoreStoresRepeatedIncompleteCandidate() throws Exception {
+        RepeatedIncompleteCandidate candidate = new RepeatedIncompleteCandidate(
+                1L,
+                10L,
+                20L,
+                2,
+                3L,
+                7,
+                Instant.parse("2026-05-07T00:00:00Z")
+        );
+        DetectedPattern stored = DetectedPattern.create(
+                1L,
+                PatternType.REPEATED_INCOMPLETE,
+                PatternSeverity.MEDIUM,
+                "{}"
+        );
+        given(progressPatternQueryRepository.findRepeatedIncompleteCandidates(eq(1L), any(Instant.class), eq(2), eq(7)))
+                .willReturn(List.of(candidate));
+        given(progressPatternQueryRepository.findConsecutiveDelayCandidates(1L, 7))
+                .willReturn(List.of());
+        given(detectedPatternStorageService.createPattern(
+                eq(1L),
+                eq(PatternType.REPEATED_INCOMPLETE),
+                eq(PatternSeverity.MEDIUM),
+                any(String.class)
+        )).willReturn(stored);
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(1L);
+
+        ArgumentCaptor<String> metadataCaptor = ArgumentCaptor.forClass(String.class);
+        then(detectedPatternStorageService).should().createPattern(
+                eq(1L),
+                eq(PatternType.REPEATED_INCOMPLETE),
+                eq(PatternSeverity.MEDIUM),
+                metadataCaptor.capture()
+        );
+        JsonNode metadata = objectMapper.readTree(metadataCaptor.getValue());
+        assertThat(detectedPatterns).containsExactly(stored);
+        assertThat(metadata.path("targetType").asText()).isEqualTo("roadmap_week");
+        assertThat(metadata.path("targetId").asLong()).isEqualTo(20L);
+        assertThat(metadata.path("windowDays").asInt()).isEqualTo(7);
+        assertThat(metadata.path("count").asLong()).isEqualTo(3L);
+    }
+
+    @Test
+    void detectAndStoreStoresConsecutiveDelayCandidate() throws Exception {
+        ConsecutiveDelayCandidate candidate = new ConsecutiveDelayCandidate(
+                1L,
+                10L,
+                21L,
+                22L,
+                1,
+                2,
+                7,
+                Instant.parse("2026-05-07T00:00:00Z")
+        );
+        DetectedPattern stored = DetectedPattern.create(
+                1L,
+                PatternType.CONSECUTIVE_DELAY,
+                PatternSeverity.MEDIUM,
+                "{}"
+        );
+        given(progressPatternQueryRepository.findRepeatedIncompleteCandidates(eq(1L), any(Instant.class), eq(2), eq(7)))
+                .willReturn(List.of());
+        given(progressPatternQueryRepository.findConsecutiveDelayCandidates(1L, 7))
+                .willReturn(List.of(candidate));
+        given(detectedPatternStorageService.createPattern(
+                eq(1L),
+                eq(PatternType.CONSECUTIVE_DELAY),
+                eq(PatternSeverity.MEDIUM),
+                any(String.class)
+        )).willReturn(stored);
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(1L);
+
+        ArgumentCaptor<String> metadataCaptor = ArgumentCaptor.forClass(String.class);
+        then(detectedPatternStorageService).should().createPattern(
+                eq(1L),
+                eq(PatternType.CONSECUTIVE_DELAY),
+                eq(PatternSeverity.MEDIUM),
+                metadataCaptor.capture()
+        );
+        JsonNode metadata = objectMapper.readTree(metadataCaptor.getValue());
+        assertThat(detectedPatterns).containsExactly(stored);
+        assertThat(metadata.path("targetType").asText()).isEqualTo("roadmap");
+        assertThat(metadata.path("targetId").asLong()).isEqualTo(10L);
+        assertThat(metadata.path("weekNumbers")).extracting(JsonNode::asInt).containsExactly(1, 2);
+        assertThat(metadata.path("roadmapWeekIds")).extracting(JsonNode::asLong).containsExactly(21L, 22L);
+    }
+
+    @Test
+    void detectAndStoreWhenNoCandidateDoesNotStorePattern() {
+        given(progressPatternQueryRepository.findRepeatedIncompleteCandidates(eq(1L), any(Instant.class), eq(2), eq(7)))
+                .willReturn(List.of());
+        given(progressPatternQueryRepository.findConsecutiveDelayCandidates(1L, 7))
+                .willReturn(List.of());
+
+        List<DetectedPattern> detectedPatterns = progressPatternDetectorService.detectAndStore(1L);
+
+        assertThat(detectedPatterns).isEmpty();
+        then(detectedPatternStorageService).should(never())
+                .createPattern(any(Long.class), any(PatternType.class), any(PatternSeverity.class), any(String.class));
+    }
+}


### PR DESCRIPTION
﻿## 변경 요약
- `progress_logs + roadmap_weeks + learning_roadmaps` 기반 SQL 집계 query repository를 추가했습니다.
- 반복 미완료와 연속 지연 후보를 감지해 `detected_patterns`에 저장하는 detector service를 추가했습니다.
- 감지 저장은 기존 `DetectedPatternStorageService`를 사용해 중복 방지 규칙을 그대로 탑니다.

## 왜 필요한가
- Coach가 사용자의 반복 미완료나 지연 상태를 데이터 기반 신호로 읽으려면 먼저 원본 row가 필요합니다.
- 예를 들어 Redis 2주차가 최근 7일 안에 `IN_PROGRESS -> SKIPPED -> IN_PROGRESS`처럼 반복되면 `REPEATED_INCOMPLETE` 후보를 저장할 수 있습니다.

## 검증
- `cd backend && .\gradlew.bat test --tests "*ProgressPattern*"`
- `cd backend && .\gradlew.bat integrationTest --tests "*ProgressPattern*"`
- `cd backend && .\gradlew.bat integrationTest --tests "*DetectedPattern*"`
- `git diff --check`

Closes #203
