### PR TITLE
feat(infra): 비동기 작업 executor 설정 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/global/config/AsyncExecutorConfig.java
+++ b/backend/src/main/java/com/back/coach/global/config/AsyncExecutorConfig.java
@@ -1,0 +1,37 @@
+package com.back.coach.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+@EnableConfigurationProperties(AsyncExecutorProperties.class)
+public class AsyncExecutorConfig {
+
+    public static final String ANALYSIS_TASK_EXECUTOR = "analysisTaskExecutor";
+    public static final String PARALLEL_ANALYSIS_EXECUTOR = "parallelAnalysisExecutor";
+
+    @Bean(name = ANALYSIS_TASK_EXECUTOR)
+    ThreadPoolTaskExecutor analysisTaskExecutor(AsyncExecutorProperties properties) {
+        return executor(properties.analysis());
+    }
+
+    @Bean(name = PARALLEL_ANALYSIS_EXECUTOR)
+    ThreadPoolTaskExecutor parallelAnalysisExecutor(AsyncExecutorProperties properties) {
+        return executor(properties.parallelAnalysis());
+    }
+
+    private ThreadPoolTaskExecutor executor(AsyncExecutorProperties.PoolProperties properties) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(properties.corePoolSize());
+        executor.setMaxPoolSize(properties.maxPoolSize());
+        executor.setQueueCapacity(properties.queueCapacity());
+        executor.setThreadNamePrefix(properties.threadNamePrefix());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/back/coach/global/config/AsyncExecutorProperties.java
+++ b/backend/src/main/java/com/back/coach/global/config/AsyncExecutorProperties.java
@@ -1,0 +1,63 @@
+package com.back.coach.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "coach.async")
+public record AsyncExecutorProperties(
+        PoolProperties analysis,
+        PoolProperties parallelAnalysis
+) {
+
+    private static final PoolProperties DEFAULT_ANALYSIS =
+            new PoolProperties("coach.async.analysis", 2, 4, 100, "analysis-task-");
+    private static final PoolProperties DEFAULT_PARALLEL_ANALYSIS =
+            new PoolProperties("coach.async.parallel-analysis", 2, 2, 20, "parallel-analysis-");
+
+    public AsyncExecutorProperties {
+        analysis = analysis == null
+                ? DEFAULT_ANALYSIS
+                : analysis.withDefaults("coach.async.analysis", DEFAULT_ANALYSIS);
+        parallelAnalysis = parallelAnalysis == null
+                ? DEFAULT_PARALLEL_ANALYSIS
+                : parallelAnalysis.withDefaults("coach.async.parallel-analysis", DEFAULT_PARALLEL_ANALYSIS);
+    }
+
+    public record PoolProperties(
+            String name,
+            Integer corePoolSize,
+            Integer maxPoolSize,
+            Integer queueCapacity,
+            String threadNamePrefix
+    ) {
+
+        PoolProperties withDefaults(String propertyName, PoolProperties defaults) {
+            PoolProperties resolved = new PoolProperties(
+                    propertyName,
+                    corePoolSize == null ? defaults.corePoolSize : corePoolSize,
+                    maxPoolSize == null ? defaults.maxPoolSize : maxPoolSize,
+                    queueCapacity == null ? defaults.queueCapacity : queueCapacity,
+                    threadNamePrefix == null ? defaults.threadNamePrefix : threadNamePrefix
+            );
+            resolved.validate();
+            return resolved;
+        }
+
+        private void validate() {
+            validatePositive(name, "core-pool-size", corePoolSize);
+            validatePositive(name, "max-pool-size", maxPoolSize);
+            validatePositive(name, "queue-capacity", queueCapacity);
+            if (maxPoolSize < corePoolSize) {
+                throw new IllegalArgumentException(name + ".max-pool-size must be greater than or equal to core-pool-size");
+            }
+            if (threadNamePrefix == null || threadNamePrefix.isBlank()) {
+                throw new IllegalArgumentException(name + ".thread-name-prefix must not be blank");
+            }
+        }
+
+        private static void validatePositive(String name, String field, Integer value) {
+            if (value == null || value < 1) {
+                throw new IllegalArgumentException(name + "." + field + " must be greater than or equal to 1");
+            }
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -67,6 +67,19 @@ ai:
     max-concurrent-calls: 4
     queue-timeout-seconds: 180
 
+coach:
+  async:
+    analysis:
+      core-pool-size: 2
+      max-pool-size: 4
+      queue-capacity: 100
+      thread-name-prefix: analysis-task-
+    parallel-analysis:
+      core-pool-size: 2
+      max-pool-size: 2
+      queue-capacity: 20
+      thread-name-prefix: parallel-analysis-
+
 github:
   api:
     base-url: ${GITHUB_API_BASE_URL:https://api.github.com}

--- a/backend/src/test/java/com/back/coach/global/config/AsyncExecutorConfigTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/AsyncExecutorConfigTest.java
@@ -1,0 +1,79 @@
+package com.back.coach.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AsyncExecutorConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(AsyncExecutorConfig.class);
+
+    @Test
+    void defaultProperties_registerExecutorBeans() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AsyncExecutorProperties.class);
+            assertThat(context).hasBean(AsyncExecutorConfig.ANALYSIS_TASK_EXECUTOR);
+            assertThat(context).hasBean(AsyncExecutorConfig.PARALLEL_ANALYSIS_EXECUTOR);
+
+            ThreadPoolTaskExecutor analysis =
+                    context.getBean(AsyncExecutorConfig.ANALYSIS_TASK_EXECUTOR, ThreadPoolTaskExecutor.class);
+            ThreadPoolTaskExecutor parallelAnalysis =
+                    context.getBean(AsyncExecutorConfig.PARALLEL_ANALYSIS_EXECUTOR, ThreadPoolTaskExecutor.class);
+
+            assertExecutor(analysis, 2, 4, 100, "analysis-task-");
+            assertExecutor(parallelAnalysis, 2, 2, 20, "parallel-analysis-");
+        });
+    }
+
+    @Test
+    void propertyOverride_appliesToExecutorBeans() {
+        contextRunner
+                .withPropertyValues(
+                        "coach.async.analysis.core-pool-size=3",
+                        "coach.async.analysis.max-pool-size=5",
+                        "coach.async.analysis.queue-capacity=50",
+                        "coach.async.analysis.thread-name-prefix=custom-analysis-",
+                        "coach.async.parallel-analysis.core-pool-size=1",
+                        "coach.async.parallel-analysis.max-pool-size=3",
+                        "coach.async.parallel-analysis.queue-capacity=10",
+                        "coach.async.parallel-analysis.thread-name-prefix=custom-parallel-"
+                )
+                .run(context -> {
+                    ThreadPoolTaskExecutor analysis =
+                            context.getBean(AsyncExecutorConfig.ANALYSIS_TASK_EXECUTOR, ThreadPoolTaskExecutor.class);
+                    ThreadPoolTaskExecutor parallelAnalysis =
+                            context.getBean(AsyncExecutorConfig.PARALLEL_ANALYSIS_EXECUTOR, ThreadPoolTaskExecutor.class);
+
+                    assertExecutor(analysis, 3, 5, 50, "custom-analysis-");
+                    assertExecutor(parallelAnalysis, 1, 3, 10, "custom-parallel-");
+                });
+    }
+
+    @Test
+    void invalidPoolSize_failsContextStartup() {
+        contextRunner
+                .withPropertyValues(
+                        "coach.async.analysis.core-pool-size=5",
+                        "coach.async.analysis.max-pool-size=4"
+                )
+                .run(context -> assertThat(context.getStartupFailure())
+                        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                        .hasRootCauseMessage("coach.async.analysis.max-pool-size must be greater than or equal to core-pool-size"));
+    }
+
+    private void assertExecutor(
+            ThreadPoolTaskExecutor executor,
+            int corePoolSize,
+            int maxPoolSize,
+            int queueCapacity,
+            String threadNamePrefix
+    ) {
+        assertThat(executor.getCorePoolSize()).isEqualTo(corePoolSize);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(maxPoolSize);
+        assertThat(executor.getThreadPoolExecutor().getQueue().remainingCapacity()).isEqualTo(queueCapacity);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo(threadNamePrefix);
+    }
+}

