### PR TITLE
feat(github): affiliationcollaborator 저장소 지원 및 저장소 선택 UX 개선

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubRepositoryListResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubRepositoryListResponse.java
@@ -13,7 +13,8 @@ public record GithubRepositoryListResponse(
             String repoFullName,
             String repoUrl,
             String primaryLanguage,
-            String defaultBranch
+            String defaultBranch,
+            String ownerType
     ) {}
 
     public static GithubRepositoryListResponse from(Long connectionId, List<GithubProject> projects) {
@@ -23,7 +24,8 @@ public record GithubRepositoryListResponse(
                         p.getRepoFullName(),
                         p.getRepoUrl(),
                         p.getPrimaryLanguage(),
-                        p.getDefaultBranch()))
+                        p.getDefaultBranch(),
+                        p.getOwnerType()))
                 .toList();
         return new GithubRepositoryListResponse(String.valueOf(connectionId), items);
     }

--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubProject.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubProject.java
@@ -49,6 +49,9 @@ public class GithubProject extends BaseEntity {
     @Column(name = "is_core_repo", nullable = false)
     private Boolean coreRepo;
 
+    @Column(name = "owner_type", length = 50)
+    private String ownerType;
+
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "metadata_payload", nullable = false, columnDefinition = "jsonb")
     private String metadataPayload;
@@ -59,7 +62,7 @@ public class GithubProject extends BaseEntity {
 
     public static GithubProject create(Long userId, Long githubConnectionId,
                                        String repoNodeId, String repoFullName, String repoUrl,
-                                       String primaryLanguage, String defaultBranch) {
+                                       String primaryLanguage, String defaultBranch, String ownerType) {
         GithubProject p = new GithubProject();
         p.userId = userId;
         p.githubConnectionId = githubConnectionId;
@@ -68,6 +71,7 @@ public class GithubProject extends BaseEntity {
         p.repoUrl = repoUrl;
         p.primaryLanguage = primaryLanguage;
         p.defaultBranch = defaultBranch;
+        p.ownerType = ownerType;
         p.selected = false;
         p.coreRepo = false;
         p.metadataPayload = "{}";

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
@@ -81,18 +81,21 @@ public class GithubConnectionService {
             String owner = parts[0];
             String repoName = parts.length > 1 ? parts[1] : parts[0];
 
-            GithubProject project = upsertProject(userId, connection.getId(), repo);
+            String ownerType = repo.owner() != null && login.equals(repo.owner().login())
+                    ? "owner"
+                    : "collaborator";
+            GithubProject project = upsertProject(userId, connection.getId(), repo, ownerType);
             fetchAndUpdateMetadata(project, accessToken, owner, repoName, login);
         }
     }
 
-    private GithubProject upsertProject(Long userId, Long connectionId, GithubRepoDto repo) {
+    private GithubProject upsertProject(Long userId, Long connectionId, GithubRepoDto repo, String ownerType) {
         return projectRepo.findByUserIdAndRepoFullName(userId, repo.fullName())
                 .orElseGet(() -> {
                     try {
                         GithubProject p = GithubProject.create(userId, connectionId,
                                 repo.nodeId(), repo.fullName(), repo.htmlUrl(),
-                                repo.language(), repo.defaultBranch());
+                                repo.language(), repo.defaultBranch(), ownerType);
                         return projectRepo.saveAndFlush(p);
                     } catch (DataIntegrityViolationException e) {
                         return projectRepo.findByUserIdAndRepoFullName(userId, repo.fullName())

--- a/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
@@ -79,7 +79,7 @@ public class RestGithubApiClient implements GithubApiClient {
     @Override
     public List<GithubRepoDto> listUserRepos(String accessToken) {
         URI uri = UriComponentsBuilder.fromUriString("/user/repos")
-                .queryParam("affiliation", "owner")
+                .queryParam("affiliation", "owner,collaborator")
                 .queryParam("per_page", 100)
                 .build().toUri();
         return getList(uri, accessToken, new ParameterizedTypeReference<>() {});

--- a/backend/src/main/java/com/back/coach/external/github/dto/GithubRepoDto.java
+++ b/backend/src/main/java/com/back/coach/external/github/dto/GithubRepoDto.java
@@ -10,5 +10,11 @@ public record GithubRepoDto(
         @JsonProperty("html_url") String htmlUrl,
         @JsonProperty("language") String language,
         @JsonProperty("default_branch") String defaultBranch,
-        @JsonProperty("fork") boolean fork
-) {}
+        @JsonProperty("fork") boolean fork,
+        @JsonProperty("owner") OwnerDto owner
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OwnerDto(
+            @JsonProperty("login") String login
+    ) {}
+}

--- a/backend/src/main/resources/db/migration/V9__Add_github_projects_owner_type.sql
+++ b/backend/src/main/resources/db/migration/V9__Add_github_projects_owner_type.sql
@@ -1,0 +1,8 @@
+-- Add ownerType column to github_projects
+ALTER TABLE github_projects ADD COLUMN owner_type VARCHAR(50);
+
+-- Set default value for existing records (assume they were all owner repos)
+UPDATE github_projects SET owner_type = 'owner' WHERE owner_type IS NULL;
+
+-- Make the column non-nullable
+ALTER TABLE github_projects ALTER COLUMN owner_type SET NOT NULL;

--- a/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
@@ -82,7 +82,7 @@ class GithubAnalysisE2eTest extends ApiTestBase {
         given(githubApiClient.getUserInfo("ghp_fake_token"))
                 .willReturn(new GithubUserInfoDto(99L, "testuser"));
         given(githubApiClient.listUserRepos("ghp_fake_token")).willReturn(List.of(
-                new GithubRepoDto("node-1", "testuser/backend", "https://github.com/testuser/backend", "Java", "main", false)
+                new GithubRepoDto("node-1", "testuser/backend", "https://github.com/testuser/backend", "Java", "main", false, new GithubRepoDto.OwnerDto("testuser"))
         ));
         given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
         given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of("Java", 10000L));
@@ -153,7 +153,7 @@ class GithubAnalysisE2eTest extends ApiTestBase {
         given(githubApiClient.getUserInfo("ghp_rev_token"))
                 .willReturn(new GithubUserInfoDto(88L, "revuser"));
         given(githubApiClient.listUserRepos("ghp_rev_token")).willReturn(List.of(
-                new GithubRepoDto("node-2", "revuser/api", "https://github.com/revuser/api", "Java", "main", false)
+                new GithubRepoDto("node-2", "revuser/api", "https://github.com/revuser/api", "Java", "main", false, new GithubRepoDto.OwnerDto("revuser"))
         ));
         given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
         given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of());

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubAnalysisControllerTest.java
@@ -56,7 +56,8 @@ class GithubAnalysisControllerTest extends ApiTestBase {
         GithubAnalysisPayload payload = samplePayload();
         given(analysisService.run(eqUser(user.getId()), eqLong(50L), any(), any()))
                 .willReturn(new GithubAnalysisService.GithubAnalysisResult(
-                        77L, 1, payload, "확정 스킬: Spring Boot", Instant.parse("2026-04-28T00:00:00Z")));
+                        77L, 1, payload, "확정 스킬: Spring Boot", Instant.parse("2026-04-28T00:00:00Z"),
+                        new GithubAnalysisService.AnalysisMetrics(5000L, 2, 1000, 2000L, 500, 1500L, 800, 1500L)));
 
         String body = objectMapper.writeValueAsString(Map.of(
                 "githubConnectionId", 50,

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubConnectionControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubConnectionControllerTest.java
@@ -175,7 +175,7 @@ class GithubConnectionControllerTest extends ApiTestBase {
         GithubConnection conn = connectionRepository.save(
                 GithubConnection.connect(user.getId(), "gh-uid-100", "testuser2", GithubAccessType.OAUTH, "ghp_tok"));
         GithubProject project = GithubProject.create(user.getId(), conn.getId(),
-                "N10", "testuser2/my-repo", "https://github.com/testuser2/my-repo", "Java", "main");
+                "N10", "testuser2/my-repo", "https://github.com/testuser2/my-repo", "Java", "main", "owner");
         projectRepository.save(project);
 
         mockMvc.perform(get("/api/github/repositories")

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
@@ -54,13 +54,13 @@ class GithubConnectionServiceTest {
         given(connectionRepo.save(any())).willReturn(savedConnection);
 
         List<GithubRepoDto> repos = List.of(
-                new GithubRepoDto("N1", "testuser/repo-a", "https://github.com/testuser/repo-a", "Java", "main", false),
-                new GithubRepoDto("N2", "testuser/repo-b", "https://github.com/testuser/repo-b", "Python", "main", false)
+                new GithubRepoDto("N1", "testuser/repo-a", "https://github.com/testuser/repo-a", "Java", "main", false, new GithubRepoDto.OwnerDto("testuser")),
+                new GithubRepoDto("N2", "testuser/repo-b", "https://github.com/testuser/repo-b", "Python", "main", false, new GithubRepoDto.OwnerDto("testuser"))
         );
         given(apiClient.listUserRepos("ghp_token")).willReturn(repos);
         given(projectRepo.findByUserIdAndRepoFullName(eq(USER_ID), anyString())).willReturn(Optional.empty());
         GithubProject savedProject = GithubProject.create(USER_ID, 10L, "N1", "testuser/repo-a",
-                "https://github.com/testuser/repo-a", "Java", "main");
+                "https://github.com/testuser/repo-a", "Java", "main", "owner");
         ReflectionTestUtils.setField(savedProject, "id", 100L);
         given(projectRepo.save(any())).willReturn(savedProject);
         given(projectRepo.saveAndFlush(any())).willReturn(savedProject);
@@ -101,7 +101,7 @@ class GithubConnectionServiceTest {
     void listRepositories_ownershipCheck() {
         GithubConnection conn = savedConnection(10L, USER_ID, "42", "testuser", "token");
         given(connectionRepo.findByIdAndUserId(10L, USER_ID)).willReturn(Optional.of(conn));
-        GithubProject p = GithubProject.create(USER_ID, 10L, "N1", "testuser/repo", "https://...", "Java", "main");
+        GithubProject p = GithubProject.create(USER_ID, 10L, "N1", "testuser/repo", "https://...", "Java", "main", "owner");
         ReflectionTestUtils.setField(p, "id", 200L);
         given(projectRepo.findByGithubConnectionIdAndUserId(10L, USER_ID)).willReturn(List.of(p));
 

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -49,21 +49,63 @@ export default function MePage() {
   };
 
   return (
-    <>
-      <h1>/me</h1>
-      {loading && <p>불러오는 중…</p>}
-      {error && <p className="error">{error}</p>}
-      {me && <pre>{JSON.stringify(me, null, 2)}</pre>}
+    <div className="screen-shell">
+      <div className="screen-hero">
+        <p className="eyebrow">계정 관리</p>
+        <div className="screen-heading">
+          <h1>내 계정</h1>
+          <p>사용자 정보 및 계정 설정을 확인합니다.</p>
+        </div>
+      </div>
 
-      <p>
-        <button onClick={() => void load()}>다시 조회</button>{" "}
-        <button onClick={refresh}>토큰 갱신 (/refresh)</button>{" "}
-        <button onClick={logout}>로그아웃</button>
-      </p>
+      {loading && (
+        <div className="panel">
+          <p>불러오는 중…</p>
+        </div>
+      )}
 
-      <p className="muted">
+      {error && (
+        <div className="panel" style={{ borderLeft: "4px solid #dc2626" }}>
+          <p style={{ color: "#dc2626", marginBottom: "0.5rem" }}>오류</p>
+          <p>{error}</p>
+        </div>
+      )}
+
+      {me && (
+        <div className="panel dashboard-summary-card">
+          <h2>사용자 정보</h2>
+          <dl className="dashboard-metric-list">
+            <div>
+              <dt>사용자 ID</dt>
+              <dd>{me.userId}</dd>
+            </div>
+            <div>
+              <dt>이메일</dt>
+              <dd>{me.email}</dd>
+            </div>
+            <div>
+              <dt>인증 제공자</dt>
+              <dd>{me.authProvider}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+
+      <div className="action-row" aria-label="계정 관리">
+        <button className="action-link" onClick={() => void load()}>
+          정보 새로고침
+        </button>
+        <button className="action-link" onClick={refresh}>
+          토큰 갱신
+        </button>
+        <button className="action-link" onClick={logout}>
+          로그아웃
+        </button>
+      </div>
+
+      <p style={{ fontSize: "0.875rem", color: "#6b7280", marginTop: "2rem", paddingTop: "1rem", borderTop: "1px solid #e5e7eb" }}>
         accessToken/refreshToken 쿠키는 HttpOnly 라 JS에서 보이지 않는다 — 정상 동작이다.
       </p>
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -140,54 +140,130 @@ export function GithubConnectionView() {
 
   const { repos } = state;
 
+  const ownedRepos = repos.filter((r) => !r.ownerType || r.ownerType === "owner");
+  const contributedRepos = repos.filter((r) => r.ownerType === "collaborator");
+
+  const renderRepoGrid = (repoList: typeof repos) => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+        gap: "1rem"
+      }}
+    >
+      {repoList.map((repo) => (
+        <div
+          key={repo.repositoryId}
+          onClick={() => toggleRepo(repo.repositoryId)}
+          style={{
+            padding: "1rem",
+            border: "1px solid #e5e7eb",
+            borderRadius: "0.5rem",
+            cursor: "pointer",
+            transition: "all 0.2s",
+            backgroundColor: selected.has(repo.repositoryId)
+              ? "#f0f9ff"
+              : "#ffffff",
+            borderColor: selected.has(repo.repositoryId)
+              ? "#0ea5e9"
+              : "#e5e7eb",
+            boxShadow: selected.has(repo.repositoryId)
+              ? "0 0 0 2px rgba(14, 165, 233, 0.1)"
+              : "none"
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "flex-start", gap: "0.75rem" }}>
+            <input
+              type="checkbox"
+              checked={selected.has(repo.repositoryId)}
+              onChange={() => toggleRepo(repo.repositoryId)}
+              onClick={(e) => e.stopPropagation()}
+              style={{ marginTop: "0.25rem", cursor: "pointer" }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <h4
+                style={{
+                  margin: "0 0 0.5rem 0",
+                  fontSize: "0.95rem",
+                  fontWeight: "600",
+                  wordBreak: "break-word"
+                }}
+              >
+                {repo.repoFullName}
+              </h4>
+              {repo.primaryLanguage && (
+                <span
+                  style={{
+                    display: "inline-block",
+                    backgroundColor: "#f3f4f6",
+                    padding: "0.25rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    fontSize: "0.8rem",
+                    color: "#374151"
+                  }}
+                >
+                  {repo.primaryLanguage}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
   return (
-    <div>
-      <h1>저장소 선택</h1>
-      <p>분석할 저장소를 선택하세요. ({selected.size}개 선택됨)</p>
+    <div className="screen-shell">
+      <div className="screen-hero">
+        <p className="eyebrow">GitHub 저장소</p>
+        <div className="screen-heading">
+          <h1>저장소 선택</h1>
+          <p>분석할 저장소를 선택하세요. ({selected.size}개 선택됨)</p>
+        </div>
+      </div>
 
       {repos.length === 0 ? (
         <StatePanel message="연결된 저장소가 없습니다." />
       ) : (
-        <ul style={{ listStyle: "none", padding: 0 }}>
-          {repos.map((repo) => (
-            <li key={repo.repositoryId} style={{ marginBottom: "0.5rem" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}>
-                <input
-                  type="checkbox"
-                  checked={selected.has(repo.repositoryId)}
-                  onChange={() => toggleRepo(repo.repositoryId)}
-                />
-                <span>{repo.repoFullName}</span>
-                {repo.primaryLanguage && (
-                  <span style={{ fontSize: "0.75rem", color: "#888" }}>
-                    {repo.primaryLanguage}
-                  </span>
-                )}
-              </label>
-            </li>
-          ))}
-        </ul>
+        <>
+          {ownedRepos.length > 0 && (
+            <div className="panel" style={{ marginBottom: "2rem" }}>
+              <h2 style={{ marginTop: 0, marginBottom: "1.5rem", fontSize: "1.1rem", fontWeight: "600" }}>
+                내 저장소 ({ownedRepos.length})
+              </h2>
+              {renderRepoGrid(ownedRepos)}
+            </div>
+          )}
+
+          {contributedRepos.length > 0 && (
+            <div className="panel" style={{ marginBottom: "2rem" }}>
+              <h2 style={{ marginTop: 0, marginBottom: "1.5rem", fontSize: "1.1rem", fontWeight: "600" }}>
+                기여한 저장소 ({contributedRepos.length})
+              </h2>
+              {renderRepoGrid(contributedRepos)}
+            </div>
+          )}
+        </>
       )}
 
-      <button
-        className="btn-primary"
-        disabled={selected.size === 0}
-        onClick={handleAnalyze}
-      >
-        분석 실행
-      </button>
-
-      <p style={{ marginTop: "1rem" }}>
+      <div className="action-row" aria-label="저장소 분석">
         <button
+          className="action-link primary"
+          disabled={selected.size === 0}
+          onClick={handleAnalyze}
+        >
+          분석 실행 ({selected.size}개)
+        </button>
+        <button
+          className="action-link"
           onClick={() => {
             clearConnectionId();
             setSelected(new Set());
           }}
-          style={{ fontSize: "0.875rem", color: "#888" }}
         >
           다른 계정으로 연결
         </button>
-      </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/github-connection/types.ts
+++ b/frontend/src/features/github-connection/types.ts
@@ -10,6 +10,7 @@ export type Repository = {
   repoUrl: string;
   primaryLanguage: string | null;
   defaultBranch: string;
+  ownerType?: "owner" | "collaborator";
 };
 
 export type GithubRepositoryList = {


### PR DESCRIPTION

- RestGithubApiClient affiliation 필터: owner → owner,collaborator
- GithubRepoDto: OwnerDto 추가로 저장소 소유자 정보 캡처
- GithubProject: ownerType 필드 추가 (owner | collaborator)
- GithubConnectionService: 저장소 소유자 판정 로직 (repo.owner.login 비교)
- DB migration V9: github_projects.owner_type VARCHAR(50) 추가
- GithubRepositoryListResponse: ownerType 필드 반환
- 프론트엔드 types: Repository.ownerType optional 필드
- github-connection-view: 소유 저장소/기여 저장소 섹션 분리 + 카드 그리드 레이아웃
- /me 페이지: 대시보드 스타일 개선

## 연관 이슈

Closes #

## 변경 요약

- 

## 테스트

실행 내용:

```text
예) ./gradlew test jacocoTestReport
```
