### PR TITLE
test(coach): Coach API 컨트롤러 계약 테스트 보강

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/coach/controller/CoachMessageControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/CoachMessageControllerTest.java
@@ -1,0 +1,213 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.domain.coach.entity.ReplanProposal;
+import com.back.coach.domain.coach.service.CoachMessageService;
+import com.back.coach.global.code.CoachRoute;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class CoachMessageControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private CoachMessageService coachMessageService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CoachMessageController(coachMessageService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void sendMessage_whenSimpleGuide_returnsCoachMessageResponse() throws Exception {
+        CoachConversation coachMessage = coachMessage(
+                9001L, 10001L, 1L,
+                "이번 주는 Redis TTL과 캐시 무효화 개념부터 정리하는 것이 좋습니다.",
+                CoachRoute.SIMPLE_GUIDE
+        );
+        given(coachMessageService.sendMessage(1L, 10001L, "오늘 무엇부터 공부하면 좋을까?"))
+                .willReturn(new CoachMessageService.MessageResult(coachMessage, null));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", "오늘 무엇부터 공부하면 좋을까?"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messageId").value("9001"))
+                .andExpect(jsonPath("$.data.responseText").value("이번 주는 Redis TTL과 캐시 무효화 개념부터 정리하는 것이 좋습니다."))
+                .andExpect(jsonPath("$.data.route").value("SIMPLE_GUIDE"))
+                .andExpect(jsonPath("$.data.replanProposal").value(nullValue()))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(coachMessageService).sendMessage(1L, 10001L, "오늘 무엇부터 공부하면 좋을까?");
+    }
+
+    @Test
+    void sendMessage_whenReplanSuggested_returnsProposalResponse() throws Exception {
+        Instant expiresAt = Instant.parse("2026-05-08T09:00:00Z");
+        CoachConversation coachMessage = coachMessage(
+                9002L, 10001L, 1L,
+                "3일간 Redis 학습이 완료되지 않았습니다. 로드맵을 조정해드릴까요?",
+                CoachRoute.REPLAN_SUGGEST
+        );
+        ReplanProposal proposal = proposal(
+                7001L, 10001L, 1L, 9002L,
+                "3일 연속 미달성 감지 (Redis 캐시 주차)",
+                expiresAt
+        );
+        given(coachMessageService.sendMessage(1L, 10001L, "로드맵 다시 짜야 할까?"))
+                .willReturn(new CoachMessageService.MessageResult(coachMessage, proposal));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", "로드맵 다시 짜야 할까?"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messageId").value("9002"))
+                .andExpect(jsonPath("$.data.responseText").value("3일간 Redis 학습이 완료되지 않았습니다. 로드맵을 조정해드릴까요?"))
+                .andExpect(jsonPath("$.data.route").value("REPLAN_SUGGEST"))
+                .andExpect(jsonPath("$.data.replanProposal.proposalId").value("7001"))
+                .andExpect(jsonPath("$.data.replanProposal.reason").value("3일 연속 미달성 감지 (Redis 캐시 주차)"))
+                .andExpect(jsonPath("$.data.replanProposal.expiresAt").value("2026-05-08T09:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+    }
+
+    @Test
+    void sendMessage_whenMessageBlank_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", " "
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(coachMessageService);
+    }
+
+    @Test
+    void sendMessage_whenSessionNotFound_returnsNotFound() throws Exception {
+        given(coachMessageService.sendMessage(eq(1L), eq(10001L), anyString()))
+                .willThrow(new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", "오늘 계획 알려줘"
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    void sendMessage_whenSessionClosed_returnsConflict() throws Exception {
+        given(coachMessageService.sendMessage(eq(1L), eq(10001L), anyString()))
+                .willThrow(new ServiceException(ErrorCode.SESSION_CLOSED));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", "오늘 계획 알려줘"
+                        ))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SESSION_CLOSED"));
+    }
+
+    @Test
+    void sendMessage_whenSessionBelongsToAnotherUser_returnsForbidden() throws Exception {
+        given(coachMessageService.sendMessage(eq(1L), eq(10001L), anyString()))
+                .willThrow(new ServiceException(ErrorCode.FORBIDDEN));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "message", "오늘 계획 알려줘"
+                        ))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    private CoachConversation coachMessage(
+            Long id,
+            Long sessionId,
+            Long userId,
+            String responseText,
+            CoachRoute route
+    ) {
+        CoachConversation conversation = CoachConversation.coach(
+                sessionId, userId, responseText, route, "CHECK_TODAY_PLAN"
+        );
+        ReflectionTestUtils.setField(conversation, "id", id);
+        return conversation;
+    }
+
+    private ReplanProposal proposal(
+            Long id,
+            Long sessionId,
+            Long userId,
+            Long messageId,
+            String reason,
+            Instant expiresAt
+    ) {
+        ReplanProposal proposal = ReplanProposal.create(sessionId, userId, messageId, reason, expiresAt);
+        ReflectionTestUtils.setField(proposal, "id", id);
+        return proposal;
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
@@ -1,0 +1,128 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.domain.coach.service.CoachSessionService;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Instant;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class CoachSessionControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private CoachSessionService coachSessionService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CoachSessionController(coachSessionService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void startSession_whenSnapshotsExist_returnsSessionResponse() throws Exception {
+        ChatSession session = session(10001L, 1L, 3, 2, Instant.parse("2026-05-07T09:00:00Z"));
+        given(coachSessionService.startSession(1L)).willReturn(session);
+
+        mockMvc.perform(post("/api/coach/sessions")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.sessionId").value("10001"))
+                .andExpect(jsonPath("$.data.profileVersion").value(3))
+                .andExpect(jsonPath("$.data.roadmapVersion").value(2))
+                .andExpect(jsonPath("$.data.startedAt").value("2026-05-07T09:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(coachSessionService).startSession(1L);
+    }
+
+    @Test
+    void startSession_whenSnapshotNotFound_returnsNotFound() throws Exception {
+        given(coachSessionService.startSession(1L))
+                .willThrow(new ServiceException(ErrorCode.SNAPSHOT_NOT_FOUND));
+
+        mockMvc.perform(post("/api/coach/sessions")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SNAPSHOT_NOT_FOUND"));
+    }
+
+    @Test
+    void closeSession_whenSessionExists_returnsNoContent() throws Exception {
+        mockMvc.perform(delete("/api/coach/sessions/{sessionId}", 10001L)
+                        .principal(authentication(1L)))
+                .andExpect(status().isNoContent());
+
+        verify(coachSessionService).closeSession(1L, 10001L);
+    }
+
+    @Test
+    void closeSession_whenSessionNotFound_returnsNotFound() throws Exception {
+        willThrow(new ServiceException(ErrorCode.SESSION_NOT_FOUND))
+                .given(coachSessionService).closeSession(1L, 10001L);
+
+        mockMvc.perform(delete("/api/coach/sessions/{sessionId}", 10001L)
+                        .principal(authentication(1L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    void closeSession_whenSessionBelongsToAnotherUser_returnsForbidden() throws Exception {
+        willThrow(new ServiceException(ErrorCode.FORBIDDEN))
+                .given(coachSessionService).closeSession(1L, 10001L);
+
+        mockMvc.perform(delete("/api/coach/sessions/{sessionId}", 10001L)
+                        .principal(authentication(1L)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    private ChatSession session(Long id, Long userId, Integer profileVersion, Integer roadmapVersion, Instant startedAt) {
+        ChatSession session = ChatSession.start(userId, profileVersion, roadmapVersion);
+        ReflectionTestUtils.setField(session, "id", id);
+        ReflectionTestUtils.setField(session, "startedAt", startedAt);
+        return session;
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/coach/controller/ReplanControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/ReplanControllerTest.java
@@ -1,0 +1,150 @@
+package com.back.coach.domain.coach.controller;
+
+import com.back.coach.domain.coach.service.ReplanService;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.security.AuthenticatedUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ReplanControllerTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
+
+    @Mock
+    private ReplanService replanService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ReplanController(replanService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    void replan_whenConfirmed_returnsNewRoadmapResponse() throws Exception {
+        given(replanService.confirm(1L, 10001L, 7001L))
+                .willReturn(new ReplanService.ReplanResult("601", 3));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/replan", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "proposalId", 7001L,
+                                "confirmed", true
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.newRoadmapId").value("601"))
+                .andExpect(jsonPath("$.data.newRoadmapVersion").value(3))
+                .andExpect(jsonPath("$.data.message").value("새 로드맵이 생성됐습니다. 현재 세션은 기존 버전을 기준으로 유지됩니다."))
+                .andExpect(jsonPath("$.data.dismissed").value(nullValue()))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(replanService).confirm(1L, 10001L, 7001L);
+    }
+
+    @Test
+    void replan_whenDismissed_returnsDeferredResponse() throws Exception {
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/replan", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "proposalId", 7001L,
+                                "confirmed", false
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.newRoadmapId").value(nullValue()))
+                .andExpect(jsonPath("$.data.newRoadmapVersion").value(nullValue()))
+                .andExpect(jsonPath("$.data.message").value("재계획을 보류했습니다."))
+                .andExpect(jsonPath("$.data.dismissed").value(true))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(replanService).dismiss(1L, 7001L);
+    }
+
+    @Test
+    void replan_whenRequiredFieldMissing_returnsInvalidInput() throws Exception {
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/replan", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "proposalId", 7001L
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        verifyNoInteractions(replanService);
+    }
+
+    @Test
+    void replan_whenSessionNotFound_returnsNotFound() throws Exception {
+        given(replanService.confirm(1L, 10001L, 7001L))
+                .willThrow(new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/replan", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "proposalId", 7001L,
+                                "confirmed", true
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    void replan_whenProposalBelongsToAnotherUser_returnsForbidden() throws Exception {
+        willThrow(new ServiceException(ErrorCode.FORBIDDEN))
+                .given(replanService).dismiss(1L, 7001L);
+
+        mockMvc.perform(post("/api/coach/sessions/{sessionId}/replan", 10001L)
+                        .principal(authentication(1L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "proposalId", 7001L,
+                                "confirmed", false
+                        ))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}


### PR DESCRIPTION
﻿## 무엇
- Coach 세션/메시지/재계획 컨트롤러의 HTTP 응답 shape 테스트를 추가했습니다.
- 주요 에러 `SNAPSHOT_NOT_FOUND`, `SESSION_NOT_FOUND`, `SESSION_CLOSED`, `FORBIDDEN` 매핑을 controller 단위에서 검증했습니다.
- 입력 validation 실패 시 `INVALID_INPUT` 응답도 고정했습니다.

## 왜
- PR #219는 service integration 중심이라 실제 API 응답 계약 회귀를 별도로 막기 위해 필요합니다.
- 프론트 연결 전에 path, status, response shape 기준을 테스트로 고정합니다.

## 확인
- `git diff --check --cached`
- `cd backend; .\gradlew.bat test --tests "com.back.coach.domain.coach.controller.*"`

Closes #233