--- a/docs/05_architecture_aligned.md
+++ b/docs/05_architecture_aligned.md
@@ -79,6 +79,9 @@ v1 저장 원본 기준은 다음과 같다.
 - v1 기본 구현은 단순 API 파이프라인 기반이다.
 - GitHub 분석, 핵심 repo 요약, 장시간 자료 탐색은 이후 비동기 확장 가능하다.
 - 비동기 확장 시에도 저장 원본과 결과 version 규칙은 유지한다.
+- 장시간 작업 실행 기반은 Spring async executor를 사용한다.
+- `analysisTaskExecutor` 기본값은 core 2, max 4, queue 100이며 사용자 단위 분석 job 실행에 사용한다.
+- `parallelAnalysisExecutor` 기본값은 core 2, max 2, queue 20이며 repo 단위 병렬 작업처럼 fan-out 폭을 제한해야 하는 작업에 사용한다.
 
 ## 4. v2 아키텍처
 


### PR DESCRIPTION
﻿## 무엇
- `analysisTaskExecutor`, `parallelAnalysisExecutor`를 Spring async executor bean으로 추가했습니다.
- `coach.async` 설정 기본값과 검증을 추가했습니다.
- executor 등록/기본값/override/잘못된 pool 설정 테스트를 추가했습니다.
- 아키텍처 문서에 executor 역할과 기본값을 정리했습니다.

## 왜
- #215 비동기 전환 전에 장시간 작업 실행 인프라를 독립적으로 테스트 가능한 형태로 고정하기 위해 필요합니다.

## 확인
- `git diff --check origin/dev...HEAD`
- `cd backend; .\gradlew.bat test --tests com.back.coach.global.config.AsyncExecutorConfigTest --tests com.back.coach.ContextWiringTest`

Closes #245
