### PR TITLE
test(smoke): v1 시연 핵심 흐름 smoke 검증 보강

### DIFF
--- a/docs/00_bundle_index.md
+++ b/docs/00_bundle_index.md
@@ -37,3 +37,4 @@
 - 22_v1_smoke_test_result_2026-05-06.md: 2026-05-06 v1 full smoke 최종 결과 — 핵심 흐름 PASS
 - 23_v1_smoke_debug_2026-05-06.md: 2026-05-06 smoke 디버그 세션 — 버그 5종 수정 기록
 - 24_v1_demo_smoke_result_2026-05-08.md: 2026-05-08 v1 시연 핵심 저장/재조회 자동 검증 결과
+- 25_v1_demo_smoke_result_2026-05-11.md: 2026-05-11 v1 시연 smoke 기준 정리와 자동 검증 결과

--- a/docs/13_v1_smoke_test_checklist.md
+++ b/docs/13_v1_smoke_test_checklist.md
@@ -2,55 +2,62 @@
 
 ## 목적
 
-v1 전체 사용자 흐름을 같은 기준으로 수동 검증하기 위한 체크리스트다. 각 단계는 화면 이동, 주요 ID, 저장 후 재조회 여부, blocker 기록을 함께 확인한다.
+v1 시연 핵심 흐름을 같은 기준으로 수동 검증하기 위한 체크리스트다. 프로필 저장부터 대시보드 재조회까지 사용자 순서대로 확인하고, 실패하면 어느 단계에서 끊겼는지 같은 양식으로 기록한다.
 
 ## 검증 전 준비
 
-- [ ] `dev` 브랜치를 최신화한다.
-- [ ] PostgreSQL과 Redis를 로컬에서 실행한다.
-- [ ] backend를 local profile로 실행한다.
-- [ ] frontend를 실행하고 `NEXT_PUBLIC_API_BASE_URL`이 backend 주소를 가리키는지 확인한다.
-- [ ] GitHub OAuth, GitHub API, AI Gateway 관련 환경변수가 실제 검증 가능한 값인지 확인한다.
-- [ ] GitHub 저장소 연결 OAuth App 값은 로그인 OAuth App 값과 분리해 확인한다.
-  - backend: `GITHUB_CONNECTION_CLIENT_ID`, `GITHUB_CONNECTION_CLIENT_SECRET`
-  - frontend: `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID`, `NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback`
-- [ ] #134, #139, #143은 팀원 담당 의존성으로만 본다. 이 문서는 해당 이슈 해결을 포함하지 않는다.
+- [ ] `dev` 브랜치를 최신화한 뒤 smoke 전용 브랜치를 만든다.
+- [ ] 루트 `.env`에 backend 실행에 필요한 값을 채운다. 민감 정보 원문은 문서나 PR에 기록하지 않는다.
+- [ ] `docker compose -f docker/docker-compose.yml up -d`로 PostgreSQL과 Redis를 실행한다.
+- [ ] backend를 `local,oauth` profile로 실행한다.
+  - 명령: `cd backend; .\gradlew.bat bootRun --args="--spring.profiles.active=local,oauth"`
+  - 로그인 OAuth App callback: `http://localhost:8080/login/oauth2/code/github`
+  - 저장소 연결 OAuth App callback: `http://localhost:3000/github/callback`
+- [ ] frontend `.env.local`이 backend와 저장소 연결 OAuth App을 가리키는지 확인한다.
+  - `NEXT_PUBLIC_API_BASE_URL=http://localhost:8080`
+  - `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID`
+  - `NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback`
+- [ ] frontend를 실행한다.
+  - 명령: `cd frontend; npm run dev`
+- [ ] 브라우저 DevTools Network와 backend 로그를 열어 요청 URL, status, trace/log 메시지를 바로 기록할 수 있게 둔다.
 
 ## 완료 기준
 
-- [ ] 프로필 저장 후 재조회가 된다.
-- [ ] GitHub 연결 후 저장소 목록을 조회할 수 있다.
-- [ ] GitHub 분석 생성 후 결과 화면에서 분석 ID를 확인할 수 있다.
+- [ ] 프로필 저장 후 새로고침/재진입해도 입력값이 유지된다.
+- [ ] GitHub 연결 후 저장소 목록을 조회하고 분석 대상을 선택할 수 있다.
+- [ ] GitHub 분석 생성 후 실제 `githubAnalysisId`가 붙은 결과 화면으로 이동한다.
 - [ ] GitHub 분석 보정값 저장 후 재조회해도 보정 내용이 유지된다.
-- [ ] 진단 생성 후 상세 화면으로 이동하고 진단 ID를 확인할 수 있다.
-- [ ] 로드맵 생성 후 상세 화면으로 이동하고 로드맵 ID를 확인할 수 있다.
+- [ ] 진단 생성 후 실제 `diagnosisId` 기반 상세 화면으로 이동한다.
+- [ ] 로드맵 생성 후 실제 `roadmapId` 기반 상세 화면으로 이동한다.
 - [ ] 진도 저장 후 로드맵 상세와 대시보드 최신 snapshot에 반영된다.
-- [ ] 실패한 단계가 있으면 blocker 항목에 요청, 응답, 화면 경로, 관련 ID를 기록한다.
+- [ ] 401 응답은 로그인 CTA 또는 로그인 화면으로 복구 가능하고, 일반 API 오류와 구분된다.
+- [ ] 실패한 단계가 있으면 blocker 양식에 요청, 응답, 화면 경로, 관련 ID, 로그를 기록한다.
 
 ## v1 흐름 체크리스트
 
-### 1. 로그인 / OAuth
+### 1. 로그인 / 인증 복구
 
-- [ ] `/login` 또는 시작 화면에서 GitHub OAuth 로그인을 시작한다.
+- [ ] `/login`에서 GitHub OAuth 로그인을 시작한다.
 - [ ] GitHub 승인 후 frontend로 돌아온다.
-- [ ] 인증 쿠키가 설정되어 보호 API 요청이 401 없이 동작한다.
-- [ ] 실패 시 blocker에 redirect URL, error query, backend 로그의 주요 메시지를 기록한다.
+- [ ] `/me` 또는 보호 화면에서 인증 쿠키 기반 요청이 401 없이 동작한다.
+- [ ] 인증 만료나 쿠키 없음 상태에서는 로그인 CTA가 표시되고, 재로그인 후 원래 화면으로 돌아오는지 확인한다.
+- [ ] blocker 기록값: redirect URL, error query, 응답 status, backend 로그의 주요 메시지.
 
 ### 2. 프로필 저장 / 조회
 
-- [ ] `/profile`에서 목표 직무, 현재 수준, 기술 스택, 관심 분야, 주당 학습 가능 시간을 입력한다.
-- [ ] 저장 성공 후 화면에 `profileId` 또는 저장 완료 상태가 표시되는지 확인한다.
-- [ ] 새로고침 또는 재진입 후 저장한 프로필 값이 유지되는지 확인한다.
-- [ ] blocker 기록값: `profileId`, 요청 payload, 응답 message.
+- [ ] `/profile`에서 목표 직무, 현재 수준, 기술 스택, 관심 분야, 주당 학습 가능 시간, 목표 날짜를 입력한다.
+- [ ] 저장 성공 후 저장 완료 상태가 표시되는지 확인한다.
+- [ ] 새로고침 또는 `/profile` 재진입 후 저장한 프로필 값이 유지되는지 확인한다.
+- [ ] blocker 기록값: `profileId`, 요청 payload, 응답 status/message.
 
 ### 3. GitHub 연결 / 저장소 선택
 
-- [ ] `/github`에서 authorization code로 GitHub 연결을 등록한다.
-- [ ] 연결 성공 후 `githubConnectionId`와 GitHub login을 확인한다.
+- [ ] `/github`에서 GitHub 저장소 연결 OAuth를 시작한다.
+- [ ] `/github/callback` 이후 저장소 선택 화면으로 돌아오는지 확인한다.
 - [ ] 저장소 목록이 조회되는지 확인한다.
 - [ ] 분석 대상 저장소를 1개 이상 선택한다.
-- [ ] 핵심 repo를 1개 이상 선택한다.
-- [ ] blocker 기록값: `githubConnectionId`, 선택한 `selectedRepositoryIds`, `coreRepositoryIds`.
+- [ ] 선택값이 분석 실행 전까지 유지되는지 확인한다.
+- [ ] blocker 기록값: `githubConnectionId`, 선택한 repository id 목록, callback query, 응답 status/message.
 
 ### 4. GitHub 분석 생성 / 결과 조회
 
@@ -58,7 +65,7 @@ v1 전체 사용자 흐름을 같은 기준으로 수동 검증하기 위한 체
 - [ ] 성공 시 `/github/analysis?githubAnalysisId=...`로 이동한다.
 - [ ] 분석 결과 화면에서 정적 신호, repo 요약, 기술 태그, 근거, 최종 기술 프로필이 표시되는지 확인한다.
 - [ ] 새로고침 후에도 같은 `githubAnalysisId` 결과를 조회할 수 있는지 확인한다.
-- [ ] blocker 기록값: `githubAnalysisId`, 분석 실행 응답, 실패한 표시 섹션.
+- [ ] blocker 기록값: `githubAnalysisId`, 분석 실행 요청/응답, 실패한 표시 섹션, backend 분석 로그.
 
 ### 5. GitHub 분석 보정 저장
 
@@ -69,27 +76,27 @@ v1 전체 사용자 흐름을 같은 기준으로 수동 검증하기 위한 체
 
 ### 6. 진단 생성 / 상세 조회
 
-- [ ] GitHub 분석 결과 화면 또는 연결된 다음 행동에서 진단 생성을 실행한다.
+- [ ] GitHub 분석 결과 화면 또는 `/diagnoses`의 다음 행동에서 진단 생성을 실행한다.
 - [ ] 성공 시 `/diagnoses/{diagnosisId}`로 이동한다.
 - [ ] 부족 기술, 강점, 우선순위, 추천 이유가 표시되는지 확인한다.
 - [ ] 새로고침 후 같은 `diagnosisId`를 재조회할 수 있는지 확인한다.
-- [ ] blocker 기록값: `profileId`, `githubAnalysisId`, `diagnosisId`, 진단 생성 응답.
+- [ ] blocker 기록값: `profileId`, `githubAnalysisId`, `diagnosisId`, 진단 생성 요청/응답.
 
 ### 7. 로드맵 생성 / 상세 조회
 
 - [ ] `/roadmaps/new` 또는 진단 상세 화면에서 로드맵 생성을 실행한다.
 - [ ] 성공 시 `/roadmaps/{roadmapId}`로 이동한다.
-- [ ] 주차별 학습 목표, 주제, 자료, 진도 상태가 표시되는지 확인한다.
+- [ ] 주차별 학습 주제, 작업, 자료, 진도 상태가 표시되는지 확인한다.
 - [ ] 새로고침 후 같은 `roadmapId`를 재조회할 수 있는지 확인한다.
-- [ ] blocker 기록값: `diagnosisId`, `githubAnalysisId`, `roadmapId`, 로드맵 생성 응답.
+- [ ] blocker 기록값: `diagnosisId`, `roadmapId`, 로드맵 생성 요청/응답.
 
 ### 8. 진도 저장 / 대시보드 snapshot
 
 - [ ] 로드맵 상세에서 한 주차의 진도를 `TODO`, `IN_PROGRESS`, `DONE`, `SKIPPED` 중 하나로 저장한다.
-- [ ] 저장 후 로드맵 상세의 해당 주차 상태가 바뀌는지 확인한다.
-- [ ] `/` 또는 대시보드 화면에서 최신 프로필, GitHub 분석, 진단, 로드맵, 진도 요약이 표시되는지 확인한다.
+- [ ] 저장 후 로드맵 상세의 해당 주차 상태와 메모가 바뀌는지 확인한다.
+- [ ] `/`에서 최신 프로필, GitHub 분석, 진단, 로드맵, 진도 요약이 표시되는지 확인한다.
 - [ ] 대시보드 최신 snapshot이 방금 생성한 결과 ID 기준으로 보이는지 확인한다.
-- [ ] blocker 기록값: `roadmapId`, `roadmapWeekId`, 저장한 상태, 대시보드 응답의 최신 ID.
+- [ ] blocker 기록값: `roadmapId`, `roadmapWeekId`, 저장한 상태/메모, 대시보드 응답의 최신 ID.
 
 ## Blocker 기록 양식
 
@@ -98,8 +105,11 @@ v1 전체 사용자 흐름을 같은 기준으로 수동 검증하기 위한 체
 화면 경로:
 관련 ID:
 요청:
-응답:
+응답 status/body:
 화면 증상:
 backend 로그:
+frontend 콘솔/Network:
+재현 조건:
 판단:
+후속 조치:
 ```

--- a/docs/25_v1_demo_smoke_result_2026-05-11.md
+++ b/docs/25_v1_demo_smoke_result_2026-05-11.md
@@ -1,0 +1,53 @@
+# v1 Demo Smoke 결과 - 2026-05-11
+
+## 목적
+
+#276 기준으로 v1 시연 핵심 흐름의 수동 smoke 기준을 최신화하고, 현재 브랜치에서 자동 검증으로 확인 가능한 범위를 기록한다.
+
+이번 검증은 브라우저에서 실제 GitHub OAuth 승인과 AI Gateway 실응답까지 확인하는 full smoke가 아니다. 시연 전 같은 순서로 점검할 수 있도록 `docs/13_v1_smoke_test_checklist.md`를 기준으로 정리하고, 코드 회귀 여부는 자동 검증 명령으로 확인했다.
+
+## 실행 환경
+
+- 기준 브랜치: `test/v1-demo-smoke-check-276`
+- 기준 commit: `a1404a6` (`origin/dev` pull 직후)
+- 검증 방식: 문서 기준 정리 + frontend/backend 자동 검증
+- 수동 브라우저 smoke: 미실행
+- Docker 상태: Docker Engine `28.5.1` 접근 가능
+
+민감 정보인 token, cookie, API key, OAuth secret 원문은 기록하지 않았다.
+
+## 자동 검증 결과
+
+| 검증 항목 | 명령 | 결과 |
+| --- | --- | --- |
+| Frontend lint | `cd frontend; npm run lint` | PASS |
+| Frontend build | `cd frontend; npm run build` | PASS |
+| Backend PR 검증 | `cd backend; .\gradlew.bat prVerification --no-daemon` | PASS |
+| Backend 통합 테스트 | `cd backend; .\gradlew.bat integrationTest --no-daemon` | PASS |
+
+## Smoke 체크리스트 정리 결과
+
+| 구간 | 정리 내용 | 결과 |
+| --- | --- | --- |
+| 로컬 실행 전제 | backend/frontend 실행 명령, Docker, OAuth callback, frontend env 확인 항목 정리 | 완료 |
+| v1 핵심 흐름 | 프로필, GitHub 연결/분석, 보정, 진단, 로드맵, 진도, 대시보드 순서로 확인 기준 정리 | 완료 |
+| 인증 복구 | 401 응답을 일반 API 오류와 구분하고 재로그인 복구 여부를 확인 항목에 추가 | 완료 |
+| blocker 기록 | 요청, 응답 status/body, 화면, 관련 ID, backend 로그, frontend Network 기록 기준 보강 | 완료 |
+
+## 미실행 범위
+
+| 항목 | 상태 | 이유 |
+| --- | --- | --- |
+| 실제 GitHub OAuth 승인 | 미실행 | 외부 계정 승인과 로컬 민감 env가 필요한 수동 리허설 영역 |
+| 실제 GitHub API 저장소 데이터 | 미실행 | 계정/저장소 상태에 따라 결과가 달라지는 외부 연동 영역 |
+| AI Gateway 실응답 기반 분석/진단/로드맵 생성 | 미실행 | API key와 모델 응답 시간이 필요한 수동 리허설 영역 |
+
+## Blocker
+
+자동 검증 기준 blocker는 없다.
+
+수동 브라우저 smoke는 이번 PR에서 실행하지 않았으므로, 실제 OAuth 승인 화면, GitHub 저장소 권한, AI Gateway 응답 시간과 출력 품질은 시연 전 별도 리허설에서 확인해야 한다.
+
+## 결론
+
+현재 브랜치 기준으로 프론트 빌드, 백엔드 PR 검증, Testcontainers 통합 테스트는 모두 PASS다. v1 시연 핵심 흐름의 수동 smoke 기준과 blocker 기록 양식은 최신 화면 흐름 기준으로 정리했다.


### PR DESCRIPTION
Closes #276

## 변경 요약
- v1 시연 핵심 흐름 smoke 체크리스트 최신화
- 로컬 실행/env 확인 기준과 blocker 기록 양식 정리
- 현재 브랜치 기준 자동 검증 결과 문서화

## 왜 필요한가
- 기능별 테스트가 통과해도 사용자 순서에서 끊기면 시연이 실패하므로, 같은 기준으로 사전 점검하고 blocker를 남겨야 하기 때문

## 테스트
- PASS: `cd frontend; npm run lint`
- PASS: `cd frontend; npm run build`
- PASS: `cd backend; .\gradlew.bat prVerification --no-daemon`
- PASS: `cd backend; .\gradlew.bat integrationTest --no-daemon`