### PR TITLE
fix(auth): 인증 만료 및 401 응답 복구 UX 정리

### DIFF
--- a/frontend/src/app/diagnoses/page.tsx
+++ b/frontend/src/app/diagnoses/page.tsx
@@ -4,12 +4,15 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
-import { ApiError, githubLoginUrl } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type DiagnosesPageState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "ready"; githubAnalysisId: string | null }
   | { status: "error"; message: string };
 
@@ -36,8 +39,8 @@ export default function DiagnosesPage() {
       })
       .catch((error) => {
         if (ignore) return;
-        if (error instanceof ApiError && error.status === 401) {
-          window.location.href = githubLoginUrl("/diagnoses");
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
           return;
         }
         setState({ message: getErrorMessage(error), status: "error" });
@@ -54,6 +57,15 @@ export default function DiagnosesPage() {
         className="diagnosis-state-panel"
         message={state.message}
         tone="danger"
+      />
+    );
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="diagnosis-state-panel"
+        redirectPath="/diagnoses"
       />
     );
   }

--- a/frontend/src/app/github/callback/page.tsx
+++ b/frontend/src/app/github/callback/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { connectGithub } from "@/features/github-connection/api";
 import { StatePanel } from "@/components/state-panel";
+import { isUnauthorizedError, getLoginPath } from "@/lib/auth";
 
 const CONNECTION_ID_KEY = "githubConnectionId";
 
@@ -30,7 +31,11 @@ function CallbackInner() {
         localStorage.setItem(CONNECTION_ID_KEY, connection.githubConnectionId);
         router.replace("/github");
       })
-      .catch(() => {
+      .catch((error) => {
+        if (isUnauthorizedError(error)) {
+          router.replace(getLoginPath("/github"));
+          return;
+        }
         router.replace("/github?error=connection_failed");
       });
   }, [params, router]);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1603,6 +1603,28 @@ a {
   color: #a32020;
 }
 
