### PR TITLE
docs(infra): JobStatus 상태 계약 정합성 정리

### DIFF
--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -794,11 +794,14 @@ data: {"messageId":"9001","route":"SIMPLE_GUIDE","replanProposal":null}
 현재 v1 외부 계약
 - 기본은 동기 처리
 
-확장 시 내부 기준
-- `REQUESTED`
-- `RUNNING`
-- `SUCCEEDED`
-- `FAILED`
+확장 시 API/내부 기준
+- `REQUESTED`: 요청 접수됨. #215의 `PENDING` 표현에 대응한다
+- `RUNNING`: 작업 실행 중. #215의 `IN_PROGRESS` 표현에 대응한다
+- `SUCCEEDED`: 작업 성공 종료. #215의 `COMPLETED` 표현에 대응한다
+- `FAILED`: 작업 실패 종료
+
+비동기 조회 API가 추가되면 응답의 `status`는 위 공식 enum만 노출한다.
+`PENDING`, `IN_PROGRESS`, `COMPLETED`는 API 응답값으로 사용하지 않는다.
 
 ---
 

--- a/docs/09_contract_appendix.md
+++ b/docs/09_contract_appendix.md
@@ -66,6 +66,11 @@
 | --- | --- | --- |
 | job_status | REQUESTED, RUNNING, SUCCEEDED, FAILED | 장시간 분석 작업 상태 |
 
+계약 기준
+- Redis 저장 payload와 API 응답의 `status`는 `job_status` enum만 사용한다
+- #215의 `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED` 표현은 각각 `REQUESTED`, `RUNNING`, `SUCCEEDED`, `FAILED`에 대응한다
+- 후속 비동기 API 문서와 OpenAPI schema도 이 enum을 기준으로 작성한다
+
 ### 3.6 v2 확장
 
 | 코드명 | 허용값 | 설명 |
@@ -395,8 +400,10 @@ shape
 - `RUNNING -> FAILED`
 
 규칙
-- `FAILED`는 종료 상태다
-- 재시도는 기존 row를 되살리지 않고 새 실행으로 시작한다
+- `REQUESTED`는 요청 접수 후 executor 실행 전 상태다
+- `RUNNING`은 장시간 작업이 실제 실행 중인 상태다
+- `SUCCEEDED`와 `FAILED`는 종료 상태다
+- 재시도는 기존 job을 되살리지 않고 새 `jobId` 실행으로 시작한다
 - v1에서 동기 처리하더라도 내부적으로는 이 상태 모델을 기준으로 삼을 수 있다
 
 ## 6.2 주차별 진도 상태

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -648,6 +648,15 @@ components:
           example:
             field: currentLevel
 
+    JobStatus:
+      type: string
+      description: Long-running job status exposed by async job APIs.
+      enum:
+        - REQUESTED
+        - RUNNING
+        - SUCCEEDED
+        - FAILED
+
     CoachRoute:
       type: string
       enum:


### PR DESCRIPTION
﻿## 무엇
- JobStatus 공식 enum을 `REQUESTED`, `RUNNING`, `SUCCEEDED`, `FAILED`로 문서에 고정했습니다.
- #215의 `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED` 표현을 공식 enum에 매핑했습니다.
- OpenAPI에 재사용 가능한 `JobStatus` schema를 추가했습니다.

## 왜
- #215 비동기 전환 전에 상태명이 문서/구현/API에서 갈라지는 것을 막기 위해 필요합니다.

## 확인
- `git diff --check`
- `git diff --cached --check`
- `cd backend; .\gradlew.bat test --tests com.back.coach.global.config.OpenApiContractTest`

Closes #244
