### PR TITLE
feat(infra): Redis JobStatus 저장 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/job/service/JobStatusService.java
+++ b/backend/src/main/java/com/back/coach/domain/job/service/JobStatusService.java
@@ -1,0 +1,97 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Service
+public class JobStatusService {
+
+    static final Duration JOB_STATUS_TTL = Duration.ofHours(24);
+    static final String KEY_PREFIX = "job:status:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public JobStatusService(StringRedisTemplate redisTemplate, ObjectMapper objectMapper) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public JobStatusSnapshot save(Long userId, String jobId, JobStatus status, String currentStep) {
+        validateRequired(userId, jobId, status);
+        return saveSnapshot(userId, new JobStatusSnapshot(jobId, status, currentStep, null));
+    }
+
+    public JobStatusSnapshot saveFailure(Long userId, String jobId, String currentStep, String error) {
+        validateRequired(userId, jobId, JobStatus.FAILED);
+        return saveSnapshot(userId, new JobStatusSnapshot(jobId, JobStatus.FAILED, currentStep, error));
+    }
+
+    public Optional<JobStatusSnapshot> find(Long userId, String jobId) {
+        validateUserId(userId);
+        validateJobId(jobId);
+
+        String payload = redisTemplate.opsForValue().get(key(userId, jobId));
+        if (payload == null) {
+            return Optional.empty();
+        }
+        return Optional.of(readSnapshot(payload));
+    }
+
+    private JobStatusSnapshot saveSnapshot(Long userId, JobStatusSnapshot snapshot) {
+        redisTemplate.opsForValue().set(
+                key(userId, snapshot.jobId()),
+                writeSnapshot(snapshot),
+                JOB_STATUS_TTL
+        );
+        return snapshot;
+    }
+
+    private void validateRequired(Long userId, String jobId, JobStatus status) {
+        validateUserId(userId);
+        validateJobId(jobId);
+        if (status == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "status는 필수입니다.");
+        }
+    }
+
+    private void validateUserId(Long userId) {
+        if (userId == null || userId < 1) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "userId는 양수여야 합니다.");
+        }
+    }
+
+    private void validateJobId(String jobId) {
+        if (jobId == null || jobId.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "jobId는 필수입니다.");
+        }
+    }
+
+    private String writeSnapshot(JobStatusSnapshot snapshot) {
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR, "JobStatus 저장 payload 직렬화에 실패했습니다.");
+        }
+    }
+
+    private JobStatusSnapshot readSnapshot(String payload) {
+        try {
+            return objectMapper.readValue(payload, JobStatusSnapshot.class);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR, "JobStatus 저장 payload를 읽을 수 없습니다.");
+        }
+    }
+
+    static String key(Long userId, String jobId) {
+        return KEY_PREFIX + userId + ":" + jobId;
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/job/service/JobStatusSnapshot.java
+++ b/backend/src/main/java/com/back/coach/domain/job/service/JobStatusSnapshot.java
@@ -1,0 +1,11 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+
+public record JobStatusSnapshot(
+        String jobId,
+        JobStatus status,
+        String currentStep,
+        String error
+) {
+}

--- a/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class JobStatusServiceIntegrationTest {
+
+    private static final Long USER_ID = 10L;
+
+    @Autowired
+    private JobStatusService jobStatusService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private final List<String> keysToDelete = new ArrayList<>();
+
+    @AfterEach
+    void cleanUp() {
+        if (!keysToDelete.isEmpty()) {
+            redisTemplate.delete(keysToDelete);
+        }
+    }
+
+    @Test
+    @DisplayName("JobStatus 저장 후 Redis에서 조회할 수 있다")
+    void saveAndFindJobStatus() {
+        String jobId = nextJobId();
+
+        JobStatusSnapshot saved = jobStatusService.save(
+                USER_ID, jobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED"
+        );
+
+        assertThat(saved).isEqualTo(new JobStatusSnapshot(
+                jobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED", null
+        ));
+        assertThat(jobStatusService.find(USER_ID, jobId))
+                .hasValue(new JobStatusSnapshot(jobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED", null));
+    }
+
+    @Test
+    @DisplayName("같은 jobId 저장은 상태와 단계를 최신 값으로 갱신한다")
+    void saveUpdatesExistingJobStatus() {
+        String jobId = nextJobId();
+        jobStatusService.save(USER_ID, jobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED");
+
+        jobStatusService.save(USER_ID, jobId, JobStatus.RUNNING, "FETCH_REPOSITORIES");
+
+        assertThat(jobStatusService.find(USER_ID, jobId))
+                .hasValue(new JobStatusSnapshot(jobId, JobStatus.RUNNING, "FETCH_REPOSITORIES", null));
+    }
+
+    @Test
+    @DisplayName("실패 상태와 error를 함께 저장한다")
+    void saveFailureStoresFailedStatusAndError() {
+        String jobId = nextJobId();
+
+        jobStatusService.saveFailure(USER_ID, jobId, "LLM_SUMMARY", "LLM timeout");
+
+        assertThat(jobStatusService.find(USER_ID, jobId))
+                .hasValue(new JobStatusSnapshot(jobId, JobStatus.FAILED, "LLM_SUMMARY", "LLM timeout"));
+    }
+
+    @Test
+    @DisplayName("저장된 JobStatus key에는 TTL이 적용된다")
+    void saveAppliesTtl() {
+        String jobId = nextJobId();
+
+        jobStatusService.save(USER_ID, jobId, JobStatus.RUNNING, "SYNTHESIZE_RESULT");
+
+        Long ttlSeconds = redisTemplate.getExpire(JobStatusService.key(USER_ID, jobId), TimeUnit.SECONDS);
+        assertThat(ttlSeconds)
+                .isNotNull()
+                .isGreaterThan(0L)
+                .isLessThanOrEqualTo(JobStatusService.JOB_STATUS_TTL.toSeconds());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 jobId 조회는 Optional.empty를 반환한다")
+    void findWhenJobStatusDoesNotExistReturnsEmpty() {
+        String jobId = nextJobId();
+
+        assertThat(jobStatusService.find(USER_ID, jobId)).isEmpty();
+    }
+
+    private String nextJobId() {
+        String jobId = "job-" + UUID.randomUUID();
+        keysToDelete.add(JobStatusService.key(USER_ID, jobId));
+        return jobId;
+    }
+}


### PR DESCRIPTION
﻿## 무엇
- Redis key `job:status:{userId}:{jobId}` 기반 JobStatus 저장/조회 service를 추가했습니다.
- `jobId`, `status`, `currentStep`, `error`를 JSON으로 저장하고 24시간 TTL을 적용합니다.
- 저장, 갱신, 실패 상태, TTL, 미존재 조회 통합 테스트를 추가했습니다.

## 왜
- #215의 GitHub 분석 비동기 전환 전에 작업 상태 저장 기반을 독립적으로 고정하기 위해 필요합니다.
- API 202 전환과 LLM 파이프라인 변경 없이 상태 저장 책임만 먼저 분리합니다.

## 확인
- `git diff --check --cached`
- `cd backend; .\gradlew.bat integrationTest --tests com.back.coach.domain.job.service.JobStatusServiceIntegrationTest`

Closes #235
