### PR TITLE
feat(job): JobStatus 조회 API 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/job/controller/JobStatusController.java
+++ b/backend/src/main/java/com/back/coach/domain/job/controller/JobStatusController.java
@@ -1,0 +1,38 @@
+package com.back.coach.domain.job.controller;
+
+import com.back.coach.domain.job.dto.JobStatusResponse;
+import com.back.coach.domain.job.service.JobStatusService;
+import com.back.coach.domain.job.service.JobStatusSnapshot;
+import com.back.coach.global.exception.ErrorCode;
+import com.back.coach.global.exception.ServiceException;
+import com.back.coach.global.response.ApiResponse;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/jobs", produces = MediaType.APPLICATION_JSON_VALUE)
+public class JobStatusController {
+
+    private final JobStatusService jobStatusService;
+
+    public JobStatusController(JobStatusService jobStatusService) {
+        this.jobStatusService = jobStatusService;
+    }
+
+    @GetMapping("/{jobId}/status")
+    public ApiResponse<JobStatusResponse> findStatus(
+            Authentication authentication,
+            @PathVariable String jobId
+    ) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        JobStatusSnapshot snapshot = jobStatusService.find(authenticatedUser.userId(), jobId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND, "작업 상태를 찾을 수 없습니다."));
+
+        return ApiResponse.success(JobStatusResponse.from(snapshot));
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/job/dto/JobStatusResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/job/dto/JobStatusResponse.java
@@ -1,0 +1,21 @@
+package com.back.coach.domain.job.dto;
+
+import com.back.coach.domain.job.service.JobStatusSnapshot;
+import com.back.coach.global.code.JobStatus;
+
+public record JobStatusResponse(
+        String jobId,
+        JobStatus status,
+        String currentStep,
+        String error
+) {
+
+    public static JobStatusResponse from(JobStatusSnapshot snapshot) {
+        return new JobStatusResponse(
+                snapshot.jobId(),
+                snapshot.status(),
+                snapshot.currentStep(),
+                snapshot.error()
+        );
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/job/controller/JobStatusControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/job/controller/JobStatusControllerTest.java
@@ -1,0 +1,97 @@
+package com.back.coach.domain.job.controller;
+
+import com.back.coach.domain.job.service.JobStatusService;
+import com.back.coach.domain.job.service.JobStatusSnapshot;
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.global.exception.GlobalExceptionHandler;
+import com.back.coach.global.security.AuthenticatedUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class JobStatusControllerTest {
+
+    @Mock
+    private JobStatusService jobStatusService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new JobStatusController(jobStatusService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void findStatus_whenJobExists_returnsJobStatus() throws Exception {
+        given(jobStatusService.find(1L, "job-1"))
+                .willReturn(Optional.of(new JobStatusSnapshot("job-1", JobStatus.RUNNING, "FETCH_REPOSITORIES", null)));
+
+        mockMvc.perform(get("/api/jobs/{jobId}/status", "job-1")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.jobId").value("job-1"))
+                .andExpect(jsonPath("$.data.status").value("RUNNING"))
+                .andExpect(jsonPath("$.data.currentStep").value("FETCH_REPOSITORIES"))
+                .andExpect(jsonPath("$.data.error").value(nullValue()))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(jobStatusService).find(1L, "job-1");
+    }
+
+    @Test
+    void findStatus_whenJobFailed_returnsError() throws Exception {
+        given(jobStatusService.find(1L, "job-failed"))
+                .willReturn(Optional.of(new JobStatusSnapshot("job-failed", JobStatus.FAILED, "LLM_SUMMARY", "LLM timeout")));
+
+        mockMvc.perform(get("/api/jobs/{jobId}/status", "job-failed")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.jobId").value("job-failed"))
+                .andExpect(jsonPath("$.data.status").value("FAILED"))
+                .andExpect(jsonPath("$.data.currentStep").value("LLM_SUMMARY"))
+                .andExpect(jsonPath("$.data.error").value("LLM timeout"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(jobStatusService).find(1L, "job-failed");
+    }
+
+    @Test
+    void findStatus_whenJobDoesNotExist_returnsNotFound() throws Exception {
+        given(jobStatusService.find(1L, "missing-job")).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/jobs/{jobId}/status", "missing-job")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("작업 상태를 찾을 수 없습니다."));
+
+        verify(jobStatusService).find(1L, "missing-job");
+    }
+
+    private Authentication authentication(Long userId) {
+        return new UsernamePasswordAuthenticationToken(new AuthenticatedUser(userId), null);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
+++ b/backend/src/test/java/com/back/coach/global/config/OpenApiContractTest.java
@@ -42,6 +42,8 @@ class OpenApiContractTest {
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/dashboard", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
+        assertThat(operation(paths, "/api/jobs/{jobId}/status", "get")
+                .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses/{diagnosisId}", "get")
                 .get("x-implementation-status")).isEqualTo("implemented");
         assertThat(operation(paths, "/api/diagnoses", "post")
@@ -59,9 +61,12 @@ class OpenApiContractTest {
         Map<String, Object> components = mapValue(loadOpenApiDocument(), "components");
         Map<String, Object> schemas = mapValue(components, "schemas");
 
-        assertThat(schemas).containsKeys("ErrorResponse", "ProgressStatus", "CurrentLevel", "DashboardApiResponse");
+        assertThat(schemas).containsKeys("ErrorResponse", "ProgressStatus", "CurrentLevel", "DashboardApiResponse",
+                "JobStatus", "JobStatusApiResponse");
         assertThat(mapValue(schemas, "ProgressStatus").get("enum"))
                 .isEqualTo(List.of("TODO", "IN_PROGRESS", "DONE", "SKIPPED"));
+        assertThat(mapValue(schemas, "JobStatus").get("enum"))
+                .isEqualTo(List.of("REQUESTED", "RUNNING", "SUCCEEDED", "FAILED"));
         Map<String, Object> errorResponseProperties = mapValue(mapValue(schemas, "ErrorResponse"), "properties");
         assertThat(errorResponseProperties).containsKeys("code", "message", "details");
 

--- a/docs/03_api_spec_aligned.md
+++ b/docs/03_api_spec_aligned.md
@@ -635,6 +635,32 @@ v1 처리 기준
 - 로드맵 진행률은 `progress_logs` 최신 row 기준으로 계산한다
 - 대시보드는 화면 편의용 snapshot이며, 각 결과의 원본 상세 조회를 대체하지 않는다
 
+## 3.7 JobStatus 조회 API
+
+### 3.7.1 장시간 작업 상태 조회
+
+- Method: `GET`
+- Path: `/api/jobs/{jobId}/status`
+
+응답 body
+```json
+{
+  "data": {
+    "jobId": "job-20260508-001",
+    "status": "RUNNING",
+    "currentStep": "FETCH_REPOSITORIES",
+    "error": null
+  },
+  "meta": {}
+}
+```
+
+조회 규칙
+- 현재 로그인 사용자 기준으로 `job:status:{userId}:{jobId}` Redis 값을 조회한다
+- 없는 `jobId`와 다른 사용자 job은 모두 `RESOURCE_NOT_FOUND`로 응답한다
+- 응답의 `status`는 `job_status` 공식 enum만 사용한다
+- GitHub 분석 submit 202 전환과 bulk 조회는 후속 API에서 다룬다
+
 ---
 
 ## 4. v2 확장 API

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -31,6 +31,8 @@ tags:
     description: Learning roadmap and progress APIs
   - name: Dashboard
     description: Current user dashboard summary APIs
+  - name: Jobs
+    description: Long-running job status APIs
   - name: Coach
     description: v2 Coach session, message, and replan APIs
 
@@ -369,6 +371,27 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /api/jobs/{jobId}/status:
+    get:
+      tags:
+        - Jobs
+      summary: Get long-running job status
+      operationId: getJobStatus
+      x-implementation-status: implemented
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job status for the authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobStatusApiResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+
   /api/coach/sessions:
     post:
       tags:
@@ -540,6 +563,13 @@ components:
       schema:
         type: string
       example: '10001'
+    JobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+      example: job-20260508-001
 
   responses:
     InvalidInput:
@@ -656,6 +686,39 @@ components:
         - RUNNING
         - SUCCEEDED
         - FAILED
+
+    JobStatusResponseData:
+      type: object
+      required:
+        - jobId
+        - status
+        - currentStep
+        - error
+      properties:
+        jobId:
+          type: string
+          example: job-20260508-001
+        status:
+          $ref: '#/components/schemas/JobStatus'
+        currentStep:
+          type: string
+          nullable: true
+          example: FETCH_REPOSITORIES
+        error:
+          type: string
+          nullable: true
+          example: LLM timeout
+
+    JobStatusApiResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          $ref: '#/components/schemas/JobStatusResponseData'
+        meta:
+          $ref: '#/components/schemas/ApiMeta'
 
     CoachRoute:
       type: string


### PR DESCRIPTION
﻿## 무엇
- 인증 사용자 기준 `GET /api/jobs/{jobId}/status` 조회 API를 추가했습니다.
- `jobId`, `status`, `currentStep`, `error` 응답 shape와 404 정책을 컨트롤러 테스트로 고정했습니다.
- `docs/03`과 OpenAPI에 JobStatus 조회 API 계약을 반영했습니다.

## 왜
- #235의 Redis JobStatus 저장 기반만으로는 #215 polling UX에서 상태를 조회할 HTTP 계약이 없기 때문에 필요합니다.

## 확인
- `git diff --check origin/dev...HEAD`
- `cd backend; .\gradlew.bat test --tests com.back.coach.domain.job.controller.JobStatusControllerTest --tests com.back.coach.global.config.OpenApiContractTest`

Closes #246
