### PR TITLE
refactor(context): activeSignals 조립 기준을 Context 계약에 맞게 정리

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/context/service/AssembledContext.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/AssembledContext.java
@@ -7,7 +7,7 @@ import com.back.coach.global.code.CoachTemplate;
  *
  * @param systemPrompt LLM에 전달할 system instruction
  * @param template     사용된 템플릿 (Tier 결정의 근거)
- * @param activeSignalCount 미처리 detected_patterns 수 (자동 승격 판단용)
+ * @param activeSignalCount Context Manager가 조립한 activeSignals 수 (자동 승격 판단용)
  */
 public record AssembledContext(
         String systemPrompt,

--- a/backend/src/main/java/com/back/coach/domain/context/service/ContextManagerService.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/ContextManagerService.java
@@ -9,9 +9,13 @@ import com.back.coach.global.code.CoachTemplate;
 import com.back.coach.global.code.ContextType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,8 +29,8 @@ import java.util.Optional;
  * </ul>
  *
  * <p>세션의 고정 version 기준으로 PROFILE/PLAN snapshot을 로드한다.
- * 활성 신호는 detected_patterns 미처리 row에서 직접 추출한다 (CONVERSATION snapshot
- * 조립 파이프라인이 완성되기 전 임시 폴백).
+ * 활성 신호는 CONVERSATION snapshot의 activeSignals를 우선 사용하고,
+ * snapshot이 비어 있는 전환기에는 미처리 detected_patterns를 fallback으로 요약한다.
  */
 @Service
 @Transactional(readOnly = true)
@@ -34,21 +38,23 @@ public class ContextManagerService {
 
     private final UserContextSnapshotRepository contextSnapshotRepository;
     private final DetectedPatternRepository detectedPatternRepository;
+    private final ObjectMapper objectMapper;
 
     public ContextManagerService(
             UserContextSnapshotRepository contextSnapshotRepository,
-            DetectedPatternRepository detectedPatternRepository
+            DetectedPatternRepository detectedPatternRepository,
+            ObjectMapper objectMapper
     ) {
         this.contextSnapshotRepository = contextSnapshotRepository;
         this.detectedPatternRepository = detectedPatternRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
      * 자동 템플릿 선택: 활성 신호가 있으면 Tier 3, 없으면 Tier 1.
      */
     public AssembledContext assembleAuto(ChatSession session, String userMessage) {
-        List<DetectedPattern> activeSignals = detectedPatternRepository
-                .findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(session.getUserId());
+        List<ActiveSignal> activeSignals = loadActiveSignals(session.getUserId());
         CoachTemplate template = activeSignals.isEmpty()
                 ? CoachTemplate.COACH_LIGHTWEIGHT
                 : CoachTemplate.COACH_FULL_CONTEXT;
@@ -59,8 +65,8 @@ public class ContextManagerService {
      * 명시 템플릿으로 조립.
      */
     public AssembledContext assemble(ChatSession session, CoachTemplate template, String userMessage) {
-        List<DetectedPattern> activeSignals = template == CoachTemplate.COACH_FULL_CONTEXT
-                ? detectedPatternRepository.findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(session.getUserId())
+        List<ActiveSignal> activeSignals = template == CoachTemplate.COACH_FULL_CONTEXT
+                ? loadActiveSignals(session.getUserId())
                 : List.of();
         return assemble(session, template, userMessage, activeSignals);
     }
@@ -69,7 +75,7 @@ public class ContextManagerService {
             ChatSession session,
             CoachTemplate template,
             String userMessage,
-            List<DetectedPattern> activeSignals
+            List<ActiveSignal> activeSignals
     ) {
         UserContextSnapshot profile = loadPinned(session.getUserId(), ContextType.PROFILE, session.getProfileVersion());
         UserContextSnapshot plan = loadPinned(session.getUserId(), ContextType.PLAN, session.getRoadmapVersion());
@@ -84,15 +90,19 @@ public class ContextManagerService {
         sb.append(plan.getPayload()).append("\n\n");
 
         if (template == CoachTemplate.COACH_FULL_CONTEXT) {
-            sb.append("# 활성 신호 (Pattern Detector 미처리)\n");
+            sb.append("# 활성 신호 (activeSignals)\n");
             if (activeSignals.isEmpty()) {
                 sb.append("없음\n\n");
             } else {
-                for (DetectedPattern signal : activeSignals) {
-                    sb.append("- type=").append(signal.getPatternType())
-                            .append(", severity=").append(signal.getSeverity())
-                            .append(", metadata=").append(signal.getMetadata())
-                            .append("\n");
+                for (ActiveSignal signal : activeSignals) {
+                    sb.append("- sourcePatternId=").append(signal.sourcePatternId())
+                            .append(", patternType=").append(signal.patternType())
+                            .append(", severity=").append(signal.severity())
+                            .append(", summary=").append(signal.summary());
+                    if (signal.detectedAt() != null && !signal.detectedAt().isBlank()) {
+                        sb.append(", detectedAt=").append(signal.detectedAt());
+                    }
+                    sb.append("\n");
                 }
                 sb.append("\n");
             }
@@ -111,11 +121,79 @@ public class ContextManagerService {
         return new AssembledContext(sb.toString(), template, activeSignals.size());
     }
 
+    private List<ActiveSignal> loadActiveSignals(Long userId) {
+        List<ActiveSignal> snapshotSignals = loadConversationActiveSignals(userId);
+        if (!snapshotSignals.isEmpty()) {
+            return snapshotSignals;
+        }
+        return loadFallbackDetectedPatterns(userId);
+    }
+
+    private List<ActiveSignal> loadConversationActiveSignals(Long userId) {
+        return contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.CONVERSATION)
+                .map(UserContextSnapshot::getPayload)
+                .map(this::parseActiveSignals)
+                .orElse(List.of());
+    }
+
+    private List<ActiveSignal> parseActiveSignals(String payload) {
+        try {
+            JsonNode activeSignalsNode = objectMapper.readTree(payload).path("activeSignals");
+            if (!activeSignalsNode.isArray() || activeSignalsNode.isEmpty()) {
+                return List.of();
+            }
+
+            List<ActiveSignal> activeSignals = new ArrayList<>();
+            for (JsonNode node : activeSignalsNode) {
+                activeSignals.add(new ActiveSignal(
+                        text(node, "sourcePatternId"),
+                        text(node, "patternType"),
+                        text(node, "severity"),
+                        text(node, "summary"),
+                        text(node, "detectedAt")
+                ));
+            }
+            return activeSignals;
+        } catch (JsonProcessingException e) {
+            return List.of();
+        }
+    }
+
+    private List<ActiveSignal> loadFallbackDetectedPatterns(Long userId) {
+        return detectedPatternRepository.findByUserIdAndProcessedAtIsNullOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(pattern -> new ActiveSignal(
+                        String.valueOf(pattern.getId()),
+                        pattern.getPatternType().name(),
+                        pattern.getSeverity().name(),
+                        "metadata=" + pattern.getMetadata(),
+                        pattern.getCreatedAt() == null ? null : pattern.getCreatedAt().toString()
+                ))
+                .toList();
+    }
+
+    private String text(JsonNode node, String fieldName) {
+        JsonNode value = node.path(fieldName);
+        if (value.isMissingNode() || value.isNull()) {
+            return "";
+        }
+        return value.asText();
+    }
+
     private UserContextSnapshot loadPinned(Long userId, ContextType type, Integer version) {
         return contextSnapshotRepository.findByUserIdAndContextTypeAndVersion(userId, type, version)
                 .orElseThrow(() -> new ServiceException(
                         ErrorCode.SNAPSHOT_NOT_FOUND,
                         "세션에 고정된 " + type + " snapshot version=" + version + " 을(를) 찾을 수 없습니다."
                 ));
+    }
+
+    private record ActiveSignal(
+            String sourcePatternId,
+            String patternType,
+            String severity,
+            String summary,
+            String detectedAt
+    ) {
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
@@ -111,6 +111,108 @@ class ContextManagerServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("CONVERSATION activeSignals가 있으면 detected_patterns fallback보다 우선")
+    void conversationActiveSignalsTakePrecedenceOverDetectedPatternsFallback() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+        seedConversationSnapshot("""
+                {
+                  "contextType": "CONVERSATION",
+                  "sourceRefs": {
+                    "sessionId": "10",
+                    "profileSnapshotVersion": 1,
+                    "planSnapshotVersion": 1
+                  },
+                  "activeSignals": [
+                    {
+                      "sourcePatternId": 31,
+                      "patternType": "REPEATED_INCOMPLETE",
+                      "severity": "MEDIUM",
+                      "summary": "Redis 2주차 과제가 최근 3회 미완료 상태로 남아 있음",
+                      "detectedAt": "2026-05-06T00:00:00Z"
+                    }
+                  ]
+                }
+                """);
+        seedDetectedPattern(PatternType.SKILL_REPEATED_FAILURE, PatternSeverity.HIGH,
+                "{\"skill\":\"Spring Security\"}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assembleAuto(session, "재계획 필요해?");
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_FULL_CONTEXT);
+        assertThat(ctx.activeSignalCount()).isEqualTo(1);
+        assertThat(ctx.systemPrompt()).contains("# 활성 신호 (activeSignals)");
+        assertThat(ctx.systemPrompt()).contains("sourcePatternId=31");
+        assertThat(ctx.systemPrompt()).contains("Redis 2주차 과제가 최근 3회 미완료 상태로 남아 있음");
+        assertThat(ctx.systemPrompt()).doesNotContain("Spring Security");
+        assertThat(ctx.systemPrompt()).doesNotContain("Pattern Detector 미처리");
+    }
+
+    @Test
+    @DisplayName("CONVERSATION activeSignals만 있어도 자동 선택은 Tier 3")
+    void assembleAutoChoosesTier3WhenConversationActiveSignalsExist() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+        seedConversationSnapshot("""
+                {
+                  "contextType": "CONVERSATION",
+                  "sourceRefs": {
+                    "sessionId": "10",
+                    "profileSnapshotVersion": 1,
+                    "planSnapshotVersion": 1
+                  },
+                  "activeSignals": [
+                    {
+                      "sourcePatternId": 41,
+                      "patternType": "GOAL_DRIFT_CANDIDATE",
+                      "severity": "LOW",
+                      "summary": "목표 직무와 다른 학습 주제가 반복됨",
+                      "detectedAt": "2026-05-06T01:00:00Z"
+                    }
+                  ]
+                }
+                """);
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assembleAuto(session, "요즘 방향이 맞아?");
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_FULL_CONTEXT);
+        assertThat(ctx.activeSignalCount()).isEqualTo(1);
+        assertThat(ctx.systemPrompt()).contains("목표 직무와 다른 학습 주제가 반복됨");
+    }
+
+    @Test
+    @DisplayName("CONVERSATION activeSignals가 비어 있으면 detected_patterns fallback 사용")
+    void emptyConversationActiveSignalsFallBackToDetectedPatterns() {
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+        seedConversationSnapshot("""
+                {
+                  "contextType": "CONVERSATION",
+                  "sourceRefs": {
+                    "sessionId": "10",
+                    "profileSnapshotVersion": 1,
+                    "planSnapshotVersion": 1
+                  },
+                  "activeSignals": []
+                }
+                """);
+        seedDetectedPattern(PatternType.CONSECUTIVE_DELAY, PatternSeverity.MEDIUM,
+                "{\"targetType\":\"roadmap_week\",\"targetId\":12}");
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assembleAuto(session, "밀린 것 같아");
+
+        assertThat(ctx.template()).isEqualTo(CoachTemplate.COACH_FULL_CONTEXT);
+        assertThat(ctx.activeSignalCount()).isEqualTo(1);
+        assertThat(ctx.systemPrompt()).contains("CONSECUTIVE_DELAY");
+        assertThat(ctx.systemPrompt()).contains("targetType");
+        assertThat(ctx.systemPrompt()).contains("roadmap_week");
+        assertThat(ctx.systemPrompt()).contains("targetId");
+    }
+
+    @Test
     @DisplayName("자동 선택: 활성 신호 없으면 Tier 1")
     void assembleAutoChoosesTier1WhenNoActiveSignal() {
         seedSnapshot(ContextType.PROFILE, 1, "{}");
@@ -179,6 +281,12 @@ class ContextManagerServiceIntegrationTest {
                 INSERT INTO detected_patterns (user_id, pattern_type, severity, metadata, idempotency_key)
                 VALUES (?, ?, ?, ?::jsonb, ?)
                 """, userId, type.name(), severity.name(), metadata, "test-" + System.nanoTime());
+    }
+
+    private void seedConversationSnapshot(String payload) {
+        contextSnapshotRepository.save(UserContextSnapshot.create(
+                userId, ContextType.CONVERSATION, 1, payload, Instant.now()
+        ));
     }
 
     private ChatSession startSession(int profileVersion, int planVersion) {

--- a/docs/19_v2_detected_patterns_contract.md
+++ b/docs/19_v2_detected_patterns_contract.md
@@ -106,6 +106,13 @@ Coach 응답 문장이나 LLM 해석 결과를 원본 metadata에 저장하지 �
 - `processed_at IS NULL`인 row만 active signal 후보가 된다.
 - active signal로 요약됐다는 이유만으로 원본 row를 수정하지 않는다.
 
+조회 우선순위:
+
+1. Context Manager는 active `CONVERSATION` snapshot의 `payload.activeSignals`를 먼저 읽는다.
+2. `CONVERSATION` snapshot이 없거나 `activeSignals`가 비어 있으면 전환기 fallback으로 미처리 `detected_patterns` row를 직접 조회해 대화용 activeSignals 형태로 요약한다.
+3. Coach는 Context Manager가 조립한 activeSignals만 읽고, SQL로 `detected_patterns`를 직접 조회하지 않는다.
+4. fallback은 snapshot 조립 파이프라인이 완성되기 전까지의 호환 경로이며 공식 대화용 payload 기준은 `CONVERSATION.activeSignals`다.
+
 ## 6. Event System 관계
 
 Pattern Detector는 `pattern.detected` 이벤트를 발행하지 않는다.


### PR DESCRIPTION
﻿## 무엇
- Context Manager가 active `CONVERSATION` snapshot의 `activeSignals`를 우선 사용하도록 정리했습니다.
- `CONVERSATION.activeSignals`가 없거나 비어 있을 때만 미처리 `detected_patterns`를 fallback으로 요약합니다.
- 우선순위와 fallback 동작을 통합 테스트로 고정하고, `docs/19`에 조회 기준을 명시했습니다.

## 왜
- Coach가 원본 `detected_patterns` row와 대화용 `activeSignals`를 혼동하지 않게 하기 위해 필요합니다.
- snapshot 조립 파이프라인 전환 중에도 기존 미처리 패턴 기반 동작은 유지해야 합니다.

## 확인
- `git diff --check`
- `git diff --check --cached`
- `cd backend; .\gradlew.bat integrationTest --tests com.back.coach.domain.context.service.ContextManagerServiceIntegrationTest`

참고: `test --tests com.back.coach.domain.context.service.ContextManagerServiceIntegrationTest`는 프로젝트 설정상 integration tag가 제외되어 테스트를 찾지 못했습니다.

Closes #234