+.login-notice {
+  display: grid;
+  gap: 6px;
+  border: 1px solid #b7d6f8;
+  border-radius: 8px;
+  background: #f3f8ff;
+  padding: 12px 14px;
+}
+
+.login-notice p {
+  margin: 0;
+  color: #225179;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.login-notice strong {
+  font-size: 13px;
+  font-weight: 700;
+  color: #225179;
+}
+
 .login-footer {
   text-align: center;
   color: var(--muted);

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useSyncExternalStore, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 import { githubLoginUrl } from "@/lib/api";
+import { normalizeLocalRedirectPath } from "@/lib/auth";
 
 const ERROR_MESSAGES: Record<string, string> = {
   access_denied: "GitHub 로그인을 취소했습니다.",
@@ -45,6 +46,8 @@ function KakaoIcon() {
 function LoginInner() {
   const params = useSearchParams();
   const error = params.get("error");
+  const redirectPath = normalizeLocalRedirectPath(params.get("redirectUrl"));
+  const isAuthRequired = params.has("redirectUrl");
   const [githubLoading, setGithubLoading] = useState(false);
 
   const origin = useSyncExternalStore(
@@ -53,7 +56,7 @@ function LoginInner() {
     () => ""
   );
 
-  const loginUrl = origin ? githubLoginUrl(`${origin}/me`) : null;
+  const loginUrl = origin ? githubLoginUrl(`${origin}${redirectPath}`) : null;
 
   function handleGitHubLogin() {
     if (!loginUrl) return;
@@ -77,6 +80,13 @@ function LoginInner() {
           <div className="login-error" role="alert">
             <strong>로그인 실패</strong>
             <p>{errorMessage}</p>
+          </div>
+        )}
+
+        {!errorMessage && isAuthRequired && (
+          <div className="login-notice" role="status">
+            <strong>로그인이 필요합니다</strong>
+            <p>다시 로그인하면 이전 화면으로 돌아갑니다.</p>
           </div>
         )}
 

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { api } from "@/lib/api";
 
 type Me = { userId: number; email: string; authProvider: string };
@@ -9,6 +10,7 @@ export default function MePage() {
   const router = useRouter();
   const [me, setMe] = useState<Me | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [authRequired, setAuthRequired] = useState(false);
   const [loading, setLoading] = useState(true);
   const didInitialLoad = useRef(false);
 
@@ -17,11 +19,13 @@ export default function MePage() {
       setLoading(true);
     }
     setError(null);
+    setAuthRequired(false);
     const res = await api<Me>("/api/v1/auth/me");
     if (res.ok && res.data) {
       setMe(res.data);
     } else if (res.status === 401) {
-      setError("인증 만료 또는 미인증. /refresh 시도하거나 다시 로그인하세요.");
+      setMe(null);
+      setAuthRequired(true);
     } else {
       setError(`HTTP ${res.status}`);
     }
@@ -40,7 +44,14 @@ export default function MePage() {
   const refresh = async () => {
     const res = await api("/api/v1/auth/refresh", { method: "POST" });
     if (res.ok) await load();
-    else setError(`refresh 실패: HTTP ${res.status}`);
+    else if (res.status === 401) {
+      setError(null);
+      setAuthRequired(true);
+    }
+    else {
+      setAuthRequired(false);
+      setError(`refresh 실패: HTTP ${res.status}`);
+    }
   };
 
   const logout = async () => {
@@ -62,6 +73,10 @@ export default function MePage() {
         <div className="panel">
           <p>불러오는 중…</p>
         </div>
+      )}
+
+      {!loading && authRequired && (
+        <AuthRequiredPanel redirectPath="/me" standalone={false} />
       )}
 
       {error && (

--- a/frontend/src/app/roadmaps/page.tsx
+++ b/frontend/src/app/roadmaps/page.tsx
@@ -1,18 +1,31 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
-import { ApiError, githubLoginUrl } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
+
+type RoadmapsPageState =
+  | { status: "loading" }
+  | { status: "auth-required" }
+  | { status: "error"; message: string };
 
 export default function RoadmapsPage() {
   const router = useRouter();
+  const [state, setState] = useState<RoadmapsPageState>({
+    status: "loading"
+  });
 
   useEffect(() => {
+    let ignore = false;
+
     getDashboard()
       .then((dashboard) => {
+        if (ignore) return;
         if (dashboard.roadmap?.roadmapId) {
           router.replace(`/roadmaps/${dashboard.roadmap.roadmapId}`);
         } else {
@@ -20,15 +33,49 @@ export default function RoadmapsPage() {
         }
       })
       .catch((error) => {
-        if (error instanceof ApiError && error.status === 401) {
-          window.location.href = githubLoginUrl("/roadmaps");
+        if (ignore) return;
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
+          return;
         }
+        setState({ message: getErrorMessage(error), status: "error" });
       });
+
+    return () => {
+      ignore = true;
+    };
   }, [router]);
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="roadmap-state-panel"
+        redirectPath="/roadmaps"
+      />
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <StatePanel
+        className="roadmap-state-panel"
+        message={state.message}
+        tone="danger"
+      />
+    );
+  }
 
   return (
     <StatePanel
       message="최근 로드맵을 불러오는 중입니다."
     />
   );
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  return "최근 로드맵을 불러오지 못했습니다.";
 }

--- a/frontend/src/components/auth-required-panel.tsx
+++ b/frontend/src/components/auth-required-panel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+import { StatePanel } from "@/components/state-panel";
+import { getLoginPath } from "@/lib/auth";
+
+type AuthRequiredPanelProps = {
+  className?: string;
+  message?: string;
+  redirectPath?: string;
+  standalone?: boolean;
+};
+
+export function AuthRequiredPanel({
+  className,
+  message = "로그인이 필요합니다. 다시 로그인하면 이 화면으로 돌아옵니다.",
+  redirectPath,
+  standalone = true
+}: AuthRequiredPanelProps) {
+  const content = (
+    <>
+      <StatePanel className={className} message={message} tone="danger" />
+      <div className="action-row" aria-label="인증 복구">
+        <Link className="action-link primary" href={getLoginPath(redirectPath)}>
+          다시 로그인
+        </Link>
+        <Link className="action-link" href="/login">
+          로그인 화면
+        </Link>
+      </div>
+    </>
+  );
+
+  return standalone ? (
+    <section className="screen-shell">{content}</section>
+  ) : (
+    content
+  );
+}

--- a/frontend/src/features/dashboard/dashboard-view.tsx
+++ b/frontend/src/features/dashboard/dashboard-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import { TagList } from "@/components/tag-list";
 import { getDashboard } from "@/features/dashboard/api";
@@ -11,10 +12,12 @@ import type {
   Dashboard,
   DashboardProgressSummary
 } from "@/features/dashboard/types";
-import { ApiError, githubLoginUrl } from "@/lib/api";
+import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type DashboardState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "error"; message: string }
   | { status: "success"; dashboard: Dashboard };
 
@@ -35,8 +38,8 @@ export function DashboardView() {
         }
       } catch (error) {
         if (ignore) return;
-        if (error instanceof ApiError && error.status === 401) {
-          window.location.href = githubLoginUrl("/");
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
           return;
         }
         setState({
@@ -60,6 +63,10 @@ export function DashboardView() {
         message="대시보드를 불러오는 중입니다."
       />
     );
+  }
+
+  if (state.status === "auth-required") {
+    return <AuthRequiredPanel className="roadmap-state-panel" redirectPath="/" />;
   }
 
   if (state.status === "error") {

--- a/frontend/src/features/diagnosis/diagnosis-create-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-create-view.tsx
@@ -2,13 +2,16 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 import { createDiagnosis } from "@/features/diagnosis/api";
 import { getMyProfile } from "@/features/profile/api";
 import { StatePanel } from "@/components/state-panel";
 
 type CreateState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "ready"; profileId: string }
   | { status: "submitting" }
   | { status: "error"; message: string };
@@ -32,7 +35,13 @@ export function DiagnosisCreateView({ githubAnalysisId }: Props) {
     loaded.current = true;
     getMyProfile()
       .then((profile) => setState({ status: "ready", profileId: profile.profileId }))
-      .catch((err) => setState({ status: "error", message: getErrorMessage(err) }));
+      .catch((err) => {
+        if (isUnauthorizedError(err)) {
+          setState({ status: "auth-required" });
+          return;
+        }
+        setState({ status: "error", message: getErrorMessage(err) });
+      });
   }, []);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -43,6 +52,10 @@ export function DiagnosisCreateView({ githubAnalysisId }: Props) {
       const diagnosis = await createDiagnosis({ profileId: state.profileId, githubAnalysisId });
       router.push(`/diagnoses/${diagnosis.diagnosisId}`);
     } catch (err) {
+      if (isUnauthorizedError(err)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setState({ status: "error", message: getErrorMessage(err) });
     }
   }
@@ -53,6 +66,14 @@ export function DiagnosisCreateView({ githubAnalysisId }: Props) {
 
   if (state.status === "submitting") {
     return <StatePanel message="진단을 생성하는 중입니다. 잠시 기다려주세요..." />;
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        redirectPath={`/diagnoses/new?githubAnalysisId=${encodeURIComponent(githubAnalysisId)}`}
+      />
+    );
   }
 
   if (state.status === "error") {

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import {
   StatusBadge,
@@ -15,6 +16,7 @@ import {
 } from "@/features/diagnosis/labels";
 import type { Diagnosis, MissingSkill } from "@/features/diagnosis/types";
 import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type DiagnosisDetailViewProps = {
   diagnosisId: string;
@@ -22,6 +24,7 @@ type DiagnosisDetailViewProps = {
 
 type DiagnosisState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "error"; message: string }
   | { status: "success"; diagnosis: Diagnosis };
 
@@ -42,6 +45,10 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
         }
       } catch (error) {
         if (!ignore) {
+          if (isUnauthorizedError(error)) {
+            setState({ status: "auth-required" });
+            return;
+          }
           setState({
             message: getErrorMessage(error),
             status: "error"
@@ -62,6 +69,15 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
       <StatePanel
         className="diagnosis-state-panel"
         message="진단 결과를 불러오는 중입니다."
+      />
+    );
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="diagnosis-state-panel"
+        redirectPath={`/diagnoses/${encodeURIComponent(diagnosisId)}`}
       />
     );
   }

--- a/frontend/src/features/github-analysis/github-analysis-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import { getDashboard } from "@/features/dashboard/api";
 import {
@@ -20,6 +21,7 @@ import type {
   GithubUserCorrection
 } from "@/features/github-analysis/types";
 import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type GithubAnalysisViewProps = {
   initialGithubAnalysisId?: string | null;
@@ -27,6 +29,7 @@ type GithubAnalysisViewProps = {
 
 type GithubAnalysisState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "empty"; message: string }
   | { status: "error"; message: string }
   | {
@@ -54,7 +57,13 @@ export function GithubAnalysisView({
       try {
         const queryGithubAnalysisId = normalizeOptionalId(initialGithubAnalysisId);
         const dashboard = queryGithubAnalysisId
-          ? await getDashboard().catch(() => null)
+          ? await getDashboard().catch((error) => {
+              if (isUnauthorizedError(error)) {
+                throw error;
+              }
+
+              return null;
+            })
           : await getDashboard();
         const githubAnalysisId =
           queryGithubAnalysisId ??
@@ -82,6 +91,10 @@ export function GithubAnalysisView({
         }
       } catch (error) {
         if (!ignore) {
+          if (isUnauthorizedError(error)) {
+            setState({ status: "auth-required" });
+            return;
+          }
           setState({
             message: getErrorMessage(error),
             status: "error"
@@ -148,6 +161,10 @@ export function GithubAnalysisView({
       });
       setSaveMessage(`저장 완료 ${formatDateTime(saved.savedAt)}`);
     } catch (error) {
+      if (isUnauthorizedError(error)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setSaveError(getSaveErrorMessage(error));
     } finally {
       setIsSaving(false);
@@ -159,6 +176,19 @@ export function GithubAnalysisView({
       <StatePanel
         className="github-analysis-state-panel"
         message="GitHub 분석 결과를 불러오는 중입니다."
+      />
+    );
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="github-analysis-state-panel"
+        redirectPath={
+          initialGithubAnalysisId
+            ? `/github/analysis?githubAnalysisId=${encodeURIComponent(initialGithubAnalysisId)}`
+            : "/github/analysis"
+        }
       />
     );
   }

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError, githubConnectionOAuthUrl } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 import { getRepositories, runAnalysis } from "@/features/github-connection/api";
 import type { Repository } from "@/features/github-connection/types";
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 
 const CONNECTION_ID_KEY = "githubConnectionId";
@@ -14,6 +16,7 @@ const SELECTED_REPOS_KEY = "githubSelectedRepos";
 type ViewState =
   | { status: "disconnected" }
   | { status: "loading-repos" }
+  | { status: "auth-required" }
   | { status: "ready"; repos: Repository[] }
   | { status: "analyzing" }
   | { status: "error"; message: string };
@@ -75,6 +78,8 @@ export function GithubConnectionView() {
         if (cancelled) return;
         if (err instanceof ApiError && err.status === 404) {
           clearConnectionId();
+        } else if (isUnauthorizedError(err)) {
+          setState({ status: "auth-required" });
         } else {
           setState({ status: "error", message: getErrorMessage(err) });
         }
@@ -99,6 +104,10 @@ export function GithubConnectionView() {
       const result = await runAnalysis(connectionId, ids, ids);
       router.push(`/github/analysis?githubAnalysisId=${result.githubAnalysisId}`);
     } catch (err) {
+      if (isUnauthorizedError(err)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setState({ status: "error", message: getErrorMessage(err) });
     }
   }
@@ -123,6 +132,15 @@ export function GithubConnectionView() {
 
   if (state.status === "analyzing") {
     return <StatePanel message="GitHub 분석 중입니다. 잠시 기다려주세요..." />;
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="github-connection-state-panel"
+        redirectPath="/github"
+      />
+    );
   }
 
   if (state.status === "error") {

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import { getJobRoles, getMyProfile, saveProfile } from "@/features/profile/api";
 import {
@@ -20,9 +21,11 @@ import type {
   ProficiencyLevel
 } from "@/features/profile/types";
 import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type ProfileState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "error"; message: string }
   | { profile: ProfileDetail | null; status: "ready" };
 
@@ -54,6 +57,10 @@ export function ProfileView() {
         }
       } catch (error) {
         if (ignore) return;
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
+          return;
+        }
         setState({ message: getErrorMessage(error), status: "error" });
       }
     }
@@ -70,6 +77,15 @@ export function ProfileView() {
       <StatePanel
         className="profile-state-panel"
         message="프로필을 불러오는 중입니다."
+      />
+    );
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="profile-state-panel"
+        redirectPath="/profile"
       />
     );
   }
@@ -108,6 +124,10 @@ export function ProfileView() {
       const profile = await getMyProfile();
       setState({ profile, status: "ready" });
     } catch (error) {
+      if (isUnauthorizedError(error)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setSaveError(getErrorMessage(error));
     } finally {
       setSaving(false);

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -4,7 +4,9 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { ApiError, apiClient } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 import { getMyProfile } from "@/features/profile/api";
 import { getDashboard } from "@/features/dashboard/api";
 import { StatePanel } from "@/components/state-panel";
@@ -12,6 +14,7 @@ import { StatePanel } from "@/components/state-panel";
 type CreateState =
   | { status: "idle" }
   | { status: "submitting" }
+  | { status: "auth-required" }
   | { status: "error"; message: string };
 
 function getErrorMessage(error: unknown): string {
@@ -57,7 +60,11 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
           setWeeklyStudyHours(String(profile.weeklyStudyHours));
         if (profile.targetDate) setTargetDate(profile.targetDate);
       })
-      .catch(() => {});
+      .catch((error) => {
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
+        }
+      });
 
     // initialDiagnosisId가 없으면 대시보드에서 최신 진단 자동 로드
     if (!initialDiagnosisId) {
@@ -68,7 +75,11 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
             setDiagnosisSummary(dashboard.diagnosis.summary);
           }
         })
-        .catch(() => {});
+        .catch((error) => {
+          if (isUnauthorizedError(error)) {
+            setState({ status: "auth-required" });
+          }
+        });
     } else {
       // initialDiagnosisId가 있으면 대시보드에서 summary만 가져옴
       getDashboard()
@@ -80,7 +91,11 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
             setDiagnosisSummary(dashboard.diagnosis.summary);
           }
         })
-        .catch(() => {});
+        .catch((error) => {
+          if (isUnauthorizedError(error)) {
+            setState({ status: "auth-required" });
+          }
+        });
     }
   }, [initialDiagnosisId]);
 
@@ -123,11 +138,28 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
       });
       router.push(`/roadmaps/${result.roadmapId}`);
     } catch (err) {
+      if (isUnauthorizedError(err)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setState({ status: "error", message: getErrorMessage(err) });
     }
   }
 
   const isSubmitting = state.status === "submitting";
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="roadmap-state-panel"
+        redirectPath={
+          initialDiagnosisId
+            ? `/roadmaps/new?diagnosisId=${encodeURIComponent(initialDiagnosisId)}`
+            : "/roadmaps/new"
+        }
+      />
+    );
+  }
 
   return (
     <section className="screen-shell">

--- a/frontend/src/features/roadmap/roadmap-detail-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-detail-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import {
   StatusBadge,
@@ -17,6 +18,7 @@ import {
 } from "@/features/roadmap/labels";
 import type { ProgressStatus, Roadmap } from "@/features/roadmap/types";
 import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
 
 type RoadmapDetailViewProps = {
   roadmapId: string;
@@ -24,6 +26,7 @@ type RoadmapDetailViewProps = {
 
 type RoadmapState =
   | { status: "loading" }
+  | { status: "auth-required" }
   | { status: "error"; message: string }
   | { status: "success"; roadmap: Roadmap };
 
@@ -46,6 +49,10 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
         }
       } catch (error) {
         if (!ignore) {
+          if (isUnauthorizedError(error)) {
+            setState({ status: "auth-required" });
+            return;
+          }
           setState({
             message: getErrorMessage(error, "로드맵을 불러오지 못했습니다."),
             status: "error"
@@ -119,6 +126,10 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
         };
       });
     } catch (error) {
+      if (isUnauthorizedError(error)) {
+        setState({ status: "auth-required" });
+        return;
+      }
       setSaveErrors((current) => ({
         ...current,
         [roadmapWeekId]: getErrorMessage(error, "진도를 저장하지 못했습니다.")
@@ -133,6 +144,15 @@ export function RoadmapDetailView({ roadmapId }: RoadmapDetailViewProps) {
       <StatePanel
         className="roadmap-state-panel"
         message="로드맵을 불러오는 중입니다."
+      />
+    );
+  }
+
+  if (state.status === "auth-required") {
+    return (
+      <AuthRequiredPanel
+        className="roadmap-state-panel"
+        redirectPath={`/roadmaps/${encodeURIComponent(roadmapId)}`}
       />
     );
   }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,39 @@
+import { ApiError } from "@/lib/api";
+
+const DEFAULT_REDIRECT_PATH = "/me";
+
+export function isUnauthorizedError(error: unknown): error is ApiError {
+  return error instanceof ApiError && error.status === 401;
+}
+
+export function getCurrentRedirectPath() {
+  if (typeof window === "undefined") {
+    return DEFAULT_REDIRECT_PATH;
+  }
+
+  const { hash, pathname, search } = window.location;
+  return normalizeLocalRedirectPath(`${pathname}${search}${hash}`);
+}
+
+export function getLoginPath(redirectPath?: string | null) {
+  const target = normalizeLocalRedirectPath(
+    redirectPath ?? getCurrentRedirectPath()
+  );
+
+  return `/login?redirectUrl=${encodeURIComponent(target)}`;
+}
+
+export function normalizeLocalRedirectPath(value?: string | null) {
+  const trimmed = value?.trim();
+
+  if (
+    trimmed &&
+    trimmed.startsWith("/") &&
+    !trimmed.startsWith("//") &&
+    !trimmed.startsWith("/\\")
+  ) {
+    return trimmed;
+  }
+
+  return DEFAULT_REDIRECT_PATH;
+}


### PR DESCRIPTION
Closes #277

## 변경 요약
- 401 응답 전용 인증 필요 CTA 추가
- 로그인 후 원래 화면으로 복귀하도록 redirect 처리 보강
- 주요 v1 화면의 인증 오류와 일반 API 오류 구분

## 왜 필요한가
- 시연 중 토큰이 없거나 만료되어도 사용자가 원인을 알고 다시 로그인해 핵심 흐름으로 복귀할 수 있어야 하기 때문

## 테스트
- PASS: `cd frontend; npm run lint`
- PASS: `cd frontend; npm run build`
- PASS: 보호 화면에서 직접 `githubLoginUrl(/)`로 보내는 처리 없음 확인
- PASS: 401 분기와 일반 오류 분리 코드 확인