### PR TITLE
fix(dashboard): v1 대시보드 중간 상태 snapshot 안정화

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/dashboard/service/DashboardSnapshotServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/dashboard/service/DashboardSnapshotServiceTest.java
@@ -82,6 +82,88 @@ class DashboardSnapshotServiceTest {
     }
 
     @Test
+    void findSnapshot_whenOnlyProfileExists_returnsProfileAndNullResultSummaries() {
+        Instant profileUpdatedAt = Instant.parse("2026-04-28T01:00:00Z");
+        UserProfile profile = userProfile(10L, profileUpdatedAt);
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.of(profile));
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.profile()).isEqualTo(new DashboardSnapshot.ProfileSummary(
+                10L,
+                100L,
+                CurrentLevel.JUNIOR,
+                12,
+                LocalDate.of(2026, 12, 31),
+                profileUpdatedAt
+        ));
+        assertThat(result.githubAnalysis()).isNull();
+        assertThat(result.diagnosis()).isNull();
+        assertThat(result.roadmap()).isNull();
+        verifyNoInteractions(roadmapWeekRepository, roadmapProgressSnapshotService);
+    }
+
+    @Test
+    void findSnapshot_whenOnlyGithubAnalysisExists_returnsGithubAnalysisAndNullLaterSummaries() {
+        Instant githubAnalysisCreatedAt = Instant.parse("2026-04-28T02:00:00Z");
+        GithubAnalysis githubAnalysis = githubAnalysis(20L, 1, "latest analysis", githubAnalysisCreatedAt);
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.empty());
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.of(githubAnalysis));
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.profile()).isNull();
+        assertThat(result.githubAnalysis()).isEqualTo(new DashboardSnapshot.GithubAnalysisSummary(
+                20L,
+                1,
+                "latest analysis",
+                githubAnalysisCreatedAt,
+                finalTechProfile(),
+                1
+        ));
+        assertThat(result.diagnosis()).isNull();
+        assertThat(result.roadmap()).isNull();
+        verifyNoInteractions(roadmapWeekRepository, roadmapProgressSnapshotService);
+    }
+
+    @Test
+    void findSnapshot_whenDiagnosisExistsWithoutRoadmap_returnsDiagnosisAndNullRoadmap() {
+        Instant diagnosisCreatedAt = Instant.parse("2026-04-28T03:00:00Z");
+        CapabilityDiagnosis diagnosis = diagnosis(30L, 1, "latest diagnosis", diagnosisCreatedAt);
+        given(userProfileRepository.findByUserId(1L)).willReturn(Optional.empty());
+        given(githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+        given(capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.of(diagnosis));
+        given(learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(1L))
+                .willReturn(Optional.empty());
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.profile()).isNull();
+        assertThat(result.githubAnalysis()).isNull();
+        assertThat(result.diagnosis()).isEqualTo(new DashboardSnapshot.DiagnosisSummary(
+                30L,
+                1,
+                "latest diagnosis",
+                diagnosisCreatedAt
+        ));
+        assertThat(result.roadmap()).isNull();
+        verifyNoInteractions(roadmapWeekRepository, roadmapProgressSnapshotService);
+    }
+
+    @Test
     void findSnapshot_whenLatestResultsExist_returnsLatestSummaries() {
         Instant profileUpdatedAt = Instant.parse("2026-04-28T01:00:00Z");
         Instant githubAnalysisCreatedAt = Instant.parse("2026-04-28T02:00:00Z");
@@ -158,6 +240,27 @@ class DashboardSnapshotServiceTest {
         DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
 
         assertThat(result.roadmap().progress()).isEqualTo(new DashboardSnapshot.ProgressSummary(4, 1, 1, 1, 1));
+    }
+
+    @Test
+    void findSnapshot_whenLatestRoadmapHasWeeksWithoutProgressLogs_countsWeeksAsTodo() {
+        LearningRoadmap roadmap = roadmap(40L, 2, 2, "latest roadmap", Instant.parse("2026-04-28T04:00:00Z"));
+        givenEmptyLatestResultsExceptRoadmap(1L, roadmap);
+        List<RoadmapWeek> roadmapWeeks = List.of(
+                roadmapWeek(10L),
+                roadmapWeek(20L)
+        );
+        given(roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(40L))
+                .willReturn(roadmapWeeks);
+        given(roadmapProgressSnapshotService.findSnapshots(1L, List.of(10L, 20L)))
+                .willReturn(List.of(
+                        progressSnapshot(10L, ProgressStatus.TODO),
+                        progressSnapshot(20L, ProgressStatus.TODO)
+                ));
+
+        DashboardSnapshot result = dashboardSnapshotService.findSnapshot(1L);
+
+        assertThat(result.roadmap().progress()).isEqualTo(new DashboardSnapshot.ProgressSummary(2, 2, 0, 0, 0));
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/flow/V1ApiStorageRequeryIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/V1ApiStorageRequeryIntegrationTest.java
@@ -162,21 +162,70 @@ class V1ApiStorageRequeryIntegrationTest extends ApiTestBase {
                 .andExpect(jsonPath("$.data.diagnosis").value(nullValue()))
                 .andExpect(jsonPath("$.data.roadmap").value(nullValue()));
 
-        User partialUser = saveUser("dashboard-partial");
-        UserProfile profile = saveProfileFixture(partialUser.getId());
-        GithubAnalysis githubAnalysis = saveGithubAnalysisFixture(partialUser.getId());
+        User profileOnlyUser = saveUser("dashboard-profile-only");
+        UserProfile profile = saveProfileFixture(profileOnlyUser.getId());
 
         mockMvc.perform(get("/api/dashboard")
-                        .cookie(accessTokenCookie(partialUser)))
+                        .cookie(accessTokenCookie(profileOnlyUser)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.userId").value(String.valueOf(partialUser.getId())))
+                .andExpect(jsonPath("$.data.userId").value(String.valueOf(profileOnlyUser.getId())))
                 .andExpect(jsonPath("$.data.profile.profileId").value(String.valueOf(profile.getId())))
                 .andExpect(jsonPath("$.data.profile.currentLevel").value("JUNIOR"))
+                .andExpect(jsonPath("$.data.githubAnalysis").value(nullValue()))
+                .andExpect(jsonPath("$.data.diagnosis").value(nullValue()))
+                .andExpect(jsonPath("$.data.roadmap").value(nullValue()));
+
+        User githubOnlyUser = saveUser("dashboard-github-only");
+        GithubAnalysis githubAnalysis = saveGithubAnalysisFixture(githubOnlyUser.getId());
+
+        mockMvc.perform(get("/api/dashboard")
+                        .cookie(accessTokenCookie(githubOnlyUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(String.valueOf(githubOnlyUser.getId())))
+                .andExpect(jsonPath("$.data.profile").value(nullValue()))
                 .andExpect(jsonPath("$.data.githubAnalysis.githubAnalysisId").value(String.valueOf(githubAnalysis.getId())))
                 .andExpect(jsonPath("$.data.githubAnalysis.version").value(1))
                 .andExpect(jsonPath("$.data.githubAnalysis.finalTechProfile.confirmedSkills[0]").value("Spring Boot"))
                 .andExpect(jsonPath("$.data.diagnosis").value(nullValue()))
                 .andExpect(jsonPath("$.data.roadmap").value(nullValue()));
+
+        User diagnosisWithoutRoadmapUser = saveUser("dashboard-diagnosis-only");
+        CapabilityDiagnosis diagnosis = saveDiagnosisFixture(diagnosisWithoutRoadmapUser.getId());
+
+        mockMvc.perform(get("/api/dashboard")
+                        .cookie(accessTokenCookie(diagnosisWithoutRoadmapUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(String.valueOf(diagnosisWithoutRoadmapUser.getId())))
+                .andExpect(jsonPath("$.data.profile").isMap())
+                .andExpect(jsonPath("$.data.githubAnalysis").isMap())
+                .andExpect(jsonPath("$.data.diagnosis.diagnosisId").value(String.valueOf(diagnosis.getId())))
+                .andExpect(jsonPath("$.data.diagnosis.summary").value("Redis 보완 필요"))
+                .andExpect(jsonPath("$.data.roadmap").value(nullValue()));
+
+        User roadmapWithoutProgressUser = saveUser("dashboard-roadmap-no-progress");
+        LearningRoadmap roadmap = saveRoadmapFixture(roadmapWithoutProgressUser.getId(), 3);
+
+        mockMvc.perform(get("/api/dashboard")
+                        .cookie(accessTokenCookie(roadmapWithoutProgressUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roadmap.roadmapId").value(String.valueOf(roadmap.getId())))
+                .andExpect(jsonPath("$.data.roadmap.progress.totalWeeks").value(3))
+                .andExpect(jsonPath("$.data.roadmap.progress.todoWeeks").value(3))
+                .andExpect(jsonPath("$.data.roadmap.progress.inProgressWeeks").value(0))
+                .andExpect(jsonPath("$.data.roadmap.progress.doneWeeks").value(0))
+                .andExpect(jsonPath("$.data.roadmap.progress.skippedWeeks").value(0));
+    }
+
+    @Test
+    @DisplayName("대시보드 API는 잘못된 GitHub 분석 payload를 공통 에러 응답으로 반환한다")
+    void dashboardApi_whenGithubAnalysisPayloadIsInvalid_returnsCommonErrorResponse() throws Exception {
+        User invalidPayloadUser = saveUser("dashboard-invalid-payload");
+        saveInvalidGithubAnalysisFixture(invalidPayloadUser.getId());
+
+        mockMvc.perform(get("/api/dashboard")
+                        .cookie(accessTokenCookie(invalidPayloadUser)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
     }
 
     @Test
@@ -206,20 +255,7 @@ class V1ApiStorageRequeryIntegrationTest extends ApiTestBase {
     }
 
     private LearningRoadmap saveRoadmapFixture(Long userId, int totalWeeks) {
-        UserProfile profile = saveProfileFixture(userId);
-        GithubAnalysis githubAnalysis = saveGithubAnalysisFixture(userId);
-        JobRole jobRole = jobRoleRepository.findByRoleCodeAndActiveTrue("BACKEND_DEVELOPER")
-                .orElseThrow();
-        CapabilityDiagnosis diagnosis = capabilityDiagnosisRepository.save(CapabilityDiagnosis.create(
-                userId,
-                profile.getId(),
-                githubAnalysis.getId(),
-                jobRole.getId(),
-                1,
-                CurrentLevel.JUNIOR,
-                "Redis 보완 필요",
-                diagnosisPayload()
-        ));
+        CapabilityDiagnosis diagnosis = saveDiagnosisFixture(userId);
         LearningRoadmap roadmap = learningRoadmapRepository.save(LearningRoadmap.create(
                 userId,
                 diagnosis.getId(),
@@ -230,6 +266,23 @@ class V1ApiStorageRequeryIntegrationTest extends ApiTestBase {
         ));
         roadmapWeekRepository.saveAll(roadmapWeeks(roadmap.getId(), totalWeeks));
         return roadmap;
+    }
+
+    private CapabilityDiagnosis saveDiagnosisFixture(Long userId) {
+        UserProfile profile = saveProfileFixture(userId);
+        GithubAnalysis githubAnalysis = saveGithubAnalysisFixture(userId);
+        JobRole jobRole = jobRoleRepository.findByRoleCodeAndActiveTrue("BACKEND_DEVELOPER")
+                .orElseThrow();
+        return capabilityDiagnosisRepository.save(CapabilityDiagnosis.create(
+                userId,
+                profile.getId(),
+                githubAnalysis.getId(),
+                jobRole.getId(),
+                1,
+                CurrentLevel.JUNIOR,
+                "Redis 보완 필요",
+                diagnosisPayload()
+        ));
     }
 
     private UserProfile saveProfileFixture(Long userId) {
@@ -261,6 +314,23 @@ class V1ApiStorageRequeryIntegrationTest extends ApiTestBase {
                 1,
                 "Spring Boot 중심 GitHub 분석",
                 githubAnalysisPayloadJson.toJson(githubAnalysisPayload())
+        ));
+    }
+
+    private GithubAnalysis saveInvalidGithubAnalysisFixture(Long userId) {
+        GithubConnection connection = githubConnectionRepository.save(GithubConnection.connect(
+                userId,
+                unique("gh-user"),
+                unique("login"),
+                GithubAccessType.OAUTH,
+                "ghp_test_token"
+        ));
+        return githubAnalysisRepository.save(GithubAnalysis.create(
+                userId,
+                connection.getId(),
+                1,
+                "깨진 GitHub 분석 payload",
+                "\"not-an-object\""
         ));
     }
 


### PR DESCRIPTION
﻿Closes #267

## 변경 요약
- 대시보드 중간 상태별 snapshot 단위 테스트 보강
- `/api/dashboard` API 회귀 테스트에 빈 상태, 프로필만, GitHub 분석만, 진단까지만, 로드맵+진도 없음 케이스 추가
- 잘못된 GitHub 분석 payload가 공통 에러 응답으로 내려가는지 검증

## 왜 필요한가
- 사용자가 v1 흐름을 중간에 멈추고 대시보드로 돌아와도 500 없이 현재까지의 결과만 안정적으로 보여줘야 합니다.

## 테스트
- `cd backend; .\gradlew.bat test --tests com.back.coach.domain.dashboard.service.DashboardSnapshotServiceTest --tests com.back.coach.domain.dashboard.controller.DashboardControllerTest --no-daemon` PASS
- `cd backend; .\gradlew.bat integrationTest --tests com.back.coach.domain.flow.V1ApiStorageRequeryIntegrationTest --no-daemon` PASS
- `cd backend; .\gradlew.bat prVerification --no-daemon` PASS
