### PR TITLE
fix(frontend): v1 demo 경로 의존 CTA 제거

### DIFF
--- a/frontend/src/app/diagnoses/page.tsx
+++ b/frontend/src/app/diagnoses/page.tsx
@@ -1,33 +1,108 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
 import { ApiError, githubLoginUrl } from "@/lib/api";
 
+type DiagnosesPageState =
+  | { status: "loading" }
+  | { status: "ready"; githubAnalysisId: string | null }
+  | { status: "error"; message: string };
+
 export default function DiagnosesPage() {
   const router = useRouter();
+  const [state, setState] = useState<DiagnosesPageState>({
+    status: "loading"
+  });
 
   useEffect(() => {
+    let ignore = false;
+
     getDashboard()
       .then((dashboard) => {
+        if (ignore) return;
         if (dashboard.diagnosis?.diagnosisId) {
           router.replace(`/diagnoses/${dashboard.diagnosis.diagnosisId}`);
+          return;
         }
+        setState({
+          githubAnalysisId: dashboard.githubAnalysis?.githubAnalysisId ?? null,
+          status: "ready"
+        });
       })
       .catch((error) => {
+        if (ignore) return;
         if (error instanceof ApiError && error.status === 401) {
           window.location.href = githubLoginUrl("/diagnoses");
+          return;
         }
+        setState({ message: getErrorMessage(error), status: "error" });
       });
+
+    return () => {
+      ignore = true;
+    };
   }, [router]);
+
+  if (state.status === "error") {
+    return (
+      <StatePanel
+        className="diagnosis-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
+  }
+
+  if (state.status === "ready") {
+    const hasGithubAnalysis = Boolean(state.githubAnalysisId);
+
+    return (
+      <section className="screen-shell">
+        <StatePanel
+          className="diagnosis-state-panel"
+          message={
+            hasGithubAnalysis
+              ? "아직 생성된 진단 결과가 없습니다."
+              : "진단에 사용할 GitHub 분석 결과가 없습니다."
+          }
+        />
+        <div className="action-row" aria-label="진단 다음 행동">
+          {hasGithubAnalysis ? (
+            <Link
+              className="action-link primary"
+              href={`/diagnoses/new?githubAnalysisId=${state.githubAnalysisId}`}
+            >
+              진단 생성
+            </Link>
+          ) : (
+            <Link className="action-link primary" href="/github">
+              GitHub 연동
+            </Link>
+          )}
+          <Link className="action-link" href="/github/analysis">
+            분석 보정
+          </Link>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <StatePanel
       message="최근 진단 결과를 불러오는 중입니다."
     />
   );
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "최근 진단 결과를 불러오지 못했습니다.";
 }

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -59,7 +59,7 @@ export const screens = {
       "프로필, GitHub 분석, 진단, 로드맵의 최신 상태를 한 화면에서 확인하는 진입점입니다.",
     states: ["최신 결과 조회", "상세 화면 이동", "진도 요약 확인"],
     primaryAction: { label: "프로필 입력", href: "/profile" },
-    secondaryAction: { label: "로드맵 보기", href: "/roadmaps/demo" },
+    secondaryAction: { label: "로드맵 보기", href: "/roadmaps" },
     sections: [
       {
         title: "표시 예정 데이터",
@@ -115,7 +115,7 @@ export const screens = {
     description:
       "정적 분석 결과와 근거를 확인하고 사용자 보정값을 저장하는 화면입니다.",
     states: ["분석 완료", "보정 전", "보정 저장 완료"],
-    primaryAction: { label: "진단 결과 확인", href: "/diagnoses/demo" },
+    primaryAction: { label: "진단 결과 확인", href: "/diagnoses" },
     secondaryAction: { label: "저장소 선택으로 이동", href: "/github" },
     sections: [
       {
@@ -149,8 +149,8 @@ export const screens = {
     description:
       "진단 결과를 기준으로 학습 가능 시간과 목표 날짜를 확인한 뒤 로드맵을 생성하는 화면입니다.",
     states: ["진단 선택", "생성 요청", "생성 완료"],
-    primaryAction: { label: "로드맵 보기", href: "/roadmaps/demo" },
-    secondaryAction: { label: "진단 결과로 이동", href: "/diagnoses/demo" },
+    primaryAction: { label: "로드맵 보기", href: "/roadmaps" },
+    secondaryAction: { label: "진단 결과로 이동", href: "/diagnoses" },
     sections: [
       {
         title: "입력 예정 항목",

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -29,7 +29,6 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
   const [state, setState] = useState<DiagnosisState>({ status: "loading" });
 
   useEffect(() => {
-    if (diagnosisId === "demo") return;
     let ignore = false;
 
     async function loadDiagnosis() {
@@ -58,15 +57,6 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
     };
   }, [diagnosisId]);
 
-  if (diagnosisId === "demo") {
-    return (
-      <StatePanel
-        tone="neutral"
-        message="이 페이지는 아직 구현 중입니다. 분석 결과 페이지(/github/analysis)의 '진단 생성' 버튼을 이용해 주세요."
-      />
-    );
-  }
-
   if (state.status === "loading") {
     return (
       <StatePanel
@@ -78,11 +68,21 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
 
   if (state.status === "error") {
     return (
-      <StatePanel
-        className="diagnosis-state-panel"
-        message={state.message}
-        tone="danger"
-      />
+      <section className="screen-shell">
+        <StatePanel
+          className="diagnosis-state-panel"
+          message={state.message}
+          tone="danger"
+        />
+        <div className="action-row" aria-label="진단 오류 다음 행동">
+          <Link className="action-link primary" href="/diagnoses">
+            최근 진단 보기
+          </Link>
+          <Link className="action-link" href="/github/analysis">
+            분석 보정
+          </Link>
+        </div>
+      </section>
     );
   }
 

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 
 import { StatePanel } from "@/components/state-panel";
@@ -32,7 +33,6 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
   const [saveErrors, setSaveErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (roadmapId === "demo") return;
     let ignore = false;
 
     async function loadRoadmap() {
@@ -128,15 +128,6 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
     }
   }
 
-  if (roadmapId === "demo") {
-    return (
-      <StatePanel
-        tone="neutral"
-        message="이 페이지는 아직 구현 중입니다. 진단 생성 후 로드맵 생성 페이지(/roadmaps/new)를 이용해 주세요."
-      />
-    );
-  }
-
   if (state.status === "loading") {
     return (
       <StatePanel
@@ -148,11 +139,21 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
 
   if (state.status === "error") {
     return (
-      <StatePanel
-        className="roadmap-state-panel"
-        message={state.message}
-        tone="danger"
-      />
+      <section className="screen-shell">
+        <StatePanel
+          className="roadmap-state-panel"
+          message={state.message}
+          tone="danger"
+        />
+        <div className="action-row" aria-label="로드맵 오류 다음 행동">
+          <Link className="action-link primary" href="/roadmaps">
+            최근 로드맵 보기
+          </Link>
+          <Link className="action-link" href="/roadmaps/new">
+            로드맵 생성
+          </Link>
+        </div>
+      </section>
     );
   }
 


### PR DESCRIPTION
Closes #275

## 변경 요약
- demo 상세 경로로 이동하는 CTA 제거
- 진단/로드맵 생성 후 실제 결과 ID 기반 이동 유지
- 결과가 없거나 잘못된 ID 접근 시 다음 행동 안내

## 왜 필요한가
- 시연 중 placeholder 화면으로 빠지지 않고 실제 v1 생성 결과 흐름이 이어져야 하기 때문

## 테스트
- PASS: `cd frontend; npm run lint`
- PASS: `cd frontend; npm run build`
- PASS: `rg '/diagnoses/demo|/roadmaps/demo' frontend/src -n` 결과 없음