### PR TITLE
test(llm): repo-summary, synthesis schema 회귀 방지 테스트 추가 (#183)

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryResponseParserTest.java
@@ -147,4 +147,39 @@ class RepoSummaryResponseParserTest {
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
     }
+
+    @Test
+    @DisplayName("repoId가 정수로 반환돼도 파싱에 성공한다 (smoke 회귀: LLM이 정수 반환)")
+    void parse_repoIdAsInteger_succeeds() {
+        String json = """
+                {
+                  "repoId": 12345,
+                  "repoName": "user/repo",
+                  "summary": "정수형 repoId 반환 케이스",
+                  "highlights": [{"text": "기능 추가", "status": "ADOPTED"}]
+                }
+                """;
+
+        GithubAnalysisPayload.RepoSummary summary = parser.parse(json);
+
+        assertThat(summary.repoName()).isEqualTo("user/repo");
+        assertThat(summary.highlights()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("highlight 객체에 status 필드가 없으면 LLM_INVALID_RESPONSE")
+    void parse_highlightMissingStatus_throws() {
+        String json = """
+                {
+                  "repoId": "1",
+                  "repoName": "user/x",
+                  "summary": "s",
+                  "highlights": [{"text": "status 없음"}]
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
@@ -103,4 +103,55 @@ class SynthesisResponseParserTest {
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
     }
+
+    @Test
+    @DisplayName("techTags에 skillName 대신 tech 필드를 쓰면 LLM_INVALID_RESPONSE (smoke 회귀)")
+    void parse_techTagsWithTechFieldInsteadOfSkillName_throws() {
+        String json = """
+                {
+                  "techTags": [{"tech": "Java", "tagReason": "주요 언어"}],
+                  "depthEstimates": [],
+                  "evidences": [],
+                  "finalTechProfile": {"confirmedSkills": [], "focusAreas": []}
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("evidences에 summary 대신 description 필드를 쓰면 LLM_INVALID_RESPONSE (smoke 회귀)")
+    void parse_evidencesWithDescriptionInsteadOfSummary_throws() {
+        String json = """
+                {
+                  "techTags": [],
+                  "depthEstimates": [],
+                  "evidences": [{"repoName": "r", "type": "CODE", "source": "s", "description": "d"}],
+                  "finalTechProfile": {"confirmedSkills": [], "focusAreas": []}
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("depthEstimates에 skillName 대신 skill 필드를 쓰면 LLM_INVALID_RESPONSE (smoke 회귀)")
+    void parse_depthEstimatesWithSkillFieldInsteadOfSkillName_throws() {
+        String json = """
+                {
+                  "techTags": [],
+                  "depthEstimates": [{"skill": "Java", "level": "PRACTICAL", "reason": "r"}],
+                  "evidences": [],
+                  "finalTechProfile": {"confirmedSkills": [], "focusAreas": []}
+                }
+                """;
+
+        assertThatThrownBy(() -> parser.parse(json))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+    }
 }


### PR DESCRIPTION



## 연관 이슈

Closes #183

## 변경 요약
smoke에서 발견된 3가지 회귀 케이스:
- repoId 정수 반환 허용 확인 (schema 수정 회귀 방지)
- highlights.status 누락 감지
- synthesis 필드명 오류: tech/description/skill → skillName/summary/skillName 등


## 테스트

   - [ ] 로컬에서 새 테스트 케이스 전부 PASS 확인
   - [ ] smoke 테스트 시 동일한 회귀 케이스가 감지되는지 확인
   - [ ] 기존 테스트와 충돌 없음 확인
