### PR TITLE
feat(coach,frontend): Slice 8 + Slice 9 — Coach 채팅 페이지 + 목록 뷰 + localStorage 의존성 제거

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,13 @@ public class CoachSessionController {
     public ApiResponse<CoachSessionResponse> startSession(Authentication authentication) {
         AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
         ChatSession session = coachSessionService.startSession(user.userId());
+        return ApiResponse.success(CoachSessionResponse.from(session));
+    }
+
+    @GetMapping("/active")
+    public ApiResponse<CoachSessionResponse> getActiveSession(Authentication authentication) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        ChatSession session = coachSessionService.getActiveSession(user.userId());
         return ApiResponse.success(CoachSessionResponse.from(session));
     }
 

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
@@ -1,7 +1,15 @@
 package com.back.coach.domain.coach.repository;
 
 import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.global.code.ChatSessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
+
+    Optional<ChatSession> findFirstByUserIdAndStatusOrderByStartedAtDesc(
+            Long userId,
+            ChatSessionStatus status
+    );
 }

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
@@ -4,6 +4,7 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.context.entity.UserContextSnapshot;
 import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.global.code.ChatSessionStatus;
 import com.back.coach.global.code.ContextType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -49,6 +50,13 @@ public class CoachSessionService {
         );
 
         return chatSessionRepository.save(session);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatSession getActiveSession(Long userId) {
+        return chatSessionRepository
+                .findFirstByUserIdAndStatusOrderByStartedAtDesc(userId, ChatSessionStatus.ACTIVE)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
     }
 
     @Transactional

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailController.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/controller/DiagnosisDetailController.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.diagnosis.controller;
 
 import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
+import com.back.coach.domain.diagnosis.dto.DiagnosisSummaryResponse;
 import com.back.coach.domain.diagnosis.service.DiagnosisDetailService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping(path = "/api/diagnoses", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DiagnosisDetailController {
@@ -19,6 +22,12 @@ public class DiagnosisDetailController {
 
     public DiagnosisDetailController(DiagnosisDetailService diagnosisDetailService) {
         this.diagnosisDetailService = diagnosisDetailService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<DiagnosisSummaryResponse>> listDiagnoses(Authentication authentication) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        return ApiResponse.success(diagnosisDetailService.listByUser(authenticatedUser.userId()));
     }
 
     @GetMapping("/{diagnosisId}")

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisSummaryResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/dto/DiagnosisSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.back.coach.domain.diagnosis.dto;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.global.code.CurrentLevel;
+
+import java.time.Instant;
+
+public record DiagnosisSummaryResponse(
+        String diagnosisId,
+        Integer version,
+        CurrentLevel currentLevel,
+        String summary,
+        String githubAnalysisId,
+        Instant createdAt
+) {
+    public static DiagnosisSummaryResponse from(CapabilityDiagnosis diagnosis) {
+        return new DiagnosisSummaryResponse(
+                String.valueOf(diagnosis.getId()),
+                diagnosis.getVersion(),
+                diagnosis.getCurrentLevel(),
+                diagnosis.getSummary(),
+                String.valueOf(diagnosis.getGithubAnalysisId()),
+                diagnosis.getCreatedAt() == null ? Instant.now() : diagnosis.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/repository/CapabilityDiagnosisRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CapabilityDiagnosisRepository extends JpaRepository<CapabilityDiagnosis, Long> {
 
     Optional<CapabilityDiagnosis> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    List<CapabilityDiagnosis> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     Optional<CapabilityDiagnosis> findByIdAndUserId(Long id, Long userId);
 

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisDetailService.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.diagnosis.service;
 
 import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
 import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.dto.DiagnosisSummaryResponse;
 import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
 import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
 import com.back.coach.domain.jobrole.entity.JobRole;
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 public class DiagnosisDetailService {
@@ -53,6 +56,13 @@ public class DiagnosisDetailService {
                 payload.recommendations(),
                 diagnosis.getCreatedAt()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<DiagnosisSummaryResponse> listByUser(Long userId) {
+        return capabilityDiagnosisRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(DiagnosisSummaryResponse::from)
+                .toList();
     }
 
     private DiagnosisPayload parsePayload(String diagnosisPayload) {

--- a/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
+++ b/backend/src/main/java/com/back/coach/domain/github/controller/GithubAnalysisController.java
@@ -5,6 +5,7 @@ import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisRequest;
 import com.back.coach.domain.github.dto.GithubAnalysisResponse;
+import com.back.coach.domain.github.dto.GithubAnalysisSummaryResponse;
 import com.back.coach.domain.github.service.GithubAnalysisDetailService;
 import com.back.coach.domain.github.service.GithubAnalysisService;
 import com.back.coach.global.response.ApiResponse;
@@ -19,6 +20,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(path = "/api/github-analyses", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -47,6 +50,12 @@ public class GithubAnalysisController {
                 request.coreRepositoryIds()
         );
         return ApiResponse.success(GithubAnalysisResponse.from(result));
+    }
+
+    @GetMapping
+    public ApiResponse<List<GithubAnalysisSummaryResponse>> listAnalyses(Authentication authentication) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        return ApiResponse.success(githubAnalysisDetailService.listByUser(authenticatedUser.userId()));
     }
 
     @GetMapping("/{githubAnalysisId}")

--- a/backend/src/main/java/com/back/coach/domain/github/controller/GithubConnectionController.java
+++ b/backend/src/main/java/com/back/coach/domain/github/controller/GithubConnectionController.java
@@ -32,6 +32,14 @@ public class GithubConnectionController {
         return ResponseEntity.ok(ApiResponse.success(GithubConnectionResponse.from(result)));
     }
 
+    @GetMapping("/connections/latest")
+    public ResponseEntity<ApiResponse<GithubConnectionResponse>> getLatestConnection(Authentication authentication) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(
+                GithubConnectionResponse.from(connectionService.findLatestConnection(user.userId()))
+        ));
+    }
+
     @GetMapping("/repositories")
     public ResponseEntity<ApiResponse<GithubRepositoryListResponse>> listRepositories(
             Authentication authentication,

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisSummaryResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.back.coach.domain.github.dto;
+
+import com.back.coach.domain.github.entity.GithubAnalysis;
+
+import java.time.Instant;
+
+public record GithubAnalysisSummaryResponse(
+        String githubAnalysisId,
+        Integer version,
+        String summary,
+        Instant createdAt
+) {
+    public static GithubAnalysisSummaryResponse from(GithubAnalysis analysis) {
+        return new GithubAnalysisSummaryResponse(
+                String.valueOf(analysis.getId()),
+                analysis.getVersion(),
+                analysis.getSummary(),
+                analysis.getCreatedAt() == null ? Instant.now() : analysis.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubConnectionResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubConnectionResponse.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.dto;
 
+import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.service.GithubConnectionService;
 
 import java.time.Instant;
@@ -14,6 +15,14 @@ public record GithubConnectionResponse(
                 String.valueOf(result.connectionId()),
                 result.githubLogin(),
                 result.connectedAt()
+        );
+    }
+
+    public static GithubConnectionResponse from(GithubConnection connection) {
+        return new GithubConnectionResponse(
+                String.valueOf(connection.getId()),
+                connection.getGithubLogin(),
+                connection.getConnectedAt()
         );
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubAnalysisRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GithubAnalysisRepository extends JpaRepository<GithubAnalysis, Long> {
 
     Optional<GithubAnalysis> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    List<GithubAnalysis> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     Optional<GithubAnalysis> findByIdAndUserId(Long id, Long userId);
 

--- a/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/github/repository/GithubConnectionRepository.java
@@ -10,6 +10,8 @@ public interface GithubConnectionRepository extends JpaRepository<GithubConnecti
 
     List<GithubConnection> findByUserIdOrderByConnectedAtDesc(Long userId);
 
+    Optional<GithubConnection> findFirstByUserIdOrderByConnectedAtDesc(Long userId);
+
     Optional<GithubConnection> findByIdAndUserId(Long id, Long userId);
 
     boolean existsByIdAndUserId(Long id, Long userId);

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -4,6 +4,7 @@ import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
 import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
+import com.back.coach.domain.github.dto.GithubAnalysisSummaryResponse;
 import com.back.coach.domain.github.entity.GithubAnalysis;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
 import com.back.coach.global.exception.ErrorCode;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.List;
 
 @Service
 public class GithubAnalysisDetailService {
@@ -40,6 +42,13 @@ public class GithubAnalysisDetailService {
         this.githubAnalysisRepository = githubAnalysisRepository;
         this.objectMapper = objectMapper;
         this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public List<GithubAnalysisSummaryResponse> listByUser(Long userId) {
+        return githubAnalysisRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(GithubAnalysisSummaryResponse::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
@@ -55,6 +55,12 @@ public class GithubConnectionService {
         return new ConnectResult(connection.getId(), connection.getGithubLogin(), connection.getConnectedAt());
     }
 
+    @Transactional(readOnly = true)
+    public GithubConnection findLatestConnection(Long userId) {
+        return connectionRepo.findFirstByUserIdOrderByConnectedAtDesc(userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
     public List<GithubProject> listRepositories(Long userId, Long connectionId) {
         connectionRepo.findByIdAndUserId(connectionId, userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));

--- a/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.roadmap.controller;
 
 import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
 import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
+import com.back.coach.domain.roadmap.dto.RoadmapSummaryResponse;
 import com.back.coach.domain.roadmap.service.RoadmapDetailSnapshotService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(path = "/api/roadmaps", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -26,6 +29,12 @@ public class RoadmapDetailController {
     ) {
         this.roadmapDetailSnapshotService = roadmapDetailSnapshotService;
         this.objectMapper = objectMapper;
+    }
+
+    @GetMapping
+    public ApiResponse<List<RoadmapSummaryResponse>> listRoadmaps(Authentication authentication) {
+        AuthenticatedUser authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+        return ApiResponse.success(roadmapDetailSnapshotService.listByUser(authenticatedUser.userId()));
     }
 
     @GetMapping("/{roadmapId}")

--- a/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapSummaryResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.back.coach.domain.roadmap.dto;
+
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+
+import java.time.Instant;
+
+public record RoadmapSummaryResponse(
+        String roadmapId,
+        Integer version,
+        Integer totalWeeks,
+        String summary,
+        String diagnosisId,
+        Instant createdAt
+) {
+    public static RoadmapSummaryResponse from(LearningRoadmap roadmap) {
+        return new RoadmapSummaryResponse(
+                String.valueOf(roadmap.getId()),
+                roadmap.getVersion(),
+                roadmap.getTotalWeeks(),
+                roadmap.getSummary(),
+                String.valueOf(roadmap.getDiagnosisId()),
+                roadmap.getCreatedAt() == null ? Instant.now() : roadmap.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/repository/LearningRoadmapRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LearningRoadmapRepository extends JpaRepository<LearningRoadmap, Long> {
 
     Optional<LearningRoadmap> findTopByUserIdOrderByVersionDescCreatedAtDesc(Long userId);
+
+    List<LearningRoadmap> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     Optional<LearningRoadmap> findByIdAndUserId(Long id, Long userId);
 

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapDetailSnapshotService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapDetailSnapshotService.java
@@ -2,6 +2,7 @@ package com.back.coach.domain.roadmap.service;
 
 import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
 import com.back.coach.domain.roadmap.dto.RoadmapProgressSnapshot;
+import com.back.coach.domain.roadmap.dto.RoadmapSummaryResponse;
 import com.back.coach.domain.roadmap.entity.LearningRoadmap;
 import com.back.coach.domain.roadmap.entity.RoadmapWeek;
 import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
@@ -29,6 +30,12 @@ public class RoadmapDetailSnapshotService {
         this.learningRoadmapRepository = learningRoadmapRepository;
         this.roadmapWeekRepository = roadmapWeekRepository;
         this.roadmapProgressSnapshotService = roadmapProgressSnapshotService;
+    }
+
+    public List<RoadmapSummaryResponse> listByUser(Long userId) {
+        return learningRoadmapRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(RoadmapSummaryResponse::from)
+                .toList();
     }
 
     public RoadmapDetailSnapshot findSnapshot(Long userId, Long roadmapId) {

--- a/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/coach/global/security/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
                 HttpHeaders.AUTHORIZATION,
                 HttpHeaders.CONTENT_TYPE,
                 "X-Requested-With",
-                "X-Trace-Id"
+                "X-Trace-Id",
+                "Idempotency-Key"
         ));
         configuration.setExposedHeaders(List.of("X-Trace-Id"));
         configuration.setAllowCredentials(true);

--- a/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
@@ -28,6 +28,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -82,6 +83,35 @@ class CoachSessionControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("SNAPSHOT_NOT_FOUND"));
+    }
+
+    @Test
+    void getActiveSession_whenActiveSessionExists_returnsSessionResponse() throws Exception {
+        ChatSession session = session(10001L, 1L, 3, 2, Instant.parse("2026-05-07T09:00:00Z"));
+        given(coachSessionService.getActiveSession(1L)).willReturn(session);
+
+        mockMvc.perform(get("/api/coach/sessions/active")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sessionId").value("10001"))
+                .andExpect(jsonPath("$.data.profileVersion").value(3))
+                .andExpect(jsonPath("$.data.roadmapVersion").value(2))
+                .andExpect(jsonPath("$.data.startedAt").value("2026-05-07T09:00:00Z"));
+
+        verify(coachSessionService).getActiveSession(1L);
+    }
+
+    @Test
+    void getActiveSession_whenNoActiveSession_returnsNotFound() throws Exception {
+        given(coachSessionService.getActiveSession(1L))
+                .willThrow(new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/coach/sessions/active")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -145,6 +145,42 @@ class CoachSessionServiceIntegrationTest {
         assertThat(reloaded.getStatus()).isEqualTo(ChatSessionStatus.CLOSED);
     }
 
+    @Test
+    @DisplayName("getActiveSession: ACTIVE 세션이 있으면 해당 세션 반환")
+    void getActiveSessionReturnsActive() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession started = coachSessionService.startSession(userId);
+
+        ChatSession active = coachSessionService.getActiveSession(userId);
+
+        assertThat(active.getId()).isEqualTo(started.getId());
+        assertThat(active.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("getActiveSession: ACTIVE/CLOSED 혼재 시 가장 최근 ACTIVE 반환")
+    void getActiveSessionReturnsMostRecentActiveAmongMixed() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession older = coachSessionService.startSession(userId);
+        coachSessionService.closeSession(userId, older.getId());
+        ChatSession newerActive = coachSessionService.startSession(userId);
+
+        ChatSession active = coachSessionService.getActiveSession(userId);
+
+        assertThat(active.getId()).isEqualTo(newerActive.getId());
+        assertThat(active.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("getActiveSession: ACTIVE 세션이 없으면 SESSION_NOT_FOUND")
+    void getActiveSessionThrowsWhenNoActive() {
+        assertThatThrownBy(() -> coachSessionService.getActiveSession(userId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_NOT_FOUND);
+    }
+
     private void seedSnapshot(ContextType type, int version) {
         UserContextSnapshot snapshot = UserContextSnapshot.create(
                 userId, type, version, "{}", Instant.now()

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,11 @@
       "dependencies": {
         "next": "16.2.4",
         "react": "19.2.5",
-        "react-dom": "19.2.5"
+        "react-dom": "19.2.5",
+        "react-markdown": "^10.1.0",
+        "react-textarea-autosize": "^8.5.9",
+        "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@types/node": "25.6.0",
@@ -212,6 +216,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1253,12 +1266,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1272,6 +1311,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1288,7 +1342,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1304,6 +1357,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -1587,6 +1646,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -2144,6 +2209,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2302,6 +2377,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2317,6 +2402,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/client-only": {
@@ -2344,6 +2469,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2378,7 +2513,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2446,7 +2580,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2458,6 +2591,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2503,6 +2649,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2511,6 +2666,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -3179,6 +3347,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3188,6 +3366,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3611,6 +3795,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3626,6 +3850,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -3665,6 +3899,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3678,6 +3918,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3838,6 +4102,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3897,6 +4171,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -3948,6 +4232,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -4277,6 +4573,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4300,6 +4606,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4308,6 +4624,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -4319,6 +4917,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4361,7 +5522,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4688,6 +5848,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4794,6 +5979,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4855,6 +6050,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4897,6 +6136,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -5255,6 +6560,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5262,6 +6577,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stable-hash": {
@@ -5398,6 +6723,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5419,6 +6758,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -5530,6 +6887,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5733,6 +7110,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -5807,6 +7271,79 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -5966,6 +7503,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,11 @@
   "dependencies": {
     "next": "16.2.4",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "react-markdown": "^10.1.0",
+    "react-textarea-autosize": "^8.5.9",
+    "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/frontend/src/app/coach/page.tsx
+++ b/frontend/src/app/coach/page.tsx
@@ -1,0 +1,5 @@
+import { CoachEntryView } from "@/features/coach/coach-entry-view";
+
+export default function CoachPage() {
+  return <CoachEntryView />;
+}

--- a/frontend/src/app/coach/sessions/[sessionId]/page.tsx
+++ b/frontend/src/app/coach/sessions/[sessionId]/page.tsx
@@ -1,0 +1,10 @@
+import { CoachChatView } from "@/features/coach/coach-chat-view";
+
+type CoachSessionPageProps = {
+  params: Promise<{ sessionId: string }>;
+};
+
+export default async function CoachSessionPage({ params }: CoachSessionPageProps) {
+  const { sessionId } = await params;
+  return <CoachChatView sessionId={sessionId} />;
+}

--- a/frontend/src/app/github/analysis/page.tsx
+++ b/frontend/src/app/github/analysis/page.tsx
@@ -1,3 +1,4 @@
+import { GithubAnalysisListView } from "@/features/github-analysis/github-analysis-list-view";
 import { GithubAnalysisView } from "@/features/github-analysis/github-analysis-view";
 
 type GithubAnalysisPageProps = {
@@ -10,12 +11,13 @@ export default async function GithubAnalysisPage({
   searchParams
 }: GithubAnalysisPageProps) {
   const { githubAnalysisId } = await searchParams;
+  const id = getFirstQueryValue(githubAnalysisId);
 
-  return (
-    <GithubAnalysisView
-      initialGithubAnalysisId={getFirstQueryValue(githubAnalysisId)}
-    />
-  );
+  if (!id) {
+    return <GithubAnalysisListView />;
+  }
+
+  return <GithubAnalysisView initialGithubAnalysisId={id} />;
 }
 
 function getFirstQueryValue(value?: string | string[]) {

--- a/frontend/src/app/github/callback/page.tsx
+++ b/frontend/src/app/github/callback/page.tsx
@@ -7,8 +7,6 @@ import { connectGithub } from "@/features/github-connection/api";
 import { StatePanel } from "@/components/state-panel";
 import { isUnauthorizedError, getLoginPath } from "@/lib/auth";
 
-const CONNECTION_ID_KEY = "githubConnectionId";
-
 function CallbackInner() {
   const router = useRouter();
   const params = useSearchParams();
@@ -27,8 +25,7 @@ function CallbackInner() {
     }
 
     connectGithub(code)
-      .then((connection) => {
-        localStorage.setItem(CONNECTION_ID_KEY, connection.githubConnectionId);
+      .then(() => {
         router.replace("/github");
       })
       .catch((error) => {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1973,3 +1973,111 @@ a {
   font-size: 12px;
   margin-top: 4px;
 }
+
+/* ===== Result list cards (Slice 9) ===== */
+
+.screen-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.screen-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.screen-description {
+  color: var(--muted);
+  font-size: 14px;
+  margin: 0;
+}
+
+.card-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.result-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.result-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 1px 6px rgba(37, 99, 235, 0.08);
+}
+
+.result-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.result-card-meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.result-card-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.result-card-badge[data-tone="accent"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.result-card-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--foreground);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.result-card-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px dashed var(--line);
+}
+
+.result-card-link {
+  color: var(--muted);
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.result-card-link:hover {
+  color: var(--accent);
+}
+
+.result-card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1697,3 +1697,279 @@ a {
     flex-direction: column;
   }
 }
+
+/* ===== Coach (Slice 8) ===== */
+
+.coach-screen {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 56px);
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 16px 24px 24px;
+  gap: 12px;
+}
+
+.coach-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.coach-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.coach-secondary-button {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--foreground);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.coach-secondary-button:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.coach-scroller {
+  position: relative;
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 4px;
+  scroll-behavior: smooth;
+}
+
+.coach-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 48px 16px;
+  font-size: 14px;
+}
+
+.coach-bubbles {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.coach-bubble {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 80%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.coach-bubble-user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+
+.coach-bubble-coach {
+  align-self: flex-start;
+  background: var(--surface);
+  color: var(--foreground);
+  border: 1px solid var(--line);
+  border-bottom-left-radius: 4px;
+}
+
+.coach-bubble-body p:first-child {
+  margin-top: 0;
+}
+
+.coach-bubble-body p:last-child {
+  margin-bottom: 0;
+}
+
+.coach-bubble-body pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.coach-bubble-body code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.coach-bubble-body pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.coach-bubble-body table {
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.coach-bubble-body th,
+.coach-bubble-body td {
+  border: 1px solid var(--line);
+  padding: 4px 8px;
+}
+
+.coach-typing {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.coach-typing span {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  animation: coach-typing-bounce 1.2s infinite ease-in-out;
+}
+
+.coach-typing span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.coach-typing span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes coach-typing-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+  30% { transform: translateY(-4px); opacity: 1; }
+}
+
+.coach-replan-card {
+  margin-top: 4px;
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.coach-replan-card[data-expired="true"] {
+  opacity: 0.6;
+  border-color: var(--line);
+  background: var(--background);
+}
+
+.coach-replan-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 13px;
+}
+
+.coach-replan-timer {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.coach-replan-reason {
+  margin: 0;
+  font-size: 13px;
+  color: var(--foreground);
+}
+
+.coach-replan-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.coach-scroll-bottom {
+  position: sticky;
+  bottom: 8px;
+  margin-left: auto;
+  display: block;
+  padding: 6px 12px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);
+}
+
+.coach-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.coach-input {
+  flex: 1;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  color: var(--foreground);
+  padding: 8px 4px;
+}
+
+.coach-input:disabled {
+  opacity: 0.6;
+}
+
+.coach-send-button,
+.coach-stop-button {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.coach-send-button {
+  background: var(--accent);
+  color: #fff;
+}
+
+.coach-send-button:disabled {
+  background: var(--line);
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
+.coach-stop-button {
+  background: var(--surface);
+  color: var(--foreground);
+  border: 1px solid var(--line);
+}
+
+.coach-trace-id {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 4px;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Toaster } from "sonner";
 
 import { AppShell } from "@/components/app-shell";
 import "./globals.css";
@@ -17,6 +18,7 @@ export default function RootLayout({
     <html lang="ko">
       <body>
         <AppShell>{children}</AppShell>
+        <Toaster position="top-right" richColors closeButton />
       </body>
     </html>
   );

--- a/frontend/src/app/roadmaps/page.tsx
+++ b/frontend/src/app/roadmaps/page.tsx
@@ -1,81 +1,130 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
-import { getDashboard } from "@/features/dashboard/api";
+import { listRoadmaps } from "@/features/roadmap/api";
+import type { RoadmapSummary } from "@/features/roadmap/types";
 import { ApiError } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/auth";
 
-type RoadmapsPageState =
+type State =
   | { status: "loading" }
   | { status: "auth-required" }
+  | { status: "ready"; items: RoadmapSummary[] }
   | { status: "error"; message: string };
 
 export default function RoadmapsPage() {
-  const router = useRouter();
-  const [state, setState] = useState<RoadmapsPageState>({
-    status: "loading"
-  });
+  const [state, setState] = useState<State>({ status: "loading" });
 
   useEffect(() => {
-    let ignore = false;
+    let cancelled = false;
 
-    getDashboard()
-      .then((dashboard) => {
-        if (ignore) return;
-        if (dashboard.roadmap?.roadmapId) {
-          router.replace(`/roadmaps/${dashboard.roadmap.roadmapId}`);
-        } else {
-          router.replace("/roadmaps/new");
-        }
+    listRoadmaps()
+      .then((items) => {
+        if (cancelled) return;
+        setState({ status: "ready", items });
       })
       .catch((error) => {
-        if (ignore) return;
+        if (cancelled) return;
         if (isUnauthorizedError(error)) {
           setState({ status: "auth-required" });
           return;
         }
-        setState({ message: getErrorMessage(error), status: "error" });
+        setState({ status: "error", message: getErrorMessage(error) });
       });
 
     return () => {
-      ignore = true;
+      cancelled = true;
     };
-  }, [router]);
+  }, []);
+
+  if (state.status === "loading") {
+    return <StatePanel message="로드맵 목록을 불러오는 중입니다." />;
+  }
 
   if (state.status === "auth-required") {
-    return (
-      <AuthRequiredPanel
-        className="roadmap-state-panel"
-        redirectPath="/roadmaps"
-      />
-    );
+    return <AuthRequiredPanel redirectPath="/roadmaps" />;
   }
 
   if (state.status === "error") {
+    return <StatePanel message={state.message} tone="danger" />;
+  }
+
+  if (state.items.length === 0) {
     return (
-      <StatePanel
-        className="roadmap-state-panel"
-        message={state.message}
-        tone="danger"
-      />
+      <section className="screen-shell">
+        <StatePanel message="아직 생성된 로드맵이 없습니다." />
+        <div className="action-row" aria-label="로드맵 다음 행동">
+          <Link className="action-link primary" href="/roadmaps/new">
+            로드맵 생성
+          </Link>
+          <Link className="action-link" href="/diagnoses">
+            진단 결과 보기
+          </Link>
+        </div>
+      </section>
     );
   }
 
   return (
-    <StatePanel
-      message="최근 로드맵을 불러오는 중입니다."
-    />
+    <section className="screen-shell">
+      <header className="screen-header">
+        <h2 className="screen-title">학습 로드맵</h2>
+        <p className="screen-description">
+          시점별 로드맵 버전을 모아 봅니다. 재계획으로 생긴 버전은 별도 카드로 보여요.
+        </p>
+      </header>
+      <ul className="card-grid">
+        {state.items.map((item) => (
+          <li key={item.roadmapId} className="result-card">
+            <header className="result-card-header">
+              <span className="result-card-meta">
+                {formatDate(item.createdAt)} · {item.totalWeeks}주 분량
+              </span>
+              <span className="result-card-badge" data-tone="accent">
+                v{item.version}
+              </span>
+            </header>
+            <p className="result-card-body">{item.summary}</p>
+            <footer className="result-card-footer">
+              <Link
+                className="result-card-link"
+                href={`/diagnoses/${item.diagnosisId}`}
+              >
+                ↳ 진단 #{item.diagnosisId} 기반
+              </Link>
+              <div className="result-card-actions">
+                <Link className="action-link" href={`/roadmaps/${item.roadmapId}`}>
+                  상세 보기
+                </Link>
+              </div>
+            </footer>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
-function getErrorMessage(error: unknown) {
-  if (error instanceof ApiError) {
-    return error.message;
+function formatDate(iso: string) {
+  try {
+    const d = new Date(iso);
+    return new Intl.DateTimeFormat("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit"
+    }).format(d);
+  } catch {
+    return iso;
   }
+}
 
-  return "최근 로드맵을 불러오지 못했습니다.";
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) return error.message;
+  return "로드맵 목록을 불러오지 못했습니다.";
 }

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -37,6 +37,7 @@ export const navigationItems: NavigationItem[] = [
     label: "진단",
     activePrefix: "/diagnoses"
   },
+  { href: "/coach", label: "코치", activePrefix: "/coach" },
   { href: "/roadmaps/new", label: "로드맵 생성", exact: true },
   {
     href: "/roadmaps",

--- a/frontend/src/features/coach/api.ts
+++ b/frontend/src/features/coach/api.ts
@@ -1,0 +1,57 @@
+import { apiClient } from "@/lib/api";
+import type {
+  CoachMessageResponse,
+  CoachSession,
+  ReplanResult
+} from "@/features/coach/types";
+
+export function getActiveSession(signal?: AbortSignal) {
+  return apiClient.get<CoachSession>("/api/coach/sessions/active", { signal });
+}
+
+export function createSession(signal?: AbortSignal) {
+  return apiClient.post<CoachSession>("/api/coach/sessions", undefined, {
+    signal
+  });
+}
+
+export function closeSession(sessionId: string, signal?: AbortSignal) {
+  return apiClient.delete<null>(`/api/coach/sessions/${sessionId}`, { signal });
+}
+
+type SendMessageOptions = {
+  signal?: AbortSignal;
+  idempotencyKey?: string;
+};
+
+export function sendMessage(
+  sessionId: string,
+  message: string,
+  { signal, idempotencyKey }: SendMessageOptions = {}
+) {
+  const headers = new Headers();
+  if (idempotencyKey) {
+    headers.set("Idempotency-Key", idempotencyKey);
+  }
+
+  return apiClient.post<CoachMessageResponse>(
+    `/api/coach/sessions/${sessionId}/messages`,
+    { message },
+    { signal, headers }
+  );
+}
+
+export function confirmReplan(
+  proposalId: string,
+  confirmed: boolean,
+  signal?: AbortSignal
+) {
+  return apiClient.post<ReplanResult>(
+    "/api/coach/replan",
+    {
+      proposalId: Number(proposalId),
+      confirmed
+    },
+    { signal }
+  );
+}

--- a/frontend/src/features/coach/coach-chat-view.tsx
+++ b/frontend/src/features/coach/coach-chat-view.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  type KeyboardEvent,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import TextareaAutosize from "react-textarea-autosize";
+import { toast } from "sonner";
+
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
+import {
+  closeSession,
+  confirmReplan,
+  sendMessage
+} from "@/features/coach/api";
+import {
+  classifyCoachError,
+  isAbortError
+} from "@/features/coach/coach-errors";
+import type {
+  ChatBubble,
+  CoachMessageResponse,
+  ReplanProposal
+} from "@/features/coach/types";
+import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
+
+type ChatViewProps = {
+  sessionId: string;
+};
+
+const SCROLL_STICK_THRESHOLD_PX = 80;
+
+export function CoachChatView({ sessionId }: ChatViewProps) {
+  const router = useRouter();
+  const [bubbles, setBubbles] = useState<ChatBubble[]>([]);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [sessionClosed, setSessionClosed] = useState(false);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const handleScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const stick = distanceFromBottom < SCROLL_STICK_THRESHOLD_PX;
+    stickToBottomRef.current = stick;
+    setShowScrollToBottom(!stick);
+  }, []);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior });
+    stickToBottomRef.current = true;
+    setShowScrollToBottom(false);
+  }, []);
+
+  useEffect(() => {
+    if (stickToBottomRef.current) {
+      scrollToBottom("auto");
+    }
+  }, [bubbles, scrollToBottom]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const handleAbort = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isSending) return;
+
+    const userBubbleId = `u-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const coachBubbleId = `c-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const idempotencyKey =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`;
+
+    setBubbles((prev) => [
+      ...prev,
+      { id: userBubbleId, role: "USER", text: trimmed },
+      { id: coachBubbleId, role: "COACH", text: "", pending: true }
+    ]);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsSending(true);
+
+    const slowToastId = `coach-slow-${userBubbleId}`;
+    const slowTimer = window.setTimeout(() => {
+      toast.message("응답이 평소보다 오래 걸리고 있어요.", {
+        description: "잠시만 기다려 주세요. 중지하려면 '중지' 버튼을 눌러주세요.",
+        id: slowToastId,
+        duration: 8000
+      });
+    }, 10000);
+
+    try {
+      const response: CoachMessageResponse = await sendMessage(
+        sessionId,
+        trimmed,
+        { signal: controller.signal, idempotencyKey }
+      );
+
+      setBubbles((prev) =>
+        prev.map((b) =>
+          b.id === coachBubbleId
+            ? {
+                ...b,
+                text: response.responseText,
+                route: response.route,
+                replanProposal: response.replanProposal,
+                pending: false
+              }
+            : b
+        )
+      );
+      setInput("");
+    } catch (error) {
+      if (isAbortError(error)) {
+        setBubbles((prev) => prev.filter((b) => b.id !== coachBubbleId));
+        return;
+      }
+
+      setBubbles((prev) => prev.filter((b) => b.id !== coachBubbleId));
+
+      if (isUnauthorizedError(error)) {
+        setAuthRequired(true);
+        return;
+      }
+
+      if (error instanceof ApiError && error.code === "SESSION_CLOSED") {
+        setSessionClosed(true);
+        toast.error("이미 종료된 세션입니다.", {
+          description: "새 세션을 시작해 주세요."
+        });
+        return;
+      }
+
+      const info = classifyCoachError(error);
+      toast.error(info.title, {
+        description: info.detail,
+        id: `coach-send-${userBubbleId}`
+      });
+    } finally {
+      window.clearTimeout(slowTimer);
+      toast.dismiss(slowToastId);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+      setIsSending(false);
+    }
+  }, [input, isSending, sessionId]);
+
+  const handleNewSession = useCallback(async () => {
+    abortRef.current?.abort();
+    try {
+      await closeSession(sessionId);
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        setAuthRequired(true);
+        return;
+      }
+      const info = classifyCoachError(error);
+      toast.error(info.title, { description: info.detail });
+    }
+    router.replace("/coach");
+  }, [router, sessionId]);
+
+  const handleConfirmReplan = useCallback(
+    async (proposal: ReplanProposal, confirmed: boolean) => {
+      try {
+        const result = await confirmReplan(proposal.proposalId, confirmed);
+        toast.success(result.message ?? (confirmed ? "재계획이 적용되었습니다." : "제안을 보류했어요."));
+        if (confirmed && !result.dismissed) {
+          await handleNewSession();
+        }
+      } catch (error) {
+        if (isUnauthorizedError(error)) {
+          setAuthRequired(true);
+          return;
+        }
+        const info = classifyCoachError(error);
+        toast.error(info.title, { description: info.detail });
+      }
+    },
+    [handleNewSession]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+        event.preventDefault();
+        void handleSend();
+        return;
+      }
+      if (event.key === "Escape") {
+        if (isSending) {
+          event.preventDefault();
+          handleAbort();
+        } else {
+          inputRef.current?.blur();
+        }
+      }
+    },
+    [handleAbort, handleSend, isSending]
+  );
+
+  if (authRequired) {
+    return (
+      <AuthRequiredPanel redirectPath={`/coach/sessions/${sessionId}`} />
+    );
+  }
+
+  if (sessionClosed) {
+    return (
+      <section className="screen-shell coach-screen">
+        <div className="panel" data-tone="danger">
+          <p>이미 종료된 세션입니다. 새 세션을 시작해 주세요.</p>
+        </div>
+        <div className="action-row">
+          <button
+            className="action-link primary"
+            type="button"
+            onClick={() => router.replace("/coach")}
+          >
+            새 세션 시작
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="coach-screen">
+      <header className="coach-header">
+        <h2 className="coach-title">코치</h2>
+        <button
+          type="button"
+          className="coach-secondary-button"
+          onClick={handleNewSession}
+        >
+          새 세션 시작
+        </button>
+      </header>
+
+      <div
+        className="coach-scroller"
+        ref={scrollerRef}
+        onScroll={handleScroll}
+      >
+        {bubbles.length === 0 ? (
+          <div className="coach-empty">
+            <p>무엇이 궁금한가요? 학습 진행 상황·로드맵 조정·막힌 부분을 자유롭게 말해 보세요.</p>
+          </div>
+        ) : null}
+
+        <ul className="coach-bubbles" aria-live="polite">
+          {bubbles.map((bubble) => (
+            <li
+              key={bubble.id}
+              className={`coach-bubble coach-bubble-${bubble.role.toLowerCase()}`}
+              data-pending={bubble.pending ? "true" : undefined}
+            >
+              {bubble.role === "COACH" ? (
+                bubble.pending ? (
+                  <div className="coach-typing" aria-label="코치가 응답을 작성 중입니다">
+                    <span />
+                    <span />
+                    <span />
+                  </div>
+                ) : (
+                  <>
+                    <div className="coach-bubble-body">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {bubble.text}
+                      </ReactMarkdown>
+                    </div>
+                    {bubble.replanProposal ? (
+                      <ReplanCard
+                        proposal={bubble.replanProposal}
+                        onConfirm={(confirmed) =>
+                          handleConfirmReplan(bubble.replanProposal!, confirmed)
+                        }
+                      />
+                    ) : null}
+                  </>
+                )
+              ) : (
+                <div className="coach-bubble-body">{bubble.text}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {showScrollToBottom ? (
+          <button
+            type="button"
+            className="coach-scroll-bottom"
+            onClick={() => scrollToBottom("smooth")}
+            aria-label="맨 아래로 이동"
+          >
+            ↓ 새 메시지
+          </button>
+        ) : null}
+      </div>
+
+      <form
+        className="coach-composer"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleSend();
+        }}
+      >
+        <TextareaAutosize
+          ref={inputRef}
+          className="coach-input"
+          minRows={1}
+          maxRows={8}
+          placeholder="메시지를 입력하세요. Enter로 전송, Shift+Enter로 줄바꿈."
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={isSending}
+        />
+        {isSending ? (
+          <button
+            type="button"
+            className="coach-stop-button"
+            onClick={handleAbort}
+          >
+            중지
+          </button>
+        ) : (
+          <button
+            type="submit"
+            className="coach-send-button"
+            disabled={input.trim().length === 0}
+          >
+            전송
+          </button>
+        )}
+      </form>
+    </section>
+  );
+}
+
+type ReplanCardProps = {
+  proposal: ReplanProposal;
+  onConfirm: (confirmed: boolean) => void | Promise<void>;
+};
+
+function ReplanCard({ proposal, onConfirm }: ReplanCardProps) {
+  const expiresAtMs = useMemo(
+    () => Date.parse(proposal.expiresAt),
+    [proposal.expiresAt]
+  );
+  const [now, setNow] = useState(() => Date.now());
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const remainingMs = Math.max(0, expiresAtMs - now);
+  const expired = remainingMs === 0;
+  const remainingLabel = formatRemaining(remainingMs);
+
+  const handleClick = useCallback(
+    async (confirmed: boolean) => {
+      if (expired || submitting) return;
+      setSubmitting(true);
+      try {
+        await onConfirm(confirmed);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [expired, onConfirm, submitting]
+  );
+
+  return (
+    <aside className="coach-replan-card" data-expired={expired ? "true" : undefined}>
+      <header className="coach-replan-header">
+        <strong>로드맵 재계획 제안</strong>
+        <span className="coach-replan-timer">
+          {expired ? "만료됨" : `남은 시간 ${remainingLabel}`}
+        </span>
+      </header>
+      <p className="coach-replan-reason">{proposal.reason}</p>
+      <div className="coach-replan-actions">
+        <button
+          type="button"
+          className="action-link primary"
+          onClick={() => handleClick(true)}
+          disabled={expired || submitting}
+        >
+          재계획 적용
+        </button>
+        <button
+          type="button"
+          className="action-link"
+          onClick={() => handleClick(false)}
+          disabled={expired || submitting}
+        >
+          이번엔 보류
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function formatRemaining(ms: number) {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes >= 1) {
+    return `${minutes}분 ${String(seconds).padStart(2, "0")}초`;
+  }
+  return `${seconds}초`;
+}

--- a/frontend/src/features/coach/coach-entry-view.tsx
+++ b/frontend/src/features/coach/coach-entry-view.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { AuthRequiredPanel } from "@/components/auth-required-panel";
+import { StatePanel } from "@/components/state-panel";
+import { createSession, getActiveSession } from "@/features/coach/api";
+import {
+  classifyCoachError,
+  type CoachErrorInfo
+} from "@/features/coach/coach-errors";
+import { ApiError } from "@/lib/api";
+import { isUnauthorizedError } from "@/lib/auth";
+
+type EntryState =
+  | { status: "loading" }
+  | { status: "auth-required" }
+  | { status: "snapshot-missing"; info: CoachErrorInfo }
+  | { status: "error"; info: CoachErrorInfo };
+
+export function CoachEntryView() {
+  const router = useRouter();
+  const [state, setState] = useState<EntryState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function run() {
+      try {
+        const active = await getActiveSession(controller.signal);
+        if (cancelled) return;
+        router.replace(`/coach/sessions/${active.sessionId}`);
+      } catch (error) {
+        if (cancelled || controller.signal.aborted) return;
+
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
+          return;
+        }
+
+        if (error instanceof ApiError && error.code === "SESSION_NOT_FOUND") {
+          try {
+            const created = await createSession(controller.signal);
+            if (cancelled) return;
+            router.replace(`/coach/sessions/${created.sessionId}`);
+            return;
+          } catch (createError) {
+            if (cancelled || controller.signal.aborted) return;
+
+            if (isUnauthorizedError(createError)) {
+              setState({ status: "auth-required" });
+              return;
+            }
+
+            const info = classifyCoachError(createError);
+            if (info.kind === "SNAPSHOT_NOT_FOUND") {
+              setState({ status: "snapshot-missing", info });
+              return;
+            }
+            setState({ status: "error", info });
+            return;
+          }
+        }
+
+        const info = classifyCoachError(error);
+        setState({ status: "error", info });
+      }
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [router]);
+
+  if (state.status === "auth-required") {
+    return <AuthRequiredPanel redirectPath="/coach" />;
+  }
+
+  if (state.status === "snapshot-missing") {
+    return (
+      <section className="screen-shell">
+        <StatePanel
+          message={`${state.info.title}${state.info.detail ? ` ${state.info.detail}` : ""}`}
+          tone="neutral"
+        />
+        <div className="action-row" aria-label="코치 사용 준비">
+          <Link className="action-link primary" href="/profile">
+            프로필 작성
+          </Link>
+          <Link className="action-link" href="/roadmaps/new">
+            로드맵 생성
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className="screen-shell">
+        <StatePanel
+          message={`${state.info.title}${state.info.detail ? ` ${state.info.detail}` : ""}`}
+          tone="danger"
+        />
+        {state.info.traceId ? (
+          <p className="coach-trace-id">traceId: {state.info.traceId}</p>
+        ) : null}
+      </section>
+    );
+  }
+
+  return <StatePanel message="코치 세션을 준비하는 중입니다." />;
+}

--- a/frontend/src/features/coach/coach-errors.ts
+++ b/frontend/src/features/coach/coach-errors.ts
@@ -1,0 +1,94 @@
+import { ApiError } from "@/lib/api";
+
+export type CoachErrorKind =
+  | "SESSION_NOT_FOUND"
+  | "SESSION_CLOSED"
+  | "SNAPSHOT_NOT_FOUND"
+  | "FORBIDDEN"
+  | "RATE_LIMITED"
+  | "SERVER"
+  | "NETWORK"
+  | "ABORTED"
+  | "UNKNOWN";
+
+export type CoachErrorInfo = {
+  kind: CoachErrorKind;
+  title: string;
+  detail?: string;
+  traceId?: string;
+};
+
+const CODE_TO_KIND: Record<string, CoachErrorKind> = {
+  SESSION_NOT_FOUND: "SESSION_NOT_FOUND",
+  SESSION_CLOSED: "SESSION_CLOSED",
+  SNAPSHOT_NOT_FOUND: "SNAPSHOT_NOT_FOUND",
+  FORBIDDEN: "FORBIDDEN"
+};
+
+const MESSAGES: Record<CoachErrorKind, { title: string; detail?: string }> = {
+  SESSION_NOT_FOUND: {
+    title: "세션을 찾을 수 없습니다.",
+    detail: "새 세션을 시작해 주세요."
+  },
+  SESSION_CLOSED: {
+    title: "이미 종료된 세션입니다.",
+    detail: "새 세션을 시작해 주세요."
+  },
+  SNAPSHOT_NOT_FOUND: {
+    title: "프로필과 로드맵을 먼저 만들어 주세요.",
+    detail: "프로필 작성과 로드맵 생성이 모두 완료되어야 코치를 사용할 수 있어요."
+  },
+  FORBIDDEN: {
+    title: "이 세션에 접근할 권한이 없습니다."
+  },
+  RATE_LIMITED: {
+    title: "잠시 후 다시 시도해 주세요.",
+    detail: "요청이 잠시 제한되었습니다."
+  },
+  SERVER: {
+    title: "일시적인 오류가 발생했어요.",
+    detail: "잠시 후 다시 시도해 주세요."
+  },
+  NETWORK: {
+    title: "네트워크 연결을 확인해 주세요.",
+    detail: "입력하신 메시지는 그대로 남겨 두었어요."
+  },
+  ABORTED: {
+    title: "요청이 중단되었습니다."
+  },
+  UNKNOWN: {
+    title: "알 수 없는 오류가 발생했어요."
+  }
+};
+
+export function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException && error.name === "AbortError"
+  ) || (error instanceof Error && error.name === "AbortError");
+}
+
+export function classifyCoachError(error: unknown): CoachErrorInfo {
+  if (isAbortError(error)) {
+    return { kind: "ABORTED", ...MESSAGES.ABORTED };
+  }
+
+  if (error instanceof ApiError) {
+    const codeKind = error.code ? CODE_TO_KIND[error.code] : undefined;
+    if (codeKind) {
+      return { kind: codeKind, ...MESSAGES[codeKind], traceId: error.traceId };
+    }
+    if (error.status === 429) {
+      return { kind: "RATE_LIMITED", ...MESSAGES.RATE_LIMITED, traceId: error.traceId };
+    }
+    if (error.status >= 500) {
+      return { kind: "SERVER", ...MESSAGES.SERVER, traceId: error.traceId };
+    }
+    return { kind: "UNKNOWN", title: error.message, traceId: error.traceId };
+  }
+
+  if (error instanceof TypeError) {
+    return { kind: "NETWORK", ...MESSAGES.NETWORK };
+  }
+
+  return { kind: "UNKNOWN", ...MESSAGES.UNKNOWN };
+}

--- a/frontend/src/features/coach/types.ts
+++ b/frontend/src/features/coach/types.ts
@@ -1,0 +1,41 @@
+export type CoachSession = {
+  sessionId: string;
+  profileVersion: number;
+  roadmapVersion: number;
+  startedAt: string;
+};
+
+export type CoachRoute =
+  | "SIMPLE_GUIDE"
+  | "REPLAN_PROPOSAL"
+  | "PATTERN_INSIGHT"
+  | "DEEP_DIVE";
+
+export type ReplanProposal = {
+  proposalId: string;
+  reason: string;
+  expiresAt: string;
+};
+
+export type CoachMessageResponse = {
+  messageId: string;
+  responseText: string;
+  route: CoachRoute;
+  replanProposal: ReplanProposal | null;
+};
+
+export type ReplanResult = {
+  newRoadmapId: string | null;
+  newRoadmapVersion: number | null;
+  message: string;
+  dismissed: boolean;
+};
+
+export type ChatBubble = {
+  id: string;
+  role: "USER" | "COACH";
+  text: string;
+  route?: CoachRoute;
+  replanProposal?: ReplanProposal | null;
+  pending?: boolean;
+};

--- a/frontend/src/features/diagnosis/api.ts
+++ b/frontend/src/features/diagnosis/api.ts
@@ -1,7 +1,8 @@
 import { apiClient } from "@/lib/api";
 import type {
   Diagnosis,
-  DiagnosisRequest
+  DiagnosisRequest,
+  DiagnosisSummary
 } from "@/features/diagnosis/types";
 
 export function createDiagnosis(payload: DiagnosisRequest) {
@@ -13,4 +14,8 @@ export function createDiagnosis(payload: DiagnosisRequest) {
 
 export function getDiagnosis(diagnosisId: string) {
   return apiClient.get<Diagnosis>(`/api/diagnoses/${diagnosisId}`);
+}
+
+export function listDiagnoses() {
+  return apiClient.get<DiagnosisSummary[]>("/api/diagnoses");
 }

--- a/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-detail-view.tsx
@@ -120,6 +120,14 @@ export function DiagnosisDetailView({ diagnosisId }: DiagnosisDetailViewProps) {
           >
             로드맵 생성
           </Link>
+          {diagnosis.githubAnalysisId ? (
+            <Link
+              className="action-link"
+              href={`/diagnoses/new?githubAnalysisId=${diagnosis.githubAnalysisId}`}
+            >
+              재진단
+            </Link>
+          ) : null}
           <Link className="action-link" href="/github/analysis">
             분석 보정
           </Link>

--- a/frontend/src/features/diagnosis/types.ts
+++ b/frontend/src/features/diagnosis/types.ts
@@ -32,3 +32,12 @@ export type DiagnosisRequest = {
   githubAnalysisId: string;
   profileId: string;
 };
+
+export type DiagnosisSummary = {
+  diagnosisId: string;
+  version: number;
+  currentLevel: CurrentLevel;
+  summary: string;
+  githubAnalysisId: string;
+  createdAt: string;
+};

--- a/frontend/src/features/github-analysis/api.ts
+++ b/frontend/src/features/github-analysis/api.ts
@@ -3,7 +3,8 @@ import type {
   GithubAnalysis,
   GithubAnalysisCorrectionRequest,
   GithubAnalysisCorrectionResponse,
-  GithubAnalysisRequest
+  GithubAnalysisRequest,
+  GithubAnalysisSummary
 } from "@/features/github-analysis/types";
 
 export function createGithubAnalysis(payload: GithubAnalysisRequest) {
@@ -14,6 +15,10 @@ export function getGithubAnalysis(githubAnalysisId: string) {
   return apiClient.get<GithubAnalysis>(
     `/api/github-analyses/${githubAnalysisId}`
   );
+}
+
+export function listGithubAnalyses() {
+  return apiClient.get<GithubAnalysisSummary[]>("/api/github-analyses");
 }
 
 export function saveGithubAnalysisCorrections(

--- a/frontend/src/features/github-analysis/github-analysis-list-view.tsx
+++ b/frontend/src/features/github-analysis/github-analysis-list-view.tsx
@@ -5,25 +5,24 @@ import { useEffect, useState } from "react";
 
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
-import { listDiagnoses } from "@/features/diagnosis/api";
-import { currentLevelLabels } from "@/features/diagnosis/labels";
-import type { DiagnosisSummary } from "@/features/diagnosis/types";
+import { listGithubAnalyses } from "@/features/github-analysis/api";
+import type { GithubAnalysisSummary } from "@/features/github-analysis/types";
 import { ApiError } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/auth";
 
 type State =
   | { status: "loading" }
   | { status: "auth-required" }
-  | { status: "ready"; items: DiagnosisSummary[] }
+  | { status: "ready"; items: GithubAnalysisSummary[] }
   | { status: "error"; message: string };
 
-export default function DiagnosesPage() {
+export function GithubAnalysisListView() {
   const [state, setState] = useState<State>({ status: "loading" });
 
   useEffect(() => {
     let cancelled = false;
 
-    listDiagnoses()
+    listGithubAnalyses()
       .then((items) => {
         if (cancelled) return;
         setState({ status: "ready", items });
@@ -43,11 +42,11 @@ export default function DiagnosesPage() {
   }, []);
 
   if (state.status === "loading") {
-    return <StatePanel message="진단 결과를 불러오는 중입니다." />;
+    return <StatePanel message="GitHub 분석 목록을 불러오는 중입니다." />;
   }
 
   if (state.status === "auth-required") {
-    return <AuthRequiredPanel redirectPath="/diagnoses" />;
+    return <AuthRequiredPanel redirectPath="/github/analysis" />;
   }
 
   if (state.status === "error") {
@@ -57,13 +56,10 @@ export default function DiagnosesPage() {
   if (state.items.length === 0) {
     return (
       <section className="screen-shell">
-        <StatePanel message="아직 생성된 진단 결과가 없습니다." />
-        <div className="action-row" aria-label="진단 다음 행동">
-          <Link className="action-link primary" href="/diagnoses/new">
-            진단 생성
-          </Link>
-          <Link className="action-link" href="/github/analysis">
-            분석 보정
+        <StatePanel message="아직 생성된 GitHub 분석 결과가 없습니다." />
+        <div className="action-row" aria-label="GitHub 분석 다음 행동">
+          <Link className="action-link primary" href="/github">
+            GitHub 연동
           </Link>
         </div>
       </section>
@@ -73,39 +69,36 @@ export default function DiagnosesPage() {
   return (
     <section className="screen-shell">
       <header className="screen-header">
-        <h2 className="screen-title">역량 진단 결과</h2>
+        <h2 className="screen-title">GitHub 분석</h2>
         <p className="screen-description">
-          시점별 진단 결과를 모아 봅니다. 최신 분석을 기반으로 다시 진단할 수 있어요.
+          저장소 분석 결과를 시점별로 모아 봅니다. 보정 작업은 카드 상세에서 진행해요.
         </p>
       </header>
       <ul className="card-grid">
         {state.items.map((item) => (
-          <li key={item.diagnosisId} className="result-card">
+          <li key={item.githubAnalysisId} className="result-card">
             <header className="result-card-header">
               <span className="result-card-meta">
-                {formatDate(item.createdAt)} · v{item.version}
+                {formatDate(item.createdAt)}
               </span>
               <span className="result-card-badge" data-tone="accent">
-                {currentLevelLabels[item.currentLevel] ?? item.currentLevel}
+                v{item.version}
               </span>
             </header>
             <p className="result-card-body">{item.summary}</p>
             <footer className="result-card-footer">
-              <Link
-                className="result-card-link"
-                href={`/github/analysis?githubAnalysisId=${item.githubAnalysisId}`}
-              >
-                ↳ GitHub 분석 #{item.githubAnalysisId} 기반
-              </Link>
               <div className="result-card-actions">
-                <Link className="action-link" href={`/diagnoses/${item.diagnosisId}`}>
+                <Link
+                  className="action-link primary"
+                  href={`/github/analysis?githubAnalysisId=${item.githubAnalysisId}`}
+                >
                   상세 보기
                 </Link>
                 <Link
-                  className="action-link primary"
+                  className="action-link"
                   href={`/diagnoses/new?githubAnalysisId=${item.githubAnalysisId}`}
                 >
-                  재진단
+                  진단 생성
                 </Link>
               </div>
             </footer>
@@ -133,5 +126,5 @@ function formatDate(iso: string) {
 
 function getErrorMessage(error: unknown) {
   if (error instanceof ApiError) return error.message;
-  return "진단 목록을 불러오지 못했습니다.";
+  return "GitHub 분석 목록을 불러오지 못했습니다.";
 }

--- a/frontend/src/features/github-analysis/types.ts
+++ b/frontend/src/features/github-analysis/types.ts
@@ -88,3 +88,10 @@ export type GithubAnalysisCorrectionResponse = {
   githubAnalysisId: string;
   savedAt: string;
 };
+
+export type GithubAnalysisSummary = {
+  githubAnalysisId: string;
+  version: number;
+  summary: string;
+  createdAt: string;
+};

--- a/frontend/src/features/github-connection/api.ts
+++ b/frontend/src/features/github-connection/api.ts
@@ -11,6 +11,10 @@ export function connectGithub(authorizationCode: string) {
   });
 }
 
+export function getLatestGithubConnection() {
+  return apiClient.get<GithubConnection>("/api/github/connections/latest");
+}
+
 export function getRepositories(connectionId: string) {
   return apiClient.get<GithubRepositoryList>(
     `/api/github/repositories?githubConnectionId=${connectionId}`

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -1,19 +1,20 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiError, githubConnectionOAuthUrl } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/auth";
-import { getRepositories, runAnalysis } from "@/features/github-connection/api";
+import {
+  getLatestGithubConnection,
+  getRepositories,
+  runAnalysis
+} from "@/features/github-connection/api";
 import type { Repository } from "@/features/github-connection/types";
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 
-const CONNECTION_ID_KEY = "githubConnectionId";
-const CONNECTION_ID_CHANGE_EVENT = "githubConnectionIdChange";
-const SELECTED_REPOS_KEY = "githubSelectedRepos";
-
 type ViewState =
+  | { status: "loading-connection" }
   | { status: "disconnected" }
   | { status: "loading-repos" }
   | { status: "auth-required" }
@@ -26,45 +27,39 @@ function getErrorMessage(error: unknown): string {
   return "오류가 발생했습니다. 다시 시도해주세요.";
 }
 
-function getConnectionIdSnapshot() {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(CONNECTION_ID_KEY);
-}
-
-function subscribeToConnectionId(onChange: () => void) {
-  if (typeof window === "undefined") return () => {};
-
-  window.addEventListener("storage", onChange);
-  window.addEventListener(CONNECTION_ID_CHANGE_EVENT, onChange);
-
-  return () => {
-    window.removeEventListener("storage", onChange);
-    window.removeEventListener(CONNECTION_ID_CHANGE_EVENT, onChange);
-  };
-}
-
-function clearConnectionId() {
-  localStorage.removeItem(CONNECTION_ID_KEY);
-  localStorage.removeItem(SELECTED_REPOS_KEY);
-  window.dispatchEvent(new Event(CONNECTION_ID_CHANGE_EVENT));
-}
-
 export function GithubConnectionView() {
   const router = useRouter();
-  const connectionId = useSyncExternalStore(
-    subscribeToConnectionId,
-    getConnectionIdSnapshot,
-    () => null
-  );
-  const [state, setState] = useState<ViewState>({ status: "loading-repos" });
-  const [selected, setSelected] = useState<Set<string>>(() => {
-    if (typeof window === "undefined") return new Set();
-    try {
-      const saved = localStorage.getItem(SELECTED_REPOS_KEY);
-      return saved ? new Set(JSON.parse(saved)) : new Set();
-    } catch { return new Set(); }
-  });
+  const [connectionId, setConnectionId] = useState<string | null>(null);
+  const [state, setState] = useState<ViewState>({ status: "loading-connection" });
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
   const [connectUrl] = useState(() => githubConnectionOAuthUrl());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getLatestGithubConnection()
+      .then((connection) => {
+        if (cancelled) return;
+        setConnectionId(connection.githubConnectionId);
+        setState({ status: "loading-repos" });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        if (isUnauthorizedError(error)) {
+          setState({ status: "auth-required" });
+          return;
+        }
+        if (error instanceof ApiError && error.status === 404) {
+          setState({ status: "disconnected" });
+          return;
+        }
+        setState({ status: "error", message: getErrorMessage(error) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!connectionId) return;
@@ -77,7 +72,8 @@ export function GithubConnectionView() {
       .catch((err) => {
         if (cancelled) return;
         if (err instanceof ApiError && err.status === 404) {
-          clearConnectionId();
+          setConnectionId(null);
+          setState({ status: "disconnected" });
         } else if (isUnauthorizedError(err)) {
           setState({ status: "auth-required" });
         } else {
@@ -91,9 +87,14 @@ export function GithubConnectionView() {
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) { next.delete(id); } else { next.add(id); }
-      localStorage.setItem(SELECTED_REPOS_KEY, JSON.stringify(Array.from(next)));
       return next;
     });
+  }
+
+  function reconnect() {
+    setConnectionId(null);
+    setSelected(new Set());
+    setState({ status: "disconnected" });
   }
 
   async function handleAnalyze() {
@@ -110,6 +111,10 @@ export function GithubConnectionView() {
       }
       setState({ status: "error", message: getErrorMessage(err) });
     }
+  }
+
+  if (state.status === "loading-connection") {
+    return <StatePanel message="연결 정보를 확인하는 중..." />;
   }
 
   if (!connectionId || state.status === "disconnected") {
@@ -148,7 +153,7 @@ export function GithubConnectionView() {
       <div>
         <StatePanel message={state.message} tone="danger" />
         <p>
-          <button onClick={clearConnectionId}>
+          <button onClick={reconnect}>
             다시 연결하기
           </button>
         </p>
@@ -274,10 +279,7 @@ export function GithubConnectionView() {
         </button>
         <button
           className="action-link"
-          onClick={() => {
-            clearConnectionId();
-            setSelected(new Set());
-          }}
+          onClick={reconnect}
         >
           다른 계정으로 연결
         </button>

--- a/frontend/src/features/roadmap/api.ts
+++ b/frontend/src/features/roadmap/api.ts
@@ -3,7 +3,8 @@ import type {
   Roadmap,
   RoadmapRequest,
   RoadmapProgressRequest,
-  RoadmapProgressResponse
+  RoadmapProgressResponse,
+  RoadmapSummary
 } from "@/features/roadmap/types";
 
 export function createRoadmap(payload: RoadmapRequest) {
@@ -12,6 +13,10 @@ export function createRoadmap(payload: RoadmapRequest) {
 
 export function getRoadmap(roadmapId: string) {
   return apiClient.get<Roadmap>(`/api/roadmaps/${roadmapId}`);
+}
+
+export function listRoadmaps() {
+  return apiClient.get<RoadmapSummary[]>("/api/roadmaps");
 }
 
 export function saveRoadmapProgress(

--- a/frontend/src/features/roadmap/types.ts
+++ b/frontend/src/features/roadmap/types.ts
@@ -68,3 +68,12 @@ export type RoadmapProgressResponse = {
   savedAt: string;
   status: ProgressStatus;
 };
+
+export type RoadmapSummary = {
+  roadmapId: string;
+  version: number;
+  totalWeeks: number;
+  summary: string;
+  diagnosisId: string;
+  createdAt: string;
+};

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -4,7 +4,7 @@ import type {
   ApiRequestOptions
 } from "@/lib/api/types";
 
-type HttpMethod = "GET" | "POST" | "PATCH";
+type HttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
 
 export type ApiTokenProvider = () =>
   | Promise<string | null | undefined>
@@ -178,5 +178,8 @@ export const apiClient = {
   },
   post<TData>(path: string, body?: unknown, options?: ApiRequestOptions) {
     return request<TData>("POST", path, { ...options, body });
+  },
+  delete<TData>(path: string, options?: ApiRequestOptions) {
+    return request<TData>("DELETE", path, options);
   }
 };


### PR DESCRIPTION
## Summary

두 슬라이스를 한 브랜치로 묶음. Slice 9의 globals.css/`GithubAnalysisDetailService` 변경이 Slice 8에 의존하여 분리가 비효율적.

- **Slice 8 (#286)** — Coach 채팅 페이지 프론트엔드 + `GET /api/coach/sessions/active`
- **Slice 9 (#287)** — 분석/진단/로드맵 목록 뷰 + 재진단 + localStorage 제거

## Slice 8 — Coach 채팅 (#286)

### Backend
- `GET /api/coach/sessions/active` (없으면 404)
- `ChatSessionRepository.findFirstByUserIdAndStatusOrderByStartedAtDesc`
- `CoachSessionService.getActiveSession`
- CORS allowedHeaders에 `Idempotency-Key` 추가

### Frontend
- `src/features/coach/` (types/api/coach-errors/entry-view/chat-view)
- `/coach` + `/coach/sessions/[sessionId]` 라우트
- nav에 Coach 메뉴 추가
- Tier 0 디테일: optimistic UI, single in-flight 가드, AbortController, 드래프트 보존, 에러 코드 한국어 매핑, auto-scroll, Idempotency-Key, 키바인딩, replan 카운트다운, 10초+ 안내 토스트

### 의존성 추가
- react-markdown, remark-gfm, react-textarea-autosize, sonner (~50KB)

## Slice 9 — 목록 뷰 + localStorage 제거 (#287)

### Backend (신규 API 4종)
- `GET /api/github-analyses` — 분석 목록
- `GET /api/diagnoses` — 진단 목록
- `GET /api/roadmaps` — 로드맵 목록
- `GET /api/github/connections/latest` — 최근 연결 (없으면 404)

### Frontend
- `/diagnoses`, `/roadmaps` 자동 redirect 제거 → 카드 그리드
- `/github/analysis?id` 없으면 목록, 있으면 detail
- 진단 detail에 재진단 버튼 (`DiagnosisDetailResponse.githubAnalysisId` 활용)
- localStorage 의존 완전 제거 (`githubConnectionId`, `githubSelectedRepos` → 서버 조회)
- 카드 UX: 날짜 + 배지 + summary 한 줄 + ref 링크

## 비범위 (후속 이슈)

- 로드맵 진도 카운트 → #293
- Coach 대화 히스토리 영속화 → #292

## Test plan

- [x] Backend fast tests 333/333 GREEN
- [x] Frontend tsc/eslint clean
- [x] Next build success (모든 라우트 등록)
- [ ] 수동: `/coach` 진입 → 새 세션 생성 → 메시지 전송 → replan confirm 흐름
- [x] 수동: `/diagnoses`, `/roadmaps`, `/github/analysis` 목록 카드 표시 + 재진단
- [x] 수동: 시크릿 모드에서 localStorage 의존 사라진 것 확인

Closes #286
Closes #287