### PR TITLE
feat(job): JobStatus bulk 조회 기반 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/job/service/JobStatusService.java
+++ b/backend/src/main/java/com/back/coach/domain/job/service/JobStatusService.java
@@ -9,7 +9,12 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 
 @Service
 public class JobStatusService {
@@ -46,6 +51,30 @@ public class JobStatusService {
         return Optional.of(readSnapshot(payload));
     }
 
+    public Map<String, JobStatusSnapshot> findAll(Long userId, List<String> jobIds) {
+        validateUserId(userId);
+        SequencedSet<String> uniqueJobIds = normalizeJobIds(jobIds);
+        if (uniqueJobIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<String> keys = uniqueJobIds.stream()
+                .map(jobId -> key(userId, jobId))
+                .toList();
+        List<String> payloads = redisTemplate.opsForValue().multiGet(keys);
+
+        Map<String, JobStatusSnapshot> result = new LinkedHashMap<>();
+        int index = 0;
+        for (String jobId : uniqueJobIds) {
+            String payload = (payloads == null || index >= payloads.size()) ? null : payloads.get(index);
+            if (payload != null) {
+                result.put(jobId, readSnapshot(payload));
+            }
+            index++;
+        }
+        return result;
+    }
+
     private JobStatusSnapshot saveSnapshot(Long userId, JobStatusSnapshot snapshot) {
         redisTemplate.opsForValue().set(
                 key(userId, snapshot.jobId()),
@@ -73,6 +102,18 @@ public class JobStatusService {
         if (jobId == null || jobId.isBlank()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "jobId는 필수입니다.");
         }
+    }
+
+    private SequencedSet<String> normalizeJobIds(List<String> jobIds) {
+        if (jobIds == null) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "jobIds는 필수입니다.");
+        }
+        SequencedSet<String> uniqueJobIds = new LinkedHashSet<>();
+        for (String jobId : jobIds) {
+            validateJobId(jobId);
+            uniqueJobIds.add(jobId);
+        }
+        return uniqueJobIds;
     }
 
     private String writeSnapshot(JobStatusSnapshot snapshot) {

--- a/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceIntegrationTest.java
@@ -10,10 +10,12 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IntegrationTest
 class JobStatusServiceIntegrationTest {
@@ -94,6 +96,77 @@ class JobStatusServiceIntegrationTest {
         String jobId = nextJobId();
 
         assertThat(jobStatusService.find(USER_ID, jobId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 jobId 상태를 한 번에 조회한다")
+    void findAllReturnsJobStatusesInRequestedOrder() {
+        String firstJobId = nextJobId();
+        String secondJobId = nextJobId();
+        jobStatusService.save(USER_ID, firstJobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED");
+        jobStatusService.save(USER_ID, secondJobId, JobStatus.RUNNING, "FETCH_REPOSITORIES");
+
+        Map<String, JobStatusSnapshot> result = jobStatusService.findAll(
+                USER_ID,
+                List.of(firstJobId, secondJobId)
+        );
+
+        assertThat(result)
+                .containsExactly(
+                        Map.entry(firstJobId, new JobStatusSnapshot(firstJobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED", null)),
+                        Map.entry(secondJobId, new JobStatusSnapshot(secondJobId, JobStatus.RUNNING, "FETCH_REPOSITORIES", null))
+                );
+    }
+
+    @Test
+    @DisplayName("없는 jobId가 섞이면 존재하는 JobStatus만 반환한다")
+    void findAllExcludesMissingJobStatus() {
+        String existingJobId = nextJobId();
+        String missingJobId = nextJobId();
+        jobStatusService.saveFailure(USER_ID, existingJobId, "LLM_SUMMARY", "LLM timeout");
+
+        Map<String, JobStatusSnapshot> result = jobStatusService.findAll(
+                USER_ID,
+                List.of(existingJobId, missingJobId)
+        );
+
+        assertThat(result)
+                .containsExactly(Map.entry(
+                        existingJobId,
+                        new JobStatusSnapshot(existingJobId, JobStatus.FAILED, "LLM_SUMMARY", "LLM timeout")
+                ));
+    }
+
+    @Test
+    @DisplayName("중복 jobId가 있어도 한 번만 반환한다")
+    void findAllDeduplicatesJobIds() {
+        String jobId = nextJobId();
+        jobStatusService.save(USER_ID, jobId, JobStatus.SUCCEEDED, "DONE");
+
+        Map<String, JobStatusSnapshot> result = jobStatusService.findAll(
+                USER_ID,
+                List.of(jobId, jobId)
+        );
+
+        assertThat(result)
+                .containsExactly(Map.entry(
+                        jobId,
+                        new JobStatusSnapshot(jobId, JobStatus.SUCCEEDED, "DONE", null)
+                ));
+    }
+
+    @Test
+    @DisplayName("빈 jobId 목록 조회는 빈 Map을 반환한다")
+    void findAllWhenJobIdsAreEmptyReturnsEmptyMap() {
+        assertThat(jobStatusService.findAll(USER_ID, List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("blank jobId가 섞이면 INVALID_INPUT 예외를 던진다")
+    void findAllWhenJobIdsContainBlankThrowsInvalidInput() {
+        assertThatThrownBy(() -> jobStatusService.findAll(USER_ID, List.of("job-1", " ")))
+                .isInstanceOf(com.back.coach.global.exception.ServiceException.class)
+                .hasMessage("jobId는 필수입니다.");
     }
 
     private String nextJobId() {

--- a/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/job/service/JobStatusServiceTest.java
@@ -1,0 +1,69 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JobStatusServiceTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private JobStatusService jobStatusService;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        jobStatusService = new JobStatusService(redisTemplate, objectMapper);
+    }
+
+    @Test
+    void findAll_usesSingleMultiGetWithOrderedKeys() throws Exception {
+        JobStatusSnapshot first = new JobStatusSnapshot("job-1", JobStatus.REQUESTED, "REQUEST_ACCEPTED", null);
+        JobStatusSnapshot second = new JobStatusSnapshot("job-2", JobStatus.RUNNING, "FETCH_REPOSITORIES", null);
+        given(valueOperations.multiGet(List.of(
+                "job:status:10:job-1",
+                "job:status:10:job-2"
+        ))).willReturn(List.of(
+                objectMapper.writeValueAsString(first),
+                objectMapper.writeValueAsString(second)
+        ));
+
+        Map<String, JobStatusSnapshot> result = jobStatusService.findAll(10L, List.of("job-1", "job-2"));
+
+        assertThat(result)
+                .containsExactly(
+                        Map.entry("job-1", first),
+                        Map.entry("job-2", second)
+                );
+        verify(valueOperations).multiGet(List.of(
+                "job:status:10:job-1",
+                "job:status:10:job-2"
+        ));
+        verify(valueOperations, never()).get(anyString());
+    }
+}


### PR DESCRIPTION
﻿## 무엇
- Redis `multiGet` 기반 `JobStatusService.findAll(userId, jobIds)`를 추가했습니다.
- 입력 jobId 순서 유지, 중복 제거, 미존재 job 제외, 빈 목록 정책을 테스트로 고정했습니다.
- API endpoint는 추가하지 않고 service 기반만 분리했습니다.

## 왜
- #215 polling UX에서 여러 장시간 작업 상태를 한 번에 조회할 기반이 필요하기 때문입니다.

## 확인
- `git diff --check origin/dev...HEAD`
- `cd backend; .\gradlew.bat test --tests com.back.coach.domain.job.service.JobStatusServiceTest --tests com.back.coach.domain.job.service.JobStatusServiceIntegrationTest`

Closes #247
