### PR TITLE
feat(coach): Coach API MVP — 세션/메시지/컨텍스트/재계획 (#190)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
@@ -2,7 +2,6 @@ package com.back.coach.domain.coach.controller;
 
 import com.back.coach.domain.coach.dto.CoachMessageRequest;
 import com.back.coach.domain.coach.dto.CoachMessageResponse;
-import com.back.coach.domain.coach.entity.CoachConversation;
 import com.back.coach.domain.coach.service.CoachMessageService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
@@ -36,9 +35,9 @@ public class CoachMessageController {
             Authentication authentication
     ) {
         AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
-        CoachConversation coachMessage = coachMessageService.sendMessage(
+        CoachMessageService.MessageResult result = coachMessageService.sendMessage(
                 user.userId(), sessionId, request.message()
         );
-        return ApiResponse.success(CoachMessageResponse.from(coachMessage));
+        return ApiResponse.success(CoachMessageResponse.from(result));
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
@@ -1,0 +1,44 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.dto.CoachMessageRequest;
+import com.back.coach.domain.coach.dto.CoachMessageResponse;
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.service.CoachMessageService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+        path = "/api/coach/sessions/{sessionId}/messages",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        consumes = MediaType.APPLICATION_JSON_VALUE
+)
+public class CoachMessageController {
+
+    private final CoachMessageService coachMessageService;
+
+    public CoachMessageController(CoachMessageService coachMessageService) {
+        this.coachMessageService = coachMessageService;
+    }
+
+    @PostMapping
+    public ApiResponse<CoachMessageResponse> sendMessage(
+            @PathVariable Long sessionId,
+            @Valid @RequestBody CoachMessageRequest request,
+            Authentication authentication
+    ) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        CoachConversation coachMessage = coachMessageService.sendMessage(
+                user.userId(), sessionId, request.message()
+        );
+        return ApiResponse.success(CoachMessageResponse.from(coachMessage));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
@@ -1,0 +1,45 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.dto.CoachSessionResponse;
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.service.CoachSessionService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/coach/sessions", produces = MediaType.APPLICATION_JSON_VALUE)
+public class CoachSessionController {
+
+    private final CoachSessionService coachSessionService;
+
+    public CoachSessionController(CoachSessionService coachSessionService) {
+        this.coachSessionService = coachSessionService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<CoachSessionResponse> startSession(Authentication authentication) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        ChatSession session = coachSessionService.startSession(user.userId());
+        return ApiResponse.success(CoachSessionResponse.from(session));
+    }
+
+    @DeleteMapping("/{sessionId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void closeSession(
+            @PathVariable Long sessionId,
+            Authentication authentication
+    ) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        coachSessionService.closeSession(user.userId(), sessionId);
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/controller/ReplanController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/ReplanController.java
@@ -1,0 +1,50 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.dto.ReplanRequest;
+import com.back.coach.domain.coach.dto.ReplanResponse;
+import com.back.coach.domain.coach.service.ReplanService;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+        path = "/api/coach/sessions/{sessionId}/replan",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        consumes = MediaType.APPLICATION_JSON_VALUE
+)
+public class ReplanController {
+
+    private final ReplanService replanService;
+
+    public ReplanController(ReplanService replanService) {
+        this.replanService = replanService;
+    }
+
+    @PostMapping
+    public ApiResponse<ReplanResponse> replan(
+            @PathVariable Long sessionId,
+            @Valid @RequestBody ReplanRequest request,
+            Authentication authentication
+    ) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+
+        if (Boolean.TRUE.equals(request.confirmed())) {
+            ReplanService.ReplanResult result = replanService.confirm(
+                    user.userId(), sessionId, request.proposalId()
+            );
+            return ApiResponse.success(ReplanResponse.confirmed(
+                    result.newRoadmapId(), result.newRoadmapVersion()));
+        } else {
+            replanService.dismiss(user.userId(), request.proposalId());
+            return ApiResponse.success(ReplanResponse.deferred());
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageRequest.java
@@ -1,0 +1,11 @@
+package com.back.coach.domain.coach.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CoachMessageRequest(
+        @NotBlank
+        @Size(max = 4000)
+        String message
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageResponse.java
@@ -1,20 +1,36 @@
 package com.back.coach.domain.coach.dto;
 
 import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.entity.ReplanProposal;
+import com.back.coach.domain.coach.service.CoachMessageService;
 import com.back.coach.global.code.CoachRoute;
+
+import java.time.Instant;
 
 public record CoachMessageResponse(
         String messageId,
         String responseText,
         CoachRoute route,
-        Object replanProposal
+        ReplanProposalDto replanProposal
 ) {
-    public static CoachMessageResponse from(CoachConversation coachMessage) {
+    public record ReplanProposalDto(String proposalId, String reason, Instant expiresAt) {}
+
+    public static CoachMessageResponse from(CoachMessageService.MessageResult result) {
+        CoachConversation msg = result.coachMessage();
+        ReplanProposal proposal = result.proposal();
+
+        ReplanProposalDto proposalDto = proposal == null ? null
+                : new ReplanProposalDto(
+                        String.valueOf(proposal.getId()),
+                        proposal.getReason(),
+                        proposal.getExpiresAt()
+                  );
+
         return new CoachMessageResponse(
-                String.valueOf(coachMessage.getId()),
-                coachMessage.getMessageText(),
-                coachMessage.getRoute(),
-                null
+                String.valueOf(msg.getId()),
+                msg.getMessageText(),
+                msg.getRoute(),
+                proposalDto
         );
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageResponse.java
@@ -1,0 +1,20 @@
+package com.back.coach.domain.coach.dto;
+
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.global.code.CoachRoute;
+
+public record CoachMessageResponse(
+        String messageId,
+        String responseText,
+        CoachRoute route,
+        Object replanProposal
+) {
+    public static CoachMessageResponse from(CoachConversation coachMessage) {
+        return new CoachMessageResponse(
+                String.valueOf(coachMessage.getId()),
+                coachMessage.getMessageText(),
+                coachMessage.getRoute(),
+                null
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachSessionResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachSessionResponse.java
@@ -1,0 +1,21 @@
+package com.back.coach.domain.coach.dto;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+
+import java.time.Instant;
+
+public record CoachSessionResponse(
+        String sessionId,
+        Integer profileVersion,
+        Integer roadmapVersion,
+        Instant startedAt
+) {
+    public static CoachSessionResponse from(ChatSession session) {
+        return new CoachSessionResponse(
+                String.valueOf(session.getId()),
+                session.getProfileVersion(),
+                session.getRoadmapVersion(),
+                session.getStartedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/ReplanRequest.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/ReplanRequest.java
@@ -1,0 +1,9 @@
+package com.back.coach.domain.coach.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReplanRequest(
+        @NotNull Long proposalId,
+        @NotNull Boolean confirmed
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/ReplanResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/ReplanResponse.java
@@ -1,0 +1,21 @@
+package com.back.coach.domain.coach.dto;
+
+public record ReplanResponse(
+        String newRoadmapId,
+        Integer newRoadmapVersion,
+        String message,
+        Boolean dismissed
+) {
+    public static ReplanResponse confirmed(String roadmapId, Integer version) {
+        return new ReplanResponse(
+                String.valueOf(roadmapId),
+                version,
+                "새 로드맵이 생성됐습니다. 현재 세션은 기존 버전을 기준으로 유지됩니다.",
+                null
+        );
+    }
+
+    public static ReplanResponse deferred() {
+        return new ReplanResponse(null, null, "재계획을 보류했습니다.", true);
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/entity/AgentEvent.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/entity/AgentEvent.java
@@ -1,0 +1,58 @@
+package com.back.coach.domain.coach.entity;
+
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "agent_events")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AgentEvent extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "session_id")
+    private Long sessionId;
+
+    @Column(name = "source_agent", nullable = false, length = 30)
+    private String sourceAgent;
+
+    @Column(name = "target_agent", length = 30)
+    private String targetAgent;
+
+    @Column(name = "event_type", nullable = false, length = 50)
+    private String eventType;
+
+    @Column(name = "event_data", nullable = false, columnDefinition = "jsonb")
+    private String eventData;
+
+    @Column(name = "processed_at")
+    private Instant processedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static AgentEvent replanRequested(Long userId, Long sessionId, String eventData) {
+        AgentEvent event = new AgentEvent();
+        event.userId = userId;
+        event.sessionId = sessionId;
+        event.sourceAgent = "COACH";
+        event.targetAgent = "PLANNER";
+        event.eventType = "REPLAN_REQUESTED";
+        event.eventData = eventData;
+        return event;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/entity/AgentEvent.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/entity/AgentEvent.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,6 +37,7 @@ public class AgentEvent extends BaseEntity {
     @Column(name = "event_type", nullable = false, length = 50)
     private String eventType;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "event_data", nullable = false, columnDefinition = "jsonb")
     private String eventData;
 

--- a/backend/src/main/java/com/back/coach/domain/coach/entity/ChatSession.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/entity/ChatSession.java
@@ -1,0 +1,67 @@
+package com.back.coach.domain.coach.entity;
+
+import com.back.coach.global.code.ChatSessionStatus;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "chat_sessions")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSession extends BaseEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "profile_version", nullable = false)
+    private Integer profileVersion;
+
+    @Column(name = "roadmap_version", nullable = false)
+    private Integer roadmapVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ChatSessionStatus status;
+
+    @CreatedDate
+    @Column(name = "started_at", nullable = false, updatable = false)
+    private Instant startedAt;
+
+    @Column(name = "ended_at")
+    private Instant endedAt;
+
+    public static ChatSession start(Long userId, Integer profileVersion, Integer roadmapVersion) {
+        ChatSession session = new ChatSession();
+        session.userId = userId;
+        session.profileVersion = profileVersion;
+        session.roadmapVersion = roadmapVersion;
+        session.status = ChatSessionStatus.ACTIVE;
+        return session;
+    }
+
+    public void close(Instant endedAt) {
+        this.status = ChatSessionStatus.CLOSED;
+        this.endedAt = endedAt;
+    }
+
+    public boolean isClosed() {
+        return this.status == ChatSessionStatus.CLOSED;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/entity/CoachConversation.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/entity/CoachConversation.java
@@ -1,0 +1,76 @@
+package com.back.coach.domain.coach.entity;
+
+import com.back.coach.global.code.CoachMessageRole;
+import com.back.coach.global.code.CoachRoute;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "coach_conversations")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoachConversation extends BaseEntity {
+
+    @Column(name = "session_id", nullable = false)
+    private Long sessionId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 10)
+    private CoachMessageRole role;
+
+    @Column(name = "message_text", nullable = false, columnDefinition = "text")
+    private String messageText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "route", length = 30)
+    private CoachRoute route;
+
+    @Column(name = "detected_intent", length = 50)
+    private String detectedIntent;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static CoachConversation user(Long sessionId, Long userId, String messageText) {
+        CoachConversation conversation = new CoachConversation();
+        conversation.sessionId = sessionId;
+        conversation.userId = userId;
+        conversation.role = CoachMessageRole.USER;
+        conversation.messageText = messageText;
+        return conversation;
+    }
+
+    public static CoachConversation coach(
+            Long sessionId,
+            Long userId,
+            String messageText,
+            CoachRoute route,
+            String detectedIntent
+    ) {
+        CoachConversation conversation = new CoachConversation();
+        conversation.sessionId = sessionId;
+        conversation.userId = userId;
+        conversation.role = CoachMessageRole.COACH;
+        conversation.messageText = messageText;
+        conversation.route = route;
+        conversation.detectedIntent = detectedIntent;
+        return conversation;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/entity/ReplanProposal.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/entity/ReplanProposal.java
@@ -1,0 +1,81 @@
+package com.back.coach.domain.coach.entity;
+
+import com.back.coach.global.code.ReplanProposalStatus;
+import com.back.coach.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(name = "replan_proposals")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplanProposal extends BaseEntity {
+
+    @Column(name = "session_id", nullable = false)
+    private Long sessionId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "message_id")
+    private Long messageId;
+
+    @Column(name = "reason", nullable = false, columnDefinition = "text")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ReplanProposalStatus status;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "resolved_at")
+    private Instant resolvedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static ReplanProposal create(Long sessionId, Long userId, Long messageId,
+                                        String reason, Instant expiresAt) {
+        ReplanProposal proposal = new ReplanProposal();
+        proposal.sessionId = sessionId;
+        proposal.userId = userId;
+        proposal.messageId = messageId;
+        proposal.reason = reason;
+        proposal.status = ReplanProposalStatus.PENDING;
+        proposal.expiresAt = expiresAt;
+        return proposal;
+    }
+
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+
+    public boolean isPending() {
+        return status == ReplanProposalStatus.PENDING;
+    }
+
+    public void confirm(Instant resolvedAt) {
+        this.status = ReplanProposalStatus.CONFIRMED;
+        this.resolvedAt = resolvedAt;
+    }
+
+    public void dismiss(Instant resolvedAt) {
+        this.status = ReplanProposalStatus.DISMISSED;
+        this.resolvedAt = resolvedAt;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/AgentEventRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/AgentEventRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.coach.repository;
+
+import com.back.coach.domain.coach.entity.AgentEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgentEventRepository extends JpaRepository<AgentEvent, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
@@ -1,0 +1,7 @@
+package com.back.coach.domain.coach.repository;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/CoachConversationRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/CoachConversationRepository.java
@@ -1,0 +1,11 @@
+package com.back.coach.domain.coach.repository;
+
+import com.back.coach.domain.coach.entity.CoachConversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoachConversationRepository extends JpaRepository<CoachConversation, Long> {
+
+    List<CoachConversation> findBySessionIdOrderByCreatedAtAsc(Long sessionId);
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/ReplanProposalRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/ReplanProposalRepository.java
@@ -1,0 +1,12 @@
+package com.back.coach.domain.coach.repository;
+
+import com.back.coach.domain.coach.entity.ReplanProposal;
+import com.back.coach.global.code.ReplanProposalStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReplanProposalRepository extends JpaRepository<ReplanProposal, Long> {
+
+    List<ReplanProposal> findByUserIdAndStatus(Long userId, ReplanProposalStatus status);
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -1,0 +1,63 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.coach.repository.CoachConversationRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.CoachRoute;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CoachMessageService {
+
+    private static final String SIMPLE_GUIDE_PROMPT = """
+            당신은 학습 코치입니다. 사용자의 질문에 짧고 실용적인 답변을 한국어로 제공합니다.
+            아직 사용자의 프로필이나 로드맵 컨텍스트는 주입되지 않았습니다 (다음 슬라이스에서 추가).
+
+            사용자 메시지: %s
+            """;
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final CoachConversationRepository coachConversationRepository;
+    private final LlmClient llmClient;
+
+    public CoachMessageService(
+            ChatSessionRepository chatSessionRepository,
+            CoachConversationRepository coachConversationRepository,
+            LlmClient llmClient
+    ) {
+        this.chatSessionRepository = chatSessionRepository;
+        this.coachConversationRepository = coachConversationRepository;
+        this.llmClient = llmClient;
+    }
+
+    @Transactional
+    public CoachConversation sendMessage(Long userId, Long sessionId, String userMessage) {
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isOwnedBy(userId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+
+        if (session.isClosed()) {
+            throw new ServiceException(ErrorCode.SESSION_CLOSED);
+        }
+
+        // USER 메시지 저장 (LLM 실패해도 사용자 메시지는 남김)
+        coachConversationRepository.save(CoachConversation.user(sessionId, userId, userMessage));
+
+        String prompt = SIMPLE_GUIDE_PROMPT.formatted(userMessage);
+        String responseText = llmClient.complete(prompt);
+
+        // COACH 응답 저장 (route는 slice 4 전까지 SIMPLE_GUIDE 고정)
+        CoachConversation coachMessage = CoachConversation.coach(
+                sessionId, userId, responseText, CoachRoute.SIMPLE_GUIDE, null
+        );
+        return coachConversationRepository.save(coachMessage);
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -4,6 +4,8 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.entity.CoachConversation;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.coach.repository.CoachConversationRepository;
+import com.back.coach.domain.context.service.AssembledContext;
+import com.back.coach.domain.context.service.ContextManagerService;
 import com.back.coach.external.llm.LlmClient;
 import com.back.coach.global.code.CoachRoute;
 import com.back.coach.global.exception.ErrorCode;
@@ -14,24 +16,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CoachMessageService {
 
-    private static final String SIMPLE_GUIDE_PROMPT = """
-            당신은 학습 코치입니다. 사용자의 질문에 짧고 실용적인 답변을 한국어로 제공합니다.
-            아직 사용자의 프로필이나 로드맵 컨텍스트는 주입되지 않았습니다 (다음 슬라이스에서 추가).
-
-            사용자 메시지: %s
-            """;
-
     private final ChatSessionRepository chatSessionRepository;
     private final CoachConversationRepository coachConversationRepository;
+    private final ContextManagerService contextManagerService;
     private final LlmClient llmClient;
 
     public CoachMessageService(
             ChatSessionRepository chatSessionRepository,
             CoachConversationRepository coachConversationRepository,
+            ContextManagerService contextManagerService,
             LlmClient llmClient
     ) {
         this.chatSessionRepository = chatSessionRepository;
         this.coachConversationRepository = coachConversationRepository;
+        this.contextManagerService = contextManagerService;
         this.llmClient = llmClient;
     }
 
@@ -48,11 +46,12 @@ public class CoachMessageService {
             throw new ServiceException(ErrorCode.SESSION_CLOSED);
         }
 
-        // USER 메시지 저장 (LLM 실패해도 사용자 메시지는 남김)
+        // USER 메시지 저장 (LLM 실패하면 트랜잭션 롤백)
         coachConversationRepository.save(CoachConversation.user(sessionId, userId, userMessage));
 
-        String prompt = SIMPLE_GUIDE_PROMPT.formatted(userMessage);
-        String responseText = llmClient.complete(prompt);
+        // 3-Tier Context 자동 조립 (활성 신호 있으면 Tier 3, 없으면 Tier 1)
+        AssembledContext context = contextManagerService.assembleAuto(session, userMessage);
+        String responseText = llmClient.complete(context.systemPrompt());
 
         // COACH 응답 저장 (route는 slice 4 전까지 SIMPLE_GUIDE 고정)
         CoachConversation coachMessage = CoachConversation.coach(

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -2,8 +2,10 @@ package com.back.coach.domain.coach.service;
 
 import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.entity.ReplanProposal;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.coach.repository.CoachConversationRepository;
+import com.back.coach.domain.coach.repository.ReplanProposalRepository;
 import com.back.coach.domain.context.service.AssembledContext;
 import com.back.coach.domain.context.service.ContextManagerService;
 import com.back.coach.external.llm.LlmClient;
@@ -13,28 +15,41 @@ import com.back.coach.global.exception.ServiceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 @Service
 public class CoachMessageService {
 
+    private static final int PROPOSAL_TTL_HOURS = 24;
+
     private final ChatSessionRepository chatSessionRepository;
     private final CoachConversationRepository coachConversationRepository;
+    private final ReplanProposalRepository replanProposalRepository;
     private final ContextManagerService contextManagerService;
+    private final CoachResponseParser responseParser;
     private final LlmClient llmClient;
 
     public CoachMessageService(
             ChatSessionRepository chatSessionRepository,
             CoachConversationRepository coachConversationRepository,
+            ReplanProposalRepository replanProposalRepository,
             ContextManagerService contextManagerService,
+            CoachResponseParser responseParser,
             LlmClient llmClient
     ) {
         this.chatSessionRepository = chatSessionRepository;
         this.coachConversationRepository = coachConversationRepository;
+        this.replanProposalRepository = replanProposalRepository;
         this.contextManagerService = contextManagerService;
+        this.responseParser = responseParser;
         this.llmClient = llmClient;
     }
 
+    public record MessageResult(CoachConversation coachMessage, ReplanProposal proposal) {}
+
     @Transactional
-    public CoachConversation sendMessage(Long userId, Long sessionId, String userMessage) {
+    public MessageResult sendMessage(Long userId, Long sessionId, String userMessage) {
         ChatSession session = chatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
 
@@ -46,17 +61,45 @@ public class CoachMessageService {
             throw new ServiceException(ErrorCode.SESSION_CLOSED);
         }
 
-        // USER 메시지 저장 (LLM 실패하면 트랜잭션 롤백)
         coachConversationRepository.save(CoachConversation.user(sessionId, userId, userMessage));
 
-        // 3-Tier Context 자동 조립 (활성 신호 있으면 Tier 3, 없으면 Tier 1)
         AssembledContext context = contextManagerService.assembleAuto(session, userMessage);
-        String responseText = llmClient.complete(context.systemPrompt());
+        String llmRaw = llmClient.complete(buildPrompt(context, userMessage));
+        CoachResponseParser.ParsedCoachResponse parsed = responseParser.parse(llmRaw);
 
-        // COACH 응답 저장 (route는 slice 4 전까지 SIMPLE_GUIDE 고정)
         CoachConversation coachMessage = CoachConversation.coach(
-                sessionId, userId, responseText, CoachRoute.SIMPLE_GUIDE, null
+                sessionId, userId, parsed.responseText(), parsed.route(), parsed.detectedIntent()
         );
-        return coachConversationRepository.save(coachMessage);
+        coachMessage = coachConversationRepository.save(coachMessage);
+
+        ReplanProposal proposal = null;
+        if (parsed.route() == CoachRoute.REPLAN_SUGGEST && parsed.replanReason() != null) {
+            proposal = replanProposalRepository.save(ReplanProposal.create(
+                    sessionId, userId, coachMessage.getId(),
+                    parsed.replanReason(),
+                    Instant.now().plus(PROPOSAL_TTL_HOURS, ChronoUnit.HOURS)
+            ));
+        }
+
+        return new MessageResult(coachMessage, proposal);
+    }
+
+    private String buildPrompt(AssembledContext context, String userMessage) {
+        return context.systemPrompt() + """
+
+                ## 응답 형식 (반드시 JSON만 출력)
+                {
+                  "route": "SIMPLE_GUIDE | REPLAN_SUGGEST | DISMISS",
+                  "responseText": "<사용자에게 보여줄 메시지>",
+                  "replanReason": "<REPLAN_SUGGEST일 때만, 재계획 필요 이유>",
+                  "detectedIntent": "<감지된 의도 (선택)>"
+                }
+
+                규칙:
+                - activeSignals가 없거나 단순 질문이면 route=SIMPLE_GUIDE
+                - activeSignals가 있고 재계획이 필요하다고 판단되면 route=REPLAN_SUGGEST
+                - 신호가 있어도 처리 불필요하면 route=DISMISS
+                - replanReason은 REPLAN_SUGGEST일 때만 작성, 나머지는 null
+                """;
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachResponseParser.java
@@ -1,0 +1,70 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.external.llm.LlmJsonResponseExtractor;
+import com.back.coach.global.code.CoachRoute;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+@Component
+public class CoachResponseParser {
+
+    private static final Logger log = LoggerFactory.getLogger(CoachResponseParser.class);
+    private static final String SCHEMA_PATH = "ai/schema/coach-response.schema.json";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JsonSchema schema = loadSchema();
+
+    public record ParsedCoachResponse(
+            CoachRoute route,
+            String responseText,
+            String replanReason,
+            String detectedIntent
+    ) {}
+
+    public ParsedCoachResponse parse(String llmJson) {
+        JsonNode root;
+        try {
+            root = mapper.readTree(LlmJsonResponseExtractor.extractJson(llmJson));
+        } catch (IOException ex) {
+            log.warn("Coach 응답 JSON 파싱 실패: {}", ex.getMessage());
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        Set<ValidationMessage> errors = schema.validate(root);
+        if (!errors.isEmpty()) {
+            log.warn("Coach 응답 schema 위반: {}", errors);
+            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+        }
+
+        CoachRoute route = CoachRoute.valueOf(root.get("route").asText());
+        String responseText = root.get("responseText").asText();
+        String replanReason = root.has("replanReason") && !root.get("replanReason").isNull()
+                ? root.get("replanReason").asText() : null;
+        String detectedIntent = root.has("detectedIntent") && !root.get("detectedIntent").isNull()
+                ? root.get("detectedIntent").asText() : null;
+
+        return new ParsedCoachResponse(route, responseText, replanReason, detectedIntent);
+    }
+
+    private JsonSchema loadSchema() {
+        try (InputStream is = new ClassPathResource(SCHEMA_PATH).getInputStream()) {
+            return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(is);
+        } catch (IOException e) {
+            throw new IllegalStateException("coach-response schema 로드 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
@@ -1,0 +1,69 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+public class CoachSessionService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final UserContextSnapshotRepository contextSnapshotRepository;
+
+    public CoachSessionService(
+            ChatSessionRepository chatSessionRepository,
+            UserContextSnapshotRepository contextSnapshotRepository
+    ) {
+        this.chatSessionRepository = chatSessionRepository;
+        this.contextSnapshotRepository = contextSnapshotRepository;
+    }
+
+    @Transactional
+    public ChatSession startSession(Long userId) {
+        UserContextSnapshot profileSnapshot = contextSnapshotRepository
+                .findActiveByUserIdAndContextType(userId, ContextType.PROFILE)
+                .orElseThrow(() -> new ServiceException(
+                        ErrorCode.SNAPSHOT_NOT_FOUND,
+                        "PROFILE snapshot이 없습니다. 프로필을 먼저 저장해주세요."
+                ));
+
+        UserContextSnapshot planSnapshot = contextSnapshotRepository
+                .findActiveByUserIdAndContextType(userId, ContextType.PLAN)
+                .orElseThrow(() -> new ServiceException(
+                        ErrorCode.SNAPSHOT_NOT_FOUND,
+                        "PLAN snapshot이 없습니다. 로드맵을 먼저 생성해주세요."
+                ));
+
+        ChatSession session = ChatSession.start(
+                userId,
+                profileSnapshot.getVersion(),
+                planSnapshot.getVersion()
+        );
+
+        return chatSessionRepository.save(session);
+    }
+
+    @Transactional
+    public void closeSession(Long userId, Long sessionId) {
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isOwnedBy(userId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+
+        if (session.isClosed()) {
+            return;
+        }
+
+        session.close(Instant.now());
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/service/ReplanService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/ReplanService.java
@@ -1,0 +1,106 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.AgentEvent;
+import com.back.coach.domain.coach.entity.ReplanProposal;
+import com.back.coach.domain.coach.repository.AgentEventRepository;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.coach.repository.ReplanProposalRepository;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.service.RoadmapCommandService;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+public class ReplanService {
+
+    private final ReplanProposalRepository replanProposalRepository;
+    private final ChatSessionRepository chatSessionRepository;
+    private final DetectedPatternRepository detectedPatternRepository;
+    private final CapabilityDiagnosisRepository diagnosisRepository;
+    private final AgentEventRepository agentEventRepository;
+    private final RoadmapCommandService roadmapCommandService;
+
+    public ReplanService(
+            ReplanProposalRepository replanProposalRepository,
+            ChatSessionRepository chatSessionRepository,
+            DetectedPatternRepository detectedPatternRepository,
+            CapabilityDiagnosisRepository diagnosisRepository,
+            AgentEventRepository agentEventRepository,
+            RoadmapCommandService roadmapCommandService
+    ) {
+        this.replanProposalRepository = replanProposalRepository;
+        this.chatSessionRepository = chatSessionRepository;
+        this.detectedPatternRepository = detectedPatternRepository;
+        this.diagnosisRepository = diagnosisRepository;
+        this.agentEventRepository = agentEventRepository;
+        this.roadmapCommandService = roadmapCommandService;
+    }
+
+    public record ReplanResult(String newRoadmapId, Integer newRoadmapVersion) {}
+
+    @Transactional
+    public ReplanResult confirm(Long userId, Long sessionId, Long proposalId) {
+        ReplanProposal proposal = loadValidProposal(userId, proposalId);
+
+        // 최신 진단으로 새 로드맵 생성
+        CapabilityDiagnosis diagnosis = diagnosisRepository
+                .findTopByUserIdOrderByVersionDescCreatedAtDesc(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND,
+                        "재계획을 위한 진단 결과가 없습니다."));
+
+        RoadmapRequest roadmapRequest = new RoadmapRequest(
+                diagnosis.getId(), null, null, null, null
+        );
+
+        RoadmapDetailResponse newRoadmap;
+        try {
+            newRoadmap = roadmapCommandService.createRoadmap(userId, roadmapRequest);
+        } catch (Exception e) {
+            throw new ServiceException(ErrorCode.PLANNER_FAILED, e.getMessage());
+        }
+
+        Instant now = Instant.now();
+        proposal.confirm(now);
+        detectedPatternRepository.markAllProcessedByUserId(userId, now);
+
+        // AgentEvent 기록
+        agentEventRepository.save(AgentEvent.replanRequested(
+                userId, sessionId,
+                "{\"proposalId\":" + proposalId + ",\"newRoadmapId\":" + newRoadmap.roadmapId() + "}"
+        ));
+
+        return new ReplanResult(newRoadmap.roadmapId(), newRoadmap.version());
+    }
+
+    @Transactional
+    public void dismiss(Long userId, Long proposalId) {
+        ReplanProposal proposal = loadValidProposal(userId, proposalId);
+        proposal.dismiss(Instant.now());
+
+        detectedPatternRepository.markAllProcessedByUserId(userId, Instant.now());
+    }
+
+    private ReplanProposal loadValidProposal(Long userId, Long proposalId) {
+        ReplanProposal proposal = replanProposalRepository.findById(proposalId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.PROPOSAL_NOT_FOUND));
+
+        if (!proposal.getUserId().equals(userId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+
+        if (!proposal.isPending() || proposal.isExpired()) {
+            throw new ServiceException(ErrorCode.PROPOSAL_EXPIRED);
+        }
+
+        return proposal;
+    }
+
+}

--- a/backend/src/main/java/com/back/coach/domain/context/repository/UserContextSnapshotRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/context/repository/UserContextSnapshotRepository.java
@@ -20,6 +20,12 @@ public interface UserContextSnapshotRepository extends JpaRepository<UserContext
             ContextType contextType
     );
 
+    Optional<UserContextSnapshot> findByUserIdAndContextTypeAndVersion(
+            Long userId,
+            ContextType contextType,
+            Integer version
+    );
+
     default Optional<UserContextSnapshot> findActiveByUserIdAndContextType(Long userId, ContextType contextType) {
         return findTopByUserIdAndContextTypeAndValidToIsNullOrderByVersionDesc(userId, contextType);
     }

--- a/backend/src/main/java/com/back/coach/domain/context/service/AssembledContext.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/AssembledContext.java
@@ -1,0 +1,17 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.global.code.CoachTemplate;
+
+/**
+ * Context Manager가 조립한 시스템 프롬프트와 사용 메타데이터.
+ *
+ * @param systemPrompt LLM에 전달할 system instruction
+ * @param template     사용된 템플릿 (Tier 결정의 근거)
+ * @param activeSignalCount 미처리 detected_patterns 수 (자동 승격 판단용)
+ */
+public record AssembledContext(
+        String systemPrompt,
+        CoachTemplate template,
+        int activeSignalCount
+) {
+}

--- a/backend/src/main/java/com/back/coach/domain/context/service/ContextManagerService.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/ContextManagerService.java
@@ -1,0 +1,121 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.global.code.CoachTemplate;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Coach 호출 시 사용자 상태를 시스템 프롬프트로 조립한다.
+ *
+ * <p>3-Tier 정책 (docs/17_v2_context_tier_assembly.md):
+ * <ul>
+ *   <li>Tier 1 — PROFILE + PLAN snapshot (오늘 할 일, 현재 주차)</li>
+ *   <li>Tier 3 — Tier 1 + 활성 신호 + 최근 대화 맥락 (재계획/재분석 판단)</li>
+ * </ul>
+ *
+ * <p>세션의 고정 version 기준으로 PROFILE/PLAN snapshot을 로드한다.
+ * 활성 신호는 detected_patterns 미처리 row에서 직접 추출한다 (CONVERSATION snapshot
+ * 조립 파이프라인이 완성되기 전 임시 폴백).
+ */
+@Service
+@Transactional(readOnly = true)
+public class ContextManagerService {
+
+    private final UserContextSnapshotRepository contextSnapshotRepository;
+    private final DetectedPatternRepository detectedPatternRepository;
+
+    public ContextManagerService(
+            UserContextSnapshotRepository contextSnapshotRepository,
+            DetectedPatternRepository detectedPatternRepository
+    ) {
+        this.contextSnapshotRepository = contextSnapshotRepository;
+        this.detectedPatternRepository = detectedPatternRepository;
+    }
+
+    /**
+     * 자동 템플릿 선택: 활성 신호가 있으면 Tier 3, 없으면 Tier 1.
+     */
+    public AssembledContext assembleAuto(ChatSession session, String userMessage) {
+        List<DetectedPattern> activeSignals = detectedPatternRepository
+                .findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(session.getUserId());
+        CoachTemplate template = activeSignals.isEmpty()
+                ? CoachTemplate.COACH_LIGHTWEIGHT
+                : CoachTemplate.COACH_FULL_CONTEXT;
+        return assemble(session, template, userMessage, activeSignals);
+    }
+
+    /**
+     * 명시 템플릿으로 조립.
+     */
+    public AssembledContext assemble(ChatSession session, CoachTemplate template, String userMessage) {
+        List<DetectedPattern> activeSignals = template == CoachTemplate.COACH_FULL_CONTEXT
+                ? detectedPatternRepository.findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(session.getUserId())
+                : List.of();
+        return assemble(session, template, userMessage, activeSignals);
+    }
+
+    private AssembledContext assemble(
+            ChatSession session,
+            CoachTemplate template,
+            String userMessage,
+            List<DetectedPattern> activeSignals
+    ) {
+        UserContextSnapshot profile = loadPinned(session.getUserId(), ContextType.PROFILE, session.getProfileVersion());
+        UserContextSnapshot plan = loadPinned(session.getUserId(), ContextType.PLAN, session.getRoadmapVersion());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("당신은 학습 코치입니다. 사용자의 질문에 짧고 실용적인 답변을 한국어로 제공합니다.\n\n");
+
+        sb.append("# 사용자 프로필 (version ").append(profile.getVersion()).append(")\n");
+        sb.append(profile.getPayload()).append("\n\n");
+
+        sb.append("# 학습 로드맵 (version ").append(plan.getVersion()).append(")\n");
+        sb.append(plan.getPayload()).append("\n\n");
+
+        if (template == CoachTemplate.COACH_FULL_CONTEXT) {
+            sb.append("# 활성 신호 (Pattern Detector 미처리)\n");
+            if (activeSignals.isEmpty()) {
+                sb.append("없음\n\n");
+            } else {
+                for (DetectedPattern signal : activeSignals) {
+                    sb.append("- type=").append(signal.getPatternType())
+                            .append(", severity=").append(signal.getSeverity())
+                            .append(", metadata=").append(signal.getMetadata())
+                            .append("\n");
+                }
+                sb.append("\n");
+            }
+
+            // 최근 대화 요약(CONVERSATION snapshot)은 있으면 포함, 없으면 생략
+            Optional<UserContextSnapshot> conversation = contextSnapshotRepository
+                    .findActiveByUserIdAndContextType(session.getUserId(), ContextType.CONVERSATION);
+            conversation.ifPresent(snap -> {
+                sb.append("# 최근 대화 요약 (version ").append(snap.getVersion()).append(")\n");
+                sb.append(snap.getPayload()).append("\n\n");
+            });
+        }
+
+        sb.append("# 사용자 메시지\n").append(userMessage).append("\n");
+
+        return new AssembledContext(sb.toString(), template, activeSignals.size());
+    }
+
+    private UserContextSnapshot loadPinned(Long userId, ContextType type, Integer version) {
+        return contextSnapshotRepository.findByUserIdAndContextTypeAndVersion(userId, type, version)
+                .orElseThrow(() -> new ServiceException(
+                        ErrorCode.SNAPSHOT_NOT_FOUND,
+                        "세션에 고정된 " + type + " snapshot version=" + version + " 을(를) 찾을 수 없습니다."
+                ));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/pattern/repository/DetectedPatternRepository.java
@@ -21,6 +21,10 @@ public interface DetectedPatternRepository extends JpaRepository<DetectedPattern
 
     Optional<DetectedPattern> findByIdAndUserId(Long id, Long userId);
 
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query("UPDATE DetectedPattern p SET p.processedAt = :processedAt WHERE p.userId = :userId AND p.processedAt IS NULL")
+    int markAllProcessedByUserId(@Param("userId") Long userId, @Param("processedAt") java.time.Instant processedAt);
+
     @Query(value = """
             SELECT *
             FROM detected_patterns

--- a/backend/src/main/java/com/back/coach/global/code/ChatSessionStatus.java
+++ b/backend/src/main/java/com/back/coach/global/code/ChatSessionStatus.java
@@ -1,0 +1,11 @@
+package com.back.coach.global.code;
+
+public enum ChatSessionStatus implements CodeEnum {
+    ACTIVE,
+    CLOSED;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/CoachMessageRole.java
+++ b/backend/src/main/java/com/back/coach/global/code/CoachMessageRole.java
@@ -1,0 +1,12 @@
+package com.back.coach.global.code;
+
+public enum CoachMessageRole implements CodeEnum {
+    USER,
+    COACH,
+    SUMMARY;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/CoachRoute.java
+++ b/backend/src/main/java/com/back/coach/global/code/CoachRoute.java
@@ -1,0 +1,13 @@
+package com.back.coach.global.code;
+
+public enum CoachRoute implements CodeEnum {
+    SIMPLE_GUIDE,
+    REPLAN_SUGGEST,
+    REPLAN_EXECUTE,
+    DISMISS;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/CoachTemplate.java
+++ b/backend/src/main/java/com/back/coach/global/code/CoachTemplate.java
@@ -1,0 +1,20 @@
+package com.back.coach.global.code;
+
+/**
+ * Coach 처리 상황별 use-case 템플릿.
+ *
+ * <p>3-Tier(읽는 정보량)와 별도. docs/17_v2_context_tier_assembly.md 참조.
+ */
+public enum CoachTemplate implements CodeEnum {
+
+    /** Tier 1 — 가벼운 기본 상태. 오늘 할 일, 현재 주차 등. */
+    COACH_LIGHTWEIGHT,
+
+    /** Tier 3 — 판단 맥락까지. 재계획/재분석 판단 시. */
+    COACH_FULL_CONTEXT;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/code/ReplanProposalStatus.java
+++ b/backend/src/main/java/com/back/coach/global/code/ReplanProposalStatus.java
@@ -1,0 +1,10 @@
+package com.back.coach.global.code;
+
+public enum ReplanProposalStatus implements CodeEnum {
+    PENDING, CONFIRMED, DISMISSED, EXPIRED;
+
+    @Override
+    public String code() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/back/coach/global/exception/ErrorCode.java
@@ -43,7 +43,10 @@ public enum ErrorCode {
     // Coach
     SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "활성화된 컨텍스트 스냅샷이 없습니다. 프로필과 로드맵을 먼저 생성해주세요."),
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다."),
-    SESSION_CLOSED(HttpStatus.CONFLICT, "이미 종료된 세션입니다.");
+    SESSION_CLOSED(HttpStatus.CONFLICT, "이미 종료된 세션입니다."),
+    PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "재계획 제안을 찾을 수 없습니다."),
+    PROPOSAL_EXPIRED(HttpStatus.GONE, "재계획 제안이 만료됐거나 이미 처리됐습니다."),
+    PLANNER_FAILED(HttpStatus.BAD_GATEWAY, "로드맵 재생성에 실패했습니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/backend/src/main/java/com/back/coach/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/back/coach/global/exception/ErrorCode.java
@@ -38,7 +38,12 @@ public enum ErrorCode {
     GITHUB_API_ERROR(HttpStatus.BAD_GATEWAY, "GitHub API 오류가 발생했습니다."),
 
     // Pattern Detector
-    PATTERN_DETECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "패턴 감지 중 오류가 발생했습니다.");
+    PATTERN_DETECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "패턴 감지 중 오류가 발생했습니다."),
+
+    // Coach
+    SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "활성화된 컨텍스트 스냅샷이 없습니다. 프로필과 로드맵을 먼저 생성해주세요."),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다."),
+    SESSION_CLOSED(HttpStatus.CONFLICT, "이미 종료된 세션입니다.");
 
     private final HttpStatus status;
     private final String defaultMessage;

--- a/backend/src/main/resources/ai/schema/coach-response.schema.json
+++ b/backend/src/main/resources/ai/schema/coach-response.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CoachResponse",
+  "type": "object",
+  "required": ["route", "responseText"],
+  "additionalProperties": false,
+  "properties": {
+    "route": {
+      "type": "string",
+      "enum": ["SIMPLE_GUIDE", "REPLAN_SUGGEST", "DISMISS"]
+    },
+    "responseText": {
+      "type": "string",
+      "minLength": 1
+    },
+    "replanReason": {
+      "type": ["string", "null"]
+    },
+    "detectedIntent": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -95,9 +95,11 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("USER 메시지 전송 시 USER/COACH 두 행이 저장되고 COACH는 SIMPLE_GUIDE 라우트")
     void sendMessageStoresUserAndCoachRows() {
-        given(llmClient.complete(anyString())).willReturn("이번 주는 Redis 캐시부터 학습하세요.");
+        given(llmClient.complete(anyString())).willReturn(
+                "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
+        );
 
-        CoachConversation coachMessage = coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
+        CoachConversation coachMessage = coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?").coachMessage();
 
         assertThat(coachMessage.getRole()).isEqualTo(CoachMessageRole.COACH);
         assertThat(coachMessage.getRoute()).isEqualTo(CoachRoute.SIMPLE_GUIDE);

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -4,7 +4,9 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.entity.CoachConversation;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.coach.repository.CoachConversationRepository;
+import com.back.coach.domain.context.entity.UserContextSnapshot;
 import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.global.code.ContextType;
 import com.back.coach.domain.user.entity.User;
 import com.back.coach.domain.user.repository.UserRepository;
 import com.back.coach.external.llm.LlmClient;
@@ -59,6 +61,14 @@ class CoachMessageServiceIntegrationTest {
                 User.signupFromOAuth(AuthProvider.GITHUB, "gh-coach-msg-" + System.nanoTime(), "msg@test.com")
         );
         userId = user.getId();
+
+        // Slice 3 ContextManager가 PROFILE/PLAN snapshot을 version 기준으로 로드하므로 시드 필요
+        contextSnapshotRepository.save(UserContextSnapshot.create(
+                userId, ContextType.PROFILE, 1, "{\"goal\":\"test\"}", Instant.now()
+        ));
+        contextSnapshotRepository.save(UserContextSnapshot.create(
+                userId, ContextType.PLAN, 1, "{\"weeks\":[]}", Instant.now()
+        ));
 
         ChatSession session = ChatSession.start(userId, 1, 1);
         sessionId = chatSessionRepository.save(session).getId();

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.coach.repository.CoachConversationRepository;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.external.llm.LlmClient;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.CoachMessageRole;
+import com.back.coach.global.code.CoachRoute;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@IntegrationTest
+class CoachMessageServiceIntegrationTest {
+
+    @Autowired
+    private CoachMessageService coachMessageService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private CoachConversationRepository coachConversationRepository;
+
+    @Autowired
+    private UserContextSnapshotRepository contextSnapshotRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private LlmClient llmClient;
+
+    private Long userId;
+    private Long sessionId;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "gh-coach-msg-" + System.nanoTime(), "msg@test.com")
+        );
+        userId = user.getId();
+
+        ChatSession session = ChatSession.start(userId, 1, 1);
+        sessionId = chatSessionRepository.save(session).getId();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        coachConversationRepository.deleteAll(
+                coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)
+        );
+        chatSessionRepository.deleteAll(
+                chatSessionRepository.findAll().stream()
+                        .filter(s -> s.getUserId().equals(userId))
+                        .toList()
+        );
+        contextSnapshotRepository.deleteAll(
+                contextSnapshotRepository.findAll().stream()
+                        .filter(s -> s.getUserId().equals(userId))
+                        .toList()
+        );
+        userRepository.deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("USER 메시지 전송 시 USER/COACH 두 행이 저장되고 COACH는 SIMPLE_GUIDE 라우트")
+    void sendMessageStoresUserAndCoachRows() {
+        given(llmClient.complete(anyString())).willReturn("이번 주는 Redis 캐시부터 학습하세요.");
+
+        CoachConversation coachMessage = coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
+
+        assertThat(coachMessage.getRole()).isEqualTo(CoachMessageRole.COACH);
+        assertThat(coachMessage.getRoute()).isEqualTo(CoachRoute.SIMPLE_GUIDE);
+        assertThat(coachMessage.getMessageText()).contains("Redis");
+
+        List<CoachConversation> rows = coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).getRole()).isEqualTo(CoachMessageRole.USER);
+        assertThat(rows.get(0).getMessageText()).isEqualTo("오늘 뭐 공부할까?");
+        assertThat(rows.get(1).getRole()).isEqualTo(CoachMessageRole.COACH);
+    }
+
+    @Test
+    @DisplayName("닫힌 세션에 메시지 보내면 SESSION_CLOSED")
+    void closedSessionRejectsMessage() {
+        ChatSession session = chatSessionRepository.findById(sessionId).orElseThrow();
+        session.close(Instant.now());
+        chatSessionRepository.save(session);
+
+        assertThatThrownBy(() -> coachMessageService.sendMessage(userId, sessionId, "hello"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_CLOSED);
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 세션에 메시지 보내면 FORBIDDEN")
+    void otherUserCannotSendMessage() {
+        Long otherUserId = userId + 99999L;
+        assertThatThrownBy(() -> coachMessageService.sendMessage(otherUserId, sessionId, "hello"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 sessionId에 보내면 SESSION_NOT_FOUND")
+    void nonexistentSessionFails() {
+        assertThatThrownBy(() -> coachMessageService.sendMessage(userId, 999_999_999L, "hello"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("LLM 실패 시 USER 메시지는 저장되지만 COACH 행은 생성되지 않음")
+    void llmFailureLeavesOnlyUserMessage() {
+        given(llmClient.complete(anyString())).willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
+
+        assertThatThrownBy(() -> coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_TIMEOUT);
+
+        List<CoachConversation> rows = coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        // @Transactional로 묶여 있어 USER 행도 롤백됨 — 시도-기록 둘 다 안 남는 게 안전
+        assertThat(rows).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -1,0 +1,154 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.ChatSessionStatus;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class CoachSessionServiceIntegrationTest {
+
+    @Autowired
+    private CoachSessionService coachSessionService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private UserContextSnapshotRepository contextSnapshotRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long userId;
+
+    @BeforeEach
+    void seedUser() {
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "gh-coach-session-" + System.nanoTime(), "coach-session@test.com")
+        );
+        userId = user.getId();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        chatSessionRepository.deleteAll(chatSessionRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList());
+        contextSnapshotRepository.deleteAll(contextSnapshotRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList());
+        userRepository.deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("active PROFILE/PLAN snapshot이 모두 있으면 세션이 시작된다")
+    void startsSessionWithBothActiveSnapshots() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 2);
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        assertThat(session.getId()).isNotNull();
+        assertThat(session.getProfileVersion()).isEqualTo(1);
+        assertThat(session.getRoadmapVersion()).isEqualTo(2);
+        assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
+        assertThat(session.getStartedAt()).isNotNull();
+        assertThat(session.getEndedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("PROFILE snapshot이 없으면 SNAPSHOT_NOT_FOUND")
+    void failsWhenProfileSnapshotMissing() {
+        seedSnapshot(ContextType.PLAN, 1);
+
+        assertThatThrownBy(() -> coachSessionService.startSession(userId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SNAPSHOT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("PLAN snapshot이 없으면 SNAPSHOT_NOT_FOUND")
+    void failsWhenPlanSnapshotMissing() {
+        seedSnapshot(ContextType.PROFILE, 1);
+
+        assertThatThrownBy(() -> coachSessionService.startSession(userId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SNAPSHOT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("세션 종료 시 status=CLOSED, ended_at 기록")
+    void closeSessionMarksClosedAndEnded() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession session = coachSessionService.startSession(userId);
+
+        coachSessionService.closeSession(userId, session.getId());
+
+        ChatSession reloaded = chatSessionRepository.findById(session.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChatSessionStatus.CLOSED);
+        assertThat(reloaded.getEndedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 세션을 종료하려 하면 FORBIDDEN")
+    void closeSessionByOtherUserForbidden() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession session = coachSessionService.startSession(userId);
+
+        Long otherUserId = userId + 99999L;
+
+        assertThatThrownBy(() -> coachSessionService.closeSession(otherUserId, session.getId()))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 sessionId 종료 시 SESSION_NOT_FOUND")
+    void closeNonexistentSession() {
+        assertThatThrownBy(() -> coachSessionService.closeSession(userId, 999_999_999L))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 종료된 세션 재종료해도 에러 없이 멱등")
+    void closeAlreadyClosedSessionIsIdempotent() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession session = coachSessionService.startSession(userId);
+
+        coachSessionService.closeSession(userId, session.getId());
+        coachSessionService.closeSession(userId, session.getId());
+
+        ChatSession reloaded = chatSessionRepository.findById(session.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChatSessionStatus.CLOSED);
+    }
+
+    private void seedSnapshot(ContextType type, int version) {
+        UserContextSnapshot snapshot = UserContextSnapshot.create(
+                userId, type, version, "{}", Instant.now()
+        );
+        contextSnapshotRepository.save(snapshot);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/coach/service/ReplanServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/ReplanServiceIntegrationTest.java
@@ -1,0 +1,220 @@
+package com.back.coach.domain.coach.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.entity.ReplanProposal;
+import com.back.coach.domain.coach.repository.AgentEventRepository;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.coach.repository.ReplanProposalRepository;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
+import com.back.coach.domain.roadmap.dto.RoadmapRequest;
+import com.back.coach.domain.roadmap.service.RoadmapCommandService;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.ReplanProposalStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@IntegrationTest
+class ReplanServiceIntegrationTest {
+
+    @Autowired
+    private ReplanService replanService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private ReplanProposalRepository replanProposalRepository;
+
+    @Autowired
+    private AgentEventRepository agentEventRepository;
+
+    @Autowired
+    private DetectedPatternRepository detectedPatternRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @MockitoBean
+    private RoadmapCommandService roadmapCommandService;
+
+    private Long userId;
+    private Long sessionId;
+    private Long proposalId;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "gh-replan-" + System.nanoTime(), "replan@test.com")
+        );
+        userId = user.getId();
+
+        // 최신 진단이 있어야 confirm 가능 — 최소 행 삽입
+        Long jobRoleId = jdbc.queryForObject(
+                "SELECT id FROM job_roles WHERE role_code = 'BACKEND_DEVELOPER'", Long.class);
+        Long profileId = jdbc.queryForObject("""
+                INSERT INTO user_profiles (user_id, job_role_id, current_level)
+                VALUES (?, ?, 'JUNIOR') RETURNING id
+                """, Long.class, userId, jobRoleId);
+        Long connId = jdbc.queryForObject("""
+                INSERT INTO github_connections (user_id, github_user_id, github_login, access_type)
+                VALUES (?, 'r-gh', 'r-login', 'OAUTH') RETURNING id
+                """, Long.class, userId);
+        Long analysisId = jdbc.queryForObject("""
+                INSERT INTO github_analyses (user_id, github_connection_id, version, summary)
+                VALUES (?, ?, 1, 's') RETURNING id
+                """, Long.class, userId, connId);
+        jdbc.update("""
+                INSERT INTO capability_diagnoses
+                    (user_id, profile_id, github_analysis_id, job_role_id, version, current_level, summary)
+                VALUES (?, ?, ?, ?, 1, 'JUNIOR', 's')
+                """, userId, profileId, analysisId, jobRoleId);
+
+        ChatSession session = ChatSession.start(userId, 1, 1);
+        sessionId = chatSessionRepository.save(session).getId();
+
+        ReplanProposal proposal = ReplanProposal.create(
+                sessionId, userId, null,
+                "3일 연속 Redis 미달성",
+                Instant.now().plus(24, ChronoUnit.HOURS)
+        );
+        proposalId = replanProposalRepository.save(proposal).getId();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        agentEventRepository.deleteAll(agentEventRepository.findAll().stream()
+                .filter(e -> e.getUserId().equals(userId)).toList());
+        jdbc.update("DELETE FROM detected_patterns WHERE user_id = ?", userId);
+        replanProposalRepository.deleteAll(replanProposalRepository.findAll().stream()
+                .filter(p -> p.getUserId().equals(userId)).toList());
+        chatSessionRepository.deleteAll(chatSessionRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId)).toList());
+        userRepository.deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("confirmed=true: 새 로드맵 생성, 제안 CONFIRMED, AgentEvent 기록")
+    void confirmCreatesNewRoadmapAndMarksProposal() {
+        given(roadmapCommandService.createRoadmap(eq(userId), any(RoadmapRequest.class)))
+                .willReturn(new RoadmapDetailResponse("99", 2, 4, "재계획 로드맵",
+                        Instant.now(), List.of()));
+
+        ReplanService.ReplanResult result = replanService.confirm(userId, sessionId, proposalId);
+
+        assertThat(result.newRoadmapId()).isEqualTo("99");
+        assertThat(result.newRoadmapVersion()).isEqualTo(2);
+
+        ReplanProposal updated = replanProposalRepository.findById(proposalId).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReplanProposalStatus.CONFIRMED);
+        assertThat(updated.getResolvedAt()).isNotNull();
+
+        long agentEvents = agentEventRepository.findAll().stream()
+                .filter(e -> e.getUserId().equals(userId)).count();
+        assertThat(agentEvents).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("confirmed=true + 미처리 패턴이 있으면 processed_at 마킹")
+    void confirmMarksUnprocessedPatterns() {
+        seedDetectedPattern();
+        given(roadmapCommandService.createRoadmap(eq(userId), any(RoadmapRequest.class)))
+                .willReturn(new RoadmapDetailResponse("99", 2, 4, "s", Instant.now(), List.of()));
+
+        replanService.confirm(userId, sessionId, proposalId);
+
+        long unprocessed = detectedPatternRepository
+                .findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(userId).size();
+        assertThat(unprocessed).isZero();
+    }
+
+    @Test
+    @DisplayName("confirmed=false: 제안 DISMISSED, 미처리 패턴 processed_at 마킹")
+    void dismissMarksDismissedAndProcessesPatterns() {
+        seedDetectedPattern();
+
+        replanService.dismiss(userId, proposalId);
+
+        ReplanProposal updated = replanProposalRepository.findById(proposalId).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(ReplanProposalStatus.DISMISSED);
+        assertThat(updated.getResolvedAt()).isNotNull();
+
+        long unprocessed = detectedPatternRepository
+                .findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(userId).size();
+        assertThat(unprocessed).isZero();
+    }
+
+    @Test
+    @DisplayName("만료된 proposal은 PROPOSAL_EXPIRED")
+    void expiredProposalThrows() {
+        ReplanProposal expired = ReplanProposal.create(
+                sessionId, userId, null, "reason",
+                Instant.now().minus(1, ChronoUnit.HOURS)
+        );
+        Long expiredId = replanProposalRepository.save(expired).getId();
+
+        assertThatThrownBy(() -> replanService.confirm(userId, sessionId, expiredId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROPOSAL_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("이미 처리된 proposal은 PROPOSAL_EXPIRED")
+    void alreadyProcessedProposalThrows() {
+        ReplanProposal proposal = replanProposalRepository.findById(proposalId).orElseThrow();
+        proposal.dismiss(Instant.now());
+        replanProposalRepository.save(proposal);
+
+        assertThatThrownBy(() -> replanService.confirm(userId, sessionId, proposalId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROPOSAL_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 proposal 접근 시 FORBIDDEN")
+    void otherUserProposalForbidden() {
+        Long otherUserId = userId + 99999L;
+
+        assertThatThrownBy(() -> replanService.confirm(otherUserId, sessionId, proposalId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 proposalId는 PROPOSAL_NOT_FOUND")
+    void nonexistentProposalThrows() {
+        assertThatThrownBy(() -> replanService.confirm(userId, sessionId, 999_999_999L))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROPOSAL_NOT_FOUND);
+    }
+
+    private void seedDetectedPattern() {
+        jdbc.update("""
+                INSERT INTO detected_patterns (user_id, pattern_type, severity, metadata, idempotency_key)
+                VALUES (?, 'REPEATED_INCOMPLETE', 'MEDIUM', '{}', ?)
+                """, userId, "test-" + System.nanoTime());
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
@@ -1,0 +1,187 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.repository.ChatSessionRepository;
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.pattern.entity.DetectedPattern;
+import com.back.coach.domain.pattern.repository.DetectedPatternRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.CoachTemplate;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.global.code.PatternSeverity;
+import com.back.coach.global.code.PatternType;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class ContextManagerServiceIntegrationTest {
+
+    @Autowired
+    private ContextManagerService contextManagerService;
+
+    @Autowired
+    private ChatSessionRepository chatSessionRepository;
+
+    @Autowired
+    private UserContextSnapshotRepository contextSnapshotRepository;
+
+    @Autowired
+    private DetectedPatternRepository detectedPatternRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    private Long userId;
+
+    @BeforeEach
+    void seedUser() {
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB, "gh-ctxmgr-" + System.nanoTime(), "ctxmgr@test.com")
+        );
+        userId = user.getId();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        jdbc.update("DELETE FROM detected_patterns WHERE user_id = ?", userId);
+        chatSessionRepository.deleteAll(chatSessionRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList());
+        contextSnapshotRepository.deleteAll(contextSnapshotRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList());
+        userRepository.deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("Tier 1: PROFILE/PLAN snapshot만 포함, 활성 신호 섹션 없음")
+    void tier1ContainsProfileAndPlanOnly() {
+        seedSnapshot(ContextType.PROFILE, 1, "{\"job\":\"BACKEND\"}");
+        seedSnapshot(ContextType.PLAN, 1, "{\"weeks\":4}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assemble(
+                session, CoachTemplate.COACH_LIGHTWEIGHT, "오늘 뭐 공부해?"
+        );
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_LIGHTWEIGHT);
+        assertThat(ctx.systemPrompt()).contains("# 사용자 프로필");
+        assertThat(ctx.systemPrompt()).contains("BACKEND");
+        assertThat(ctx.systemPrompt()).contains("# 학습 로드맵");
+        assertThat(ctx.systemPrompt()).doesNotContain("# 활성 신호");
+        assertThat(ctx.systemPrompt()).contains("# 사용자 메시지").contains("오늘 뭐 공부해?");
+    }
+
+    @Test
+    @DisplayName("Tier 3: Tier 1 + 활성 신호 섹션 포함")
+    void tier3IncludesActiveSignals() {
+        seedSnapshot(ContextType.PROFILE, 2, "{}");
+        seedSnapshot(ContextType.PLAN, 3, "{}");
+        seedDetectedPattern(PatternType.REPEATED_INCOMPLETE, PatternSeverity.MEDIUM,
+                "{\"count\":3,\"targetType\":\"roadmap_week\",\"targetId\":12}");
+        ChatSession session = startSession(2, 3);
+
+        AssembledContext ctx = contextManagerService.assemble(
+                session, CoachTemplate.COACH_FULL_CONTEXT, "재계획 필요해?"
+        );
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_FULL_CONTEXT);
+        assertThat(ctx.activeSignalCount()).isEqualTo(1);
+        assertThat(ctx.systemPrompt()).contains("# 활성 신호");
+        assertThat(ctx.systemPrompt()).contains("REPEATED_INCOMPLETE");
+        assertThat(ctx.systemPrompt()).contains("MEDIUM");
+    }
+
+    @Test
+    @DisplayName("자동 선택: 활성 신호 없으면 Tier 1")
+    void assembleAutoChoosesTier1WhenNoActiveSignal() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assembleAuto(session, "hello");
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_LIGHTWEIGHT);
+        assertThat(ctx.activeSignalCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("자동 선택: 활성 신호 있으면 Tier 3")
+    void assembleAutoChoosesTier3WhenActiveSignalExists() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+        seedDetectedPattern(PatternType.SKILL_REPEATED_FAILURE, PatternSeverity.HIGH, "{}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assembleAuto(session, "hello");
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_FULL_CONTEXT);
+        assertThat(ctx.activeSignalCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("세션 고정 version 기준으로 조립 — active와 다른 version도 정확히 로드")
+    void assemblesByPinnedVersionNotActive() {
+        // version 1, 2가 모두 존재. active는 v2지만 세션은 v1으로 고정.
+        seedSnapshot(ContextType.PROFILE, 1, "{\"v\":\"old\"}");
+        seedSnapshot(ContextType.PROFILE, 2, "{\"v\":\"new\"}");
+        seedSnapshot(ContextType.PLAN, 1, "{\"weeks\":4}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assemble(
+                session, CoachTemplate.COACH_LIGHTWEIGHT, "hello"
+        );
+
+        assertThat(ctx.systemPrompt()).contains("\"old\"");
+        assertThat(ctx.systemPrompt()).doesNotContain("\"new\"");
+    }
+
+    @Test
+    @DisplayName("고정된 version의 snapshot이 없으면 SNAPSHOT_NOT_FOUND")
+    void missingPinnedSnapshotThrows() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        // PLAN version=1 없음
+        ChatSession session = startSession(1, 1);
+
+        assertThatThrownBy(() -> contextManagerService.assemble(
+                session, CoachTemplate.COACH_LIGHTWEIGHT, "hello"
+        ))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SNAPSHOT_NOT_FOUND);
+    }
+
+    private void seedSnapshot(ContextType type, int version, String payload) {
+        contextSnapshotRepository.save(UserContextSnapshot.create(
+                userId, type, version, payload, Instant.now()
+        ));
+    }
+
+    private void seedDetectedPattern(PatternType type, PatternSeverity severity, String metadata) {
+        jdbc.update("""
+                INSERT INTO detected_patterns (user_id, pattern_type, severity, metadata, idempotency_key)
+                VALUES (?, ?, ?, ?::jsonb, ?)
+                """, userId, type.name(), severity.name(), metadata, "test-" + System.nanoTime());
+    }
+
+    private ChatSession startSession(int profileVersion, int planVersion) {
+        return chatSessionRepository.save(ChatSession.start(userId, profileVersion, planVersion));
+    }
+}


### PR DESCRIPTION
## Summary

v2 Coach API 전체 구현. 4개 슬라이스로 분리 개발 후 단일 브랜치로 통합.

| 슬라이스 | 내용 |
|---|---|
| Slice 1 (#211) | `ChatSession` 엔티티, `POST/DELETE /api/coach/sessions` |
| Slice 2 (#212) | `CoachConversation` 엔티티, `POST /api/coach/sessions/{id}/messages` |
| Slice 3 (#213) | `ContextManagerService` 3-Tier 조립, 세션 고정 version 기준 |
| Slice 4 (#214) | 4-way 분기, `ReplanProposal`, `AgentEvent`, `POST .../replan` |

## 엔드포인트

| Method | Path | 설명 |
|---|---|---|
| `POST` | `/api/coach/sessions` | 세션 생성 — active PROFILE/PLAN snapshot version 고정 |
| `DELETE` | `/api/coach/sessions/{id}` | 세션 종료 (멱등) |
| `POST` | `/api/coach/sessions/{id}/messages` | 메시지 전송 — 4-way 라우팅 |
| `POST` | `/api/coach/sessions/{id}/replan` | 재계획 확인/거절 |

## Context Manager (Slice 3) — 팀원 선행 작업

- `ContextManagerService.assembleAuto(session, message)` — 활성 신호 유무로 Tier 1/3 자동 선택
- 세션의 고정 version으로 PROFILE/PLAN snapshot 로드 (`findByUserIdAndContextTypeAndVersion`)
- Tier 3: `detected_patterns` 미처리 row를 activeSignals로 포함
- CONVERSATION snapshot이 있으면 추가 포함 (팀원 파이프라인과 연동 지점)

## 4-way 라우팅 (Slice 4)

LLM이 `coach-response.schema.json` 형식으로 응답 → `CoachResponseParser` 파싱:
- `SIMPLE_GUIDE` — 직접 응답
- `REPLAN_SUGGEST` — `ReplanProposal` 생성 (24h TTL), proposalId 반환
- `DISMISS` — `detected_patterns.processed_at` 마킹

재계획 확인(`confirmed=true`) → `RoadmapCommandService.createRoadmap()` 호출 → `AgentEvent` 기록

## 신규 ErrorCode

`SNAPSHOT_NOT_FOUND`, `SESSION_NOT_FOUND`, `SESSION_CLOSED`, `PROPOSAL_NOT_FOUND`, `PROPOSAL_EXPIRED`, `PLANNER_FAILED`

## Test plan

- [x] `CoachSessionServiceIntegrationTest` — 6 케이스 (snapshot 검증, FORBIDDEN, 멱등 종료)
- [x] `CoachMessageServiceIntegrationTest` — 5 케이스 (정상 왕복, 닫힌 세션, LLM 실패 롤백)
- [x] `ContextManagerServiceIntegrationTest` — 6 케이스 (Tier 1/3, 자동 선택, 고정 version)
- [x] `ReplanServiceIntegrationTest` — 7 케이스 (confirm/dismiss, 만료, FORBIDDEN)

Closes #211, #212, #213, #214, #190