### PR TITLE
fix(llm): GitHub 분석 synthesis evidence type 보정

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
@@ -68,6 +68,8 @@ public class SynthesisPromptBuilder {
         sb.append("  \"evidences\": [ { \"repoName\": string, \"type\": \"").append(EVIDENCE_VALUES).append("\", \"source\": string, \"summary\": string } ],\n");
         sb.append("  \"finalTechProfile\": { \"confirmedSkills\": [ string ], \"focusAreas\": [ string ] }\n");
         sb.append("}\n");
+        sb.append("For evidences[].type, use ONLY one of: ").append(EVIDENCE_VALUES).append(".\n");
+        sb.append("If evidence type is uncertain, use REPO_METADATA. Do NOT leave it blank and do NOT invent new values.\n");
         sb.append("Do NOT rename fields. Do NOT add extra fields.\n");
         return sb.toString();
     }

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParser.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParser.java
@@ -8,6 +8,7 @@ import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
@@ -21,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 @Component
@@ -40,6 +42,8 @@ public class SynthesisResponseParser {
             log.warn("Synthesis 응답 JSON 파싱 실패: {}", e.getMessage());
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
         }
+
+        normalizeEvidenceTypes(root);
 
         Set<ValidationMessage> errors = schema.validate(root);
         if (!errors.isEmpty()) {
@@ -63,6 +67,33 @@ public class SynthesisResponseParser {
                         mapList(root.get("finalTechProfile").get("confirmedSkills"), JsonNode::asText),
                         mapList(root.get("finalTechProfile").get("focusAreas"), JsonNode::asText))
         );
+    }
+
+    private static void normalizeEvidenceTypes(JsonNode root) {
+        JsonNode evidences = root.get("evidences");
+        if (evidences == null || !evidences.isArray()) {
+            return;
+        }
+
+        evidences.forEach(evidence -> {
+            if (evidence instanceof ObjectNode object && object.has("type")) {
+                object.put("type", normalizeEvidenceType(object.get("type").asText()));
+            }
+        });
+    }
+
+    private static String normalizeEvidenceType(String rawType) {
+        if (rawType != null) {
+            String candidate = rawType.trim().toUpperCase(Locale.ROOT);
+            if (!candidate.isBlank()) {
+                try {
+                    return GithubEvidenceType.valueOf(candidate).name();
+                } catch (IllegalArgumentException ignored) {
+                    // Unknown evidence labels are non-critical; keep analysis usable with a safe enum value.
+                }
+            }
+        }
+        return GithubEvidenceType.REPO_METADATA.name();
     }
 
     private static <T> List<T> mapList(JsonNode array, java.util.function.Function<JsonNode, T> mapper) {

--- a/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisResponseParserTest.java
@@ -88,8 +88,8 @@ class SynthesisResponseParserTest {
     }
 
     @Test
-    @DisplayName("Evidence.type이 enum 외 값이면 LLM_INVALID_RESPONSE")
-    void parse_invalidEvidenceType_throws() {
+    @DisplayName("Evidence.type이 enum 외 값이면 REPO_METADATA로 보정한다")
+    void parse_invalidEvidenceType_fallsBackToRepoMetadata() {
         String json = """
                 {
                   "techTags": [],
@@ -99,9 +99,43 @@ class SynthesisResponseParserTest {
                 }
                 """;
 
-        assertThatThrownBy(() -> parser.parse(json))
-                .isInstanceOf(ServiceException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LLM_INVALID_RESPONSE);
+        SynthesisResponseParser.SynthesisResult result = parser.parse(json);
+
+        assertThat(result.evidences().get(0).type()).isEqualTo(GithubEvidenceType.REPO_METADATA);
+    }
+
+    @Test
+    @DisplayName("Evidence.type이 소문자면 enum 대문자 값으로 보정한다")
+    void parse_lowercaseEvidenceType_normalizesToEnum() {
+        String json = """
+                {
+                  "techTags": [],
+                  "depthEstimates": [],
+                  "evidences": [{"repoName": "r", "type": "commit", "source": "s", "summary": "x"}],
+                  "finalTechProfile": {"confirmedSkills": [], "focusAreas": []}
+                }
+                """;
+
+        SynthesisResponseParser.SynthesisResult result = parser.parse(json);
+
+        assertThat(result.evidences().get(0).type()).isEqualTo(GithubEvidenceType.COMMIT);
+    }
+
+    @Test
+    @DisplayName("Evidence.type이 빈 문자열이면 REPO_METADATA로 보정한다")
+    void parse_blankEvidenceType_fallsBackToRepoMetadata() {
+        String json = """
+                {
+                  "techTags": [],
+                  "depthEstimates": [],
+                  "evidences": [{"repoName": "r", "type": " ", "source": "s", "summary": "x"}],
+                  "finalTechProfile": {"confirmedSkills": [], "focusAreas": []}
+                }
+                """;
+
+        SynthesisResponseParser.SynthesisResult result = parser.parse(json);
+
+        assertThat(result.evidences().get(0).type()).isEqualTo(GithubEvidenceType.REPO_METADATA);
     }
 
     @Test


### PR DESCRIPTION
## 무엇
- Closes #288
- Synthesis LLM 응답의 `evidences[].type`을 schema validation 전에 안전하게 정규화합니다.
- 소문자 enum은 기존 enum으로 보정하고, 빈 값이나 알 수 없는 값은 `REPO_METADATA`로 fallback합니다.
- prompt에 허용 evidence type과 fallback 규칙을 명시했습니다.

## 왜
- #282 수동 smoke 중 AI Gateway 응답은 도착했지만 evidence type schema 위반으로 GitHub 분석 생성이 실패했습니다.
- 응답 latency와 별개로 v1 흐름 진행을 막는 blocker라 먼저 해결합니다.

## 검증
- `cd backend; .\gradlew.bat test --tests *SynthesisResponseParserTest --tests *GithubAnalysisServiceTest`
- 수동 smoke 재검증: 로그인 세션 복구 후 `/github`에서 저장소 1개 선택 상태로 분석 실행, `githubAnalysisId=2` 결과 화면 도달

## 제외
- AI Gateway latency 개선
- Redis 비동기 polling
- provider 교체