### PR TITLE
chore(test): Testcontainers 통합 테스트 실행 기준 정리

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,5 +11,7 @@ Closes #
 실행 내용:
 
 ```text
-예) ./gradlew test jacocoTestReport
+예) cd backend && ./gradlew prVerification
+예) cd backend && ./gradlew integrationTest  # Docker/Testcontainers 필요 시
+예) cd backend && ./gradlew fullVerification # 전체 백엔드 검증 필요 시
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,32 @@ npm run build
 
 ## 테스트
 
+백엔드 테스트는 실행 범위와 Docker 필요 여부가 다릅니다.
+
 ```powershell
 cd backend
 .\gradlew.bat test
 ```
+
+- `test`: 단위 테스트와 Docker가 필요 없는 빠른 테스트를 실행합니다. `integration` 태그는 제외됩니다.
+- `prIntegrationTest`: PR 병합 전에 확인할 `pr-gate` 태그 테스트를 실행합니다. 현재 CI의 PR 검증에 포함됩니다.
+- `prVerification`: `test`와 `prIntegrationTest`를 함께 실행합니다. 백엔드 PR 본문에는 기본적으로 이 명령 결과를 적습니다.
+- `integrationTest`: `integration` 태그 테스트를 실행합니다. Testcontainers가 PostgreSQL/Redis 컨테이너를 띄우므로 Docker Desktop이 켜져 있어야 합니다.
+- `fullVerification`: `test`, `integrationTest`, JaCoCo 리포트 생성을 함께 실행합니다. `dev`/`main` push CI의 전체 백엔드 검증 기준입니다.
+
+PR 검증 기준:
+
+```powershell
+cd backend
+.\gradlew.bat prVerification
+```
+
+Docker/Testcontainers까지 포함해 전체 통합 테스트를 확인하려면 Docker Desktop을 먼저 실행한 뒤 다음 중 하나를 사용합니다.
+
+```powershell
+cd backend
+.\gradlew.bat integrationTest
+.\gradlew.bat fullVerification
+```
+
+Docker가 꺼져 있거나 Docker CLI에 접근할 수 없으면 `integrationTest`는 시작 전에 실패합니다. 이 경우 Docker Desktop을 켠 뒤 같은 명령을 다시 실행합니다.

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,5 +1,43 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.Test
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+abstract class DockerPreflightTask : DefaultTask() {
+  @get:Inject
+  abstract val execOperations: ExecOperations
+
+  @TaskAction
+  fun checkDocker() {
+    val output = ByteArrayOutputStream()
+    val result = try {
+      execOperations.exec {
+        commandLine("docker", "info", "--format", "{{.ServerVersion}}")
+        isIgnoreExitValue = true
+        standardOutput = output
+        errorOutput = output
+      }
+    } catch (ex: Exception) {
+      throw GradleException(dockerPreflightMessage(), ex)
+    }
+
+    if (result.exitValue != 0) {
+      val dockerOutput = output.toString().trim()
+      val detail = if (dockerOutput.isBlank()) "" else "\n\nDocker output:\n${dockerOutput.take(1200)}"
+      throw GradleException(dockerPreflightMessage() + detail)
+    }
+  }
+
+  private fun dockerPreflightMessage() = """
+    integrationTest는 Docker/Testcontainers 환경이 필요합니다.
+    Docker Desktop을 실행한 뒤 다시 시도하세요.
+    Docker가 필요 없는 빠른 검증은 ./gradlew test 또는 ./gradlew prVerification을 사용하세요.
+  """.trimIndent()
+}
 
 plugins {
   java
@@ -103,6 +141,11 @@ tasks.test {
 
 val testSourceSet = the<JavaPluginExtension>().sourceSets.getByName("test")
 
+val dockerPreflight = tasks.register<DockerPreflightTask>("dockerPreflight") {
+  description = "Checks whether Docker is available before Testcontainers integration tests."
+  group = "verification"
+}
+
 val prIntegrationTest = tasks.register<Test>("prIntegrationTest") {
   description = "Runs integration tests that must pass before merging a PR."
   group = "verification"
@@ -117,6 +160,7 @@ val prIntegrationTest = tasks.register<Test>("prIntegrationTest") {
 val integrationTest = tasks.register<Test>("integrationTest") {
   description = "Runs integration tests that require Spring Boot and Testcontainers."
   group = "verification"
+  dependsOn(dockerPreflight)
   testClassesDirs = testSourceSet.output.classesDirs
   classpath = testSourceSet.runtimeClasspath
   useJUnitPlatform {

--- a/backend/src/test/java/com/back/coach/support/ApiTestBase.java
+++ b/backend/src/test/java/com/back/coach/support/ApiTestBase.java
@@ -12,6 +12,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
  * API(HTTP 계층) 테스트 베이스.
  *
  * <p>{@link IntegrationTest} 설정을 포함한다 — 별도 어노테이션 불필요.
+ * Docker/Testcontainers 기반 테스트이므로 Gradle {@code integrationTest} 태스크에서 실행한다.
  *
  * <h2>사용 예 (HTTP 레이어만 검증)</h2>
  * <pre>{@code

--- a/backend/src/test/java/com/back/coach/support/IntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/support/IntegrationTest.java
@@ -12,10 +12,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Repository / Schema 통합 테스트용 메타 어노테이션.
+ * Docker/Testcontainers 기반 통합 테스트용 메타 어노테이션.
  *
  * <p>SpringBootTest + test 프로파일 + Testcontainers PostgreSQL/Redis 를 한 번에 적용한다.
  * API 테스트(MockMvc 필요)는 {@link ApiTestBase} 를 상속.
+ * 이 어노테이션이 붙은 테스트는 Gradle {@code integrationTest} 태스크에서 실행한다.
  *
  * <ul>
  *   <li><b>Docker Desktop 이 켜져 있어야 한다.</b> Testcontainers 가 컨테이너를 띄운다.


### PR DESCRIPTION
﻿Closes #268

## 변경 요약
- 백엔드 테스트 태스크별 실행 범위와 Docker 필요 여부를 README/PR 템플릿에 정리
- `integrationTest` 실행 전 Docker 접근 가능 여부를 확인해 명확한 실패 메시지 제공
- `@IntegrationTest` / `ApiTestBase` 설명을 Testcontainers 실행 기준과 맞춤

## 왜 필요한가
- Docker/Testcontainers 환경 문제와 실제 코드 회귀를 구분해야 PR 검증 결과를 신뢰할 수 있습니다.

## 테스트
- `cd backend; .\gradlew.bat test --no-daemon` PASS
- `cd backend; .\gradlew.bat prVerification --no-daemon` PASS
- `cd backend; .\gradlew.bat dockerPreflight --no-daemon` PASS
- `cd backend; .\gradlew.bat integrationTest --tests com.back.coach.ApplicationIntegrationTest --no-daemon --rerun` PASS
- `cd backend; .\gradlew.bat integrationTest --no-daemon` FAIL
  - 기존 통합 테스트 실패 확인: `GithubAnalysisE2eTest` 2건 JSON path 불일치, `GithubAnalysisFlowIntegrationTest` 1건 `owner_type` fixture 누락
  - 이번 변경 파일과 직접 관련 없는 실패입니다.
