### PR TITLE
test(flow): v1 통합 테스트 실패 정리

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
@@ -3,6 +3,8 @@ package com.back.coach.domain.flow;
 import com.back.coach.domain.user.entity.User;
 import com.back.coach.domain.user.repository.UserRepository;
 import com.back.coach.external.github.GithubApiClient;
+import com.back.coach.external.github.dto.GithubCommitDetailDto;
+import com.back.coach.external.github.dto.GithubCommitDto;
 import com.back.coach.external.github.dto.GithubRepoDto;
 import com.back.coach.external.github.dto.GithubUserInfoDto;
 import com.back.coach.global.code.AuthProvider;
@@ -28,7 +30,7 @@ import java.util.UUID;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -86,7 +88,10 @@ class GithubAnalysisE2eTest extends ApiTestBase {
         ));
         given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
         given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of("Java", 10000L));
-        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), any(int.class))).willReturn(List.of());
+        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                .willReturn(List.of(commit("abc123", "feat: Spring Boot 도입")));
+        given(githubApiClient.getCommitDetail(anyString(), anyString(), anyString(), anyString()))
+                .willReturn(commitDetail("abc123", "feat: Spring Boot 도입"));
         given(githubApiClient.listPullRequests(anyString(), anyString(), anyString())).willReturn(List.of());
         given(githubApiClient.listIssues(anyString(), anyString(), anyString())).willReturn(List.of());
 
@@ -157,7 +162,10 @@ class GithubAnalysisE2eTest extends ApiTestBase {
         ));
         given(githubApiClient.getReadme(anyString(), anyString(), anyString())).willReturn(Optional.empty());
         given(githubApiClient.getLanguages(anyString(), anyString(), anyString())).willReturn(Map.of());
-        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), any(int.class))).willReturn(List.of());
+        given(githubApiClient.listCommits(anyString(), anyString(), anyString(), anyString(), anyInt()))
+                .willReturn(List.of(commit("abc123", "refactor: 마이크로서비스 전환 시도")));
+        given(githubApiClient.getCommitDetail(anyString(), anyString(), anyString(), anyString()))
+                .willReturn(commitDetail("abc123", "refactor: 마이크로서비스 전환 시도"));
         given(githubApiClient.listPullRequests(anyString(), anyString(), anyString())).willReturn(List.of());
         given(githubApiClient.listIssues(anyString(), anyString(), anyString())).willReturn(List.of());
 
@@ -234,6 +242,28 @@ class GithubAnalysisE2eTest extends ApiTestBase {
                 "\"depthEstimates\":[{\"skillName\":\"Spring Boot\",\"level\":\"PRACTICAL\",\"reason\":\"일관된 사용\"}]," +
                 "\"evidences\":[{\"repoName\":\"testuser/backend\",\"type\":\"COMMIT\",\"source\":\"abc123\",\"summary\":\"핵심 로직\"}]," +
                 "\"finalTechProfile\":{\"confirmedSkills\":[\"Spring Boot\"],\"focusAreas\":[\"백엔드\"]}}";
+    }
+
+    private static GithubCommitDto commit(String sha, String message) {
+        return new GithubCommitDto(
+                sha,
+                new GithubCommitDto.CommitInfo(
+                        message,
+                        new GithubCommitDto.Committer("2026-05-01T00:00:00Z")
+                )
+        );
+    }
+
+    private static GithubCommitDetailDto commitDetail(String sha, String message) {
+        return new GithubCommitDetailDto(
+                sha,
+                new GithubCommitDetailDto.CommitInfo(message),
+                new GithubCommitDetailDto.Stats(24, 3),
+                List.of(new GithubCommitDetailDto.FileChange(
+                        "src/main/java/com/example/App.java",
+                        "@@ -1,3 +1,5 @@\n+class App {}\n+// Spring Boot"
+                ))
+        );
     }
 
     private static long extractLong(String json, String field) {

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisFlowIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisFlowIntegrationTest.java
@@ -118,6 +118,7 @@ class GithubAnalysisFlowIntegrationTest {
             org.springframework.test.util.ReflectionTestUtils.setField(p, "repoFullName", fullName);
             org.springframework.test.util.ReflectionTestUtils.setField(p, "repoUrl", "https://github.com/" + fullName);
             org.springframework.test.util.ReflectionTestUtils.setField(p, "primaryLanguage", lang);
+            org.springframework.test.util.ReflectionTestUtils.setField(p, "ownerType", "owner");
             org.springframework.test.util.ReflectionTestUtils.setField(p, "selected", true);
             org.springframework.test.util.ReflectionTestUtils.setField(p, "coreRepo", true);
             org.springframework.test.util.ReflectionTestUtils.setField(p, "metadataPayload", metadataJson);


### PR DESCRIPTION
﻿Closes #274

## 변경 요약
- GitHub 분석 E2E 테스트의 commit metadata mock 보강
- GitHub 분석 플로우 테스트의 `ownerType` fixture 보강
- 현재 API 응답 계약인 `repoSummaries[].highlights[].{text,status}` 검증 유지

## 왜 필요한가
- 시연 전 통합 테스트 실패가 실제 회귀인지 테스트 fixture 노후화인지 구분 가능해야 v1 안정화 검증을 신뢰할 수 있습니다.

## 테스트
- `cd backend; .\gradlew.bat integrationTest --tests com.back.coach.domain.flow.GithubAnalysisE2eTest --tests com.back.coach.domain.github.service.GithubAnalysisFlowIntegrationTest --no-daemon` PASS
- `cd backend; .\gradlew.bat prVerification --no-daemon` PASS
- `cd backend; .\gradlew.bat integrationTest --no-daemon` PASS
