### PR TITLE
feat(context): v1 결과 변경 시 PROFILE/PLAN Context Snapshot 자동 생성 (#284)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotPublisher.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotPublisher.java
@@ -1,0 +1,206 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
+import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.repository.GithubAnalysisRepository;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.jobrole.repository.JobRoleRepository;
+import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.domain.user.entity.UserSkill;
+import com.back.coach.domain.user.repository.UserProfileRepository;
+import com.back.coach.domain.user.repository.UserSkillRepository;
+import com.back.coach.global.code.ContextType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * v1 결과 변경 이후 PROFILE/PLAN snapshot을 생성한다.
+ *
+ * 호출 시점에 활성 트랜잭션이 있으면 afterCommit 훅으로 지연시켜 v1 저장 흐름을 보호한다.
+ * snapshot 생성 실패는 항상 swallow + log.warn.
+ */
+@Service
+public class ContextSnapshotPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(ContextSnapshotPublisher.class);
+
+    private final ContextSnapshotStorageService storageService;
+    private final UserProfileRepository userProfileRepository;
+    private final UserSkillRepository userSkillRepository;
+    private final JobRoleRepository jobRoleRepository;
+    private final GithubAnalysisRepository githubAnalysisRepository;
+    private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
+    private final LearningRoadmapRepository learningRoadmapRepository;
+    private final ObjectMapper objectMapper;
+
+    public ContextSnapshotPublisher(
+            ContextSnapshotStorageService storageService,
+            UserProfileRepository userProfileRepository,
+            UserSkillRepository userSkillRepository,
+            JobRoleRepository jobRoleRepository,
+            GithubAnalysisRepository githubAnalysisRepository,
+            CapabilityDiagnosisRepository capabilityDiagnosisRepository,
+            LearningRoadmapRepository learningRoadmapRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.storageService = storageService;
+        this.userProfileRepository = userProfileRepository;
+        this.userSkillRepository = userSkillRepository;
+        this.jobRoleRepository = jobRoleRepository;
+        this.githubAnalysisRepository = githubAnalysisRepository;
+        this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
+        this.learningRoadmapRepository = learningRoadmapRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void publishProfile(Long userId) {
+        runAfterCommit(() -> doPublishProfile(userId));
+    }
+
+    public void publishPlan(Long userId) {
+        runAfterCommit(() -> doPublishPlan(userId));
+    }
+
+    private void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+        } else {
+            action.run();
+        }
+    }
+
+    private void doPublishProfile(Long userId) {
+        try {
+            String payload = buildProfilePayload(userId);
+            storageService.createSnapshot(userId, ContextType.PROFILE, payload);
+        } catch (Exception e) {
+            log.warn("PROFILE snapshot publish failed userId={} reason={}", userId, e.getMessage());
+        }
+    }
+
+    private void doPublishPlan(Long userId) {
+        try {
+            String payload = buildPlanPayload(userId);
+            storageService.createSnapshot(userId, ContextType.PLAN, payload);
+        } catch (Exception e) {
+            log.warn("PLAN snapshot publish failed userId={} reason={}", userId, e.getMessage());
+        }
+    }
+
+    private String buildProfilePayload(Long userId) throws JsonProcessingException {
+        Optional<UserProfile> profile = userProfileRepository.findByUserId(userId);
+        Optional<GithubAnalysis> github = githubAnalysisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId);
+        Optional<CapabilityDiagnosis> diagnosis = capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId);
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("contextType", "PROFILE");
+        root.put("generatedAt", Instant.now().toString());
+
+        ObjectNode sourceRefs = root.putObject("sourceRefs");
+        profile.ifPresent(p -> sourceRefs.put("profileId", String.valueOf(p.getId())));
+        github.ifPresent(g -> {
+            sourceRefs.put("githubAnalysisId", String.valueOf(g.getId()));
+            sourceRefs.put("githubAnalysisVersion", g.getVersion());
+        });
+        diagnosis.ifPresent(d -> {
+            sourceRefs.put("diagnosisId", String.valueOf(d.getId()));
+            sourceRefs.put("diagnosisVersion", d.getVersion());
+        });
+
+        ObjectNode profileNode = root.putObject("profile");
+        if (profile.isPresent()) {
+            UserProfile p = profile.get();
+            JobRole jobRole = jobRoleRepository.findById(p.getJobRoleId()).orElse(null);
+            if (jobRole != null) {
+                profileNode.put("targetRole", jobRole.getRoleCode());
+            }
+            profileNode.put("currentLevel", p.getCurrentLevel().name());
+            if (p.getWeeklyStudyHours() != null) {
+                profileNode.put("weeklyStudyHours", p.getWeeklyStudyHours());
+            }
+            if (p.getInterestAreasJson() != null && !p.getInterestAreasJson().isBlank()) {
+                profileNode.set("interestAreas", objectMapper.readTree(p.getInterestAreasJson()));
+            }
+        }
+
+        ArrayNode skillsArr = root.putArray("skills");
+        List<UserSkill> skills = userSkillRepository.findByUserIdOrderBySkillNameAsc(userId);
+        for (UserSkill s : skills) {
+            ObjectNode sn = skillsArr.addObject();
+            sn.put("skillName", s.getSkillName());
+            sn.put("sourceType", s.getSourceType().name());
+            if (s.getProficiencyLevel() != null) {
+                sn.put("proficiencyLevel", s.getProficiencyLevel().name());
+            }
+        }
+
+        if (github.isPresent() && github.get().getAnalysisPayload() != null) {
+            try {
+                ObjectNode techProfile = (ObjectNode) objectMapper.readTree(github.get().getAnalysisPayload())
+                        .path("finalTechProfile");
+                if (!techProfile.isMissingNode()) {
+                    root.set("githubFinalTechProfile", techProfile);
+                }
+            } catch (Exception ignored) {
+                // tolerate parse issues; leave field absent
+            }
+        }
+
+        if (diagnosis.isPresent()) {
+            ObjectNode dx = root.putObject("diagnosisSummary");
+            dx.put("summary", diagnosis.get().getSummary());
+        }
+
+        return objectMapper.writeValueAsString(root);
+    }
+
+    private String buildPlanPayload(Long userId) throws JsonProcessingException {
+        Optional<LearningRoadmap> roadmap = learningRoadmapRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId);
+        Optional<CapabilityDiagnosis> diagnosis = capabilityDiagnosisRepository.findTopByUserIdOrderByVersionDescCreatedAtDesc(userId);
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("contextType", "PLAN");
+        Instant now = Instant.now();
+        root.put("generatedAt", now.toString());
+
+        ObjectNode sourceRefs = root.putObject("sourceRefs");
+        roadmap.ifPresent(r -> {
+            sourceRefs.put("roadmapId", String.valueOf(r.getId()));
+            sourceRefs.put("roadmapVersion", r.getVersion());
+        });
+        diagnosis.ifPresent(d -> {
+            sourceRefs.put("diagnosisId", String.valueOf(d.getId()));
+            sourceRefs.put("diagnosisVersion", d.getVersion());
+        });
+
+        root.put("progressAsOf", now.toString());
+
+        ObjectNode rmNode = root.putObject("roadmap");
+        if (roadmap.isPresent()) {
+            LearningRoadmap r = roadmap.get();
+            rmNode.put("totalWeeks", r.getTotalWeeks());
+            rmNode.put("summary", r.getSummary());
+        }
+
+        return objectMapper.writeValueAsString(root);
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.diagnosis.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.diagnosis.dto.DiagnosisDetailResponse;
 import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
 import com.back.coach.domain.diagnosis.dto.DiagnosisRequest;
@@ -45,6 +46,7 @@ public class DiagnosisCommandService {
     private final DiagnosisResponseParser diagnosisResponseParser;
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public DiagnosisCommandService(
             UserProfileRepository userProfileRepository,
@@ -58,7 +60,8 @@ public class DiagnosisCommandService {
             DiagnosisPromptBuilder diagnosisPromptBuilder,
             DiagnosisResponseParser diagnosisResponseParser,
             LlmClient llmClient,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.userProfileRepository = userProfileRepository;
         this.userSkillRepository = userSkillRepository;
@@ -72,6 +75,7 @@ public class DiagnosisCommandService {
         this.diagnosisResponseParser = diagnosisResponseParser;
         this.llmClient = llmClient;
         this.objectMapper = objectMapper;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     @Transactional
@@ -114,6 +118,8 @@ public class DiagnosisCommandService {
                         toJson(diagnosisPayload)
                 )
         );
+
+        contextSnapshotPublisher.publishProfile(userId);
 
         return toResponse(savedDiagnosis, jobRole, diagnosisPayload);
     }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.github.dto.GithubAnalysisDetailResponse;
 import com.back.coach.domain.github.dto.GithubAnalysisCorrectionRequest;
 import com.back.coach.domain.github.dto.GithubAnalysisCorrectionResponse;
@@ -23,23 +24,27 @@ public class GithubAnalysisDetailService {
     private final GithubAnalysisRepository githubAnalysisRepository;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     @Autowired
     public GithubAnalysisDetailService(
             GithubAnalysisRepository githubAnalysisRepository,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
-        this(githubAnalysisRepository, objectMapper, Clock.systemUTC());
+        this(githubAnalysisRepository, objectMapper, Clock.systemUTC(), contextSnapshotPublisher);
     }
 
     GithubAnalysisDetailService(
             GithubAnalysisRepository githubAnalysisRepository,
             ObjectMapper objectMapper,
-            Clock clock
+            Clock clock,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.githubAnalysisRepository = githubAnalysisRepository;
         this.objectMapper = objectMapper;
         this.clock = clock;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -77,6 +82,8 @@ public class GithubAnalysisDetailService {
 
         githubAnalysis.updateAnalysisPayload(toJson(updatedPayload));
         Instant savedAt = Instant.now(clock);
+
+        contextSnapshotPublisher.publishProfile(userId);
 
         return GithubAnalysisCorrectionResponse.of(
                 githubAnalysis.getId(),

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.entity.GithubAnalysis;
 import com.back.coach.domain.github.entity.GithubProject;
@@ -51,6 +52,7 @@ public class GithubAnalysisService {
     private final SynthesisResponseParser synthesisResponseParser;
     private final GithubAnalysisPayloadJson payloadJson;
     private final LlmClient llmClient;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public GithubAnalysisService(GithubConnectionRepository connectionRepo,
                                  GithubProjectRepository projectRepo,
@@ -63,7 +65,8 @@ public class GithubAnalysisService {
                                  SynthesisPromptBuilder synthesisPromptBuilder,
                                  SynthesisResponseParser synthesisResponseParser,
                                  GithubAnalysisPayloadJson payloadJson,
-                                 LlmClient llmClient) {
+                                 LlmClient llmClient,
+                                 ContextSnapshotPublisher contextSnapshotPublisher) {
         this.connectionRepo = connectionRepo;
         this.projectRepo = projectRepo;
         this.analysisRepo = analysisRepo;
@@ -76,6 +79,7 @@ public class GithubAnalysisService {
         this.synthesisResponseParser = synthesisResponseParser;
         this.payloadJson = payloadJson;
         this.llmClient = llmClient;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     @Transactional
@@ -157,6 +161,7 @@ public class GithubAnalysisService {
         GithubAnalysis saved = analysisRepo.save(
                 GithubAnalysis.create(userId, githubConnectionId, version, summary, payloadJson.toJson(payload))
         );
+        contextSnapshotPublisher.publishProfile(userId);
         long totalElapsedMs = System.currentTimeMillis() - analysisStartMs;
         AnalysisMetrics metrics = new AnalysisMetrics(
                 totalElapsedMs,

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.roadmap.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
 import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
 import com.back.coach.domain.diagnosis.repository.CapabilityDiagnosisRepository;
@@ -45,6 +46,7 @@ public class RoadmapCommandService {
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
     private final TransactionTemplate transactionTemplate;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public RoadmapCommandService(
             CapabilityDiagnosisRepository capabilityDiagnosisRepository,
@@ -58,7 +60,8 @@ public class RoadmapCommandService {
             RoadmapResponseParser roadmapResponseParser,
             LlmClient llmClient,
             ObjectMapper objectMapper,
-            TransactionTemplate transactionTemplate
+            TransactionTemplate transactionTemplate,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
         this.githubAnalysisRepository = githubAnalysisRepository;
@@ -72,6 +75,7 @@ public class RoadmapCommandService {
         this.llmClient = llmClient;
         this.objectMapper = objectMapper;
         this.transactionTemplate = transactionTemplate;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     // LLM 호출을 트랜잭션 밖에서 수행해 DB 커넥션을 장시간 점유하지 않도록 분리
@@ -98,7 +102,7 @@ public class RoadmapCommandService {
                 roadmapResponseParser.parse(llmClient.complete(prompt));
 
         // 3. DB 저장 (새 트랜잭션)
-        return transactionTemplate.execute(status -> {
+        RoadmapDetailResponse response = transactionTemplate.execute(status -> {
             RoadmapPayload roadmapPayload = new RoadmapPayload(roadmapResult.weeks());
             LearningRoadmap savedRoadmap = learningRoadmapRepository.save(LearningRoadmap.create(
                     userId,
@@ -111,8 +115,10 @@ public class RoadmapCommandService {
             List<RoadmapWeek> savedWeeks = roadmapWeekRepository.saveAll(toRoadmapWeeks(
                     savedRoadmap.getId(), roadmapResult.weeks()
             ));
+            contextSnapshotPublisher.publishPlan(userId);
             return RoadmapDetailResponse.from(toSnapshot(savedRoadmap, savedWeeks), objectMapper);
         });
+        return response;
     }
 
     private void validateGithubAnalysisOwnership(Long userId, Long githubAnalysisId) {

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapProgressCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapProgressCommandService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.roadmap.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.roadmap.dto.RoadmapProgressCommandResult;
 import com.back.coach.domain.roadmap.entity.ProgressLog;
 import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
@@ -18,15 +19,18 @@ public class RoadmapProgressCommandService {
     private final LearningRoadmapRepository learningRoadmapRepository;
     private final RoadmapWeekRepository roadmapWeekRepository;
     private final ProgressLogRepository progressLogRepository;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public RoadmapProgressCommandService(
             LearningRoadmapRepository learningRoadmapRepository,
             RoadmapWeekRepository roadmapWeekRepository,
-            ProgressLogRepository progressLogRepository
+            ProgressLogRepository progressLogRepository,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.learningRoadmapRepository = learningRoadmapRepository;
         this.roadmapWeekRepository = roadmapWeekRepository;
         this.progressLogRepository = progressLogRepository;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     public RoadmapProgressCommandResult appendProgress(
@@ -44,6 +48,8 @@ public class RoadmapProgressCommandService {
 
         ProgressLog progressLog = ProgressLog.create(userId, roadmapWeekId, nextStatus, note);
         ProgressLog savedProgressLog = progressLogRepository.save(progressLog);
+
+        contextSnapshotPublisher.publishPlan(userId);
 
         return new RoadmapProgressCommandResult(
                 savedProgressLog.getId(),

--- a/backend/src/main/java/com/back/coach/domain/user/service/ProfileService.java
+++ b/backend/src/main/java/com/back/coach/domain/user/service/ProfileService.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.user.service;
 
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.jobrole.entity.JobRole;
 import com.back.coach.domain.jobrole.repository.JobRoleRepository;
 import com.back.coach.domain.user.dto.ProfileDetailResponse;
@@ -35,17 +36,20 @@ public class ProfileService {
     private final UserSkillRepository userSkillRepository;
     private final JobRoleRepository jobRoleRepository;
     private final ObjectMapper objectMapper;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public ProfileService(
             UserProfileRepository userProfileRepository,
             UserSkillRepository userSkillRepository,
             JobRoleRepository jobRoleRepository,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.userProfileRepository = userProfileRepository;
         this.userSkillRepository = userSkillRepository;
         this.jobRoleRepository = jobRoleRepository;
         this.objectMapper = objectMapper;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
     @Transactional
@@ -80,6 +84,8 @@ public class ProfileService {
 
         UserProfile savedProfile = userProfileRepository.saveAndFlush(profile);
         replaceUserInputSkills(userId, normalizedSkills);
+
+        contextSnapshotPublisher.publishProfile(userId);
 
         return new ProfileSaveResult(savedProfile.getId(), savedProfile.getUpdatedAt());
     }

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotPublisherIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotPublisherIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.back.coach.domain.context.service;
+
+import com.back.coach.domain.context.entity.UserContextSnapshot;
+import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.user.entity.User;
+import com.back.coach.domain.user.repository.UserRepository;
+import com.back.coach.global.code.AuthProvider;
+import com.back.coach.global.code.ContextType;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class ContextSnapshotPublisherIntegrationTest {
+
+    @Autowired
+    private ContextSnapshotPublisher publisher;
+
+    @Autowired
+    private UserContextSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long userId;
+
+    @BeforeEach
+    void seedUser() {
+        User user = userRepository.save(
+                User.signupFromOAuth(AuthProvider.GITHUB,
+                        "gh-snapshot-pub-" + System.nanoTime(),
+                        "snapshot-pub@test.com")
+        );
+        userId = user.getId();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        snapshotRepository.deleteAll(snapshotRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .toList());
+        userRepository.deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("publishProfile: 활성 트랜잭션 없이 호출 시 PROFILE snapshot 1건 active로 저장")
+    void publishProfileCreatesActiveSnapshot() {
+        publisher.publishProfile(userId);
+
+        Optional<UserContextSnapshot> active =
+                snapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE);
+        assertThat(active).isPresent();
+        assertThat(active.get().getVersion()).isEqualTo(1);
+        assertThat(active.get().getValidTo()).isNull();
+    }
+
+    @Test
+    @DisplayName("publishPlan: 활성 트랜잭션 없이 호출 시 PLAN snapshot 1건 active로 저장")
+    void publishPlanCreatesActiveSnapshot() {
+        publisher.publishPlan(userId);
+
+        Optional<UserContextSnapshot> active =
+                snapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN);
+        assertThat(active).isPresent();
+        assertThat(active.get().getVersion()).isEqualTo(1);
+        assertThat(active.get().getValidTo()).isNull();
+    }
+
+    @Test
+    @DisplayName("publishProfile 두 번 호출 시 이전 snapshot은 close되고 새 version active")
+    void publishProfileTwiceClosesPreviousVersion() {
+        publisher.publishProfile(userId);
+        publisher.publishProfile(userId);
+
+        long total = snapshotRepository.findAll().stream()
+                .filter(s -> s.getUserId().equals(userId))
+                .filter(s -> s.getContextType() == ContextType.PROFILE)
+                .count();
+        assertThat(total).isEqualTo(2);
+
+        Optional<UserContextSnapshot> active =
+                snapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE);
+        assertThat(active).isPresent();
+        assertThat(active.get().getVersion()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
@@ -102,7 +102,8 @@ class DiagnosisCommandServiceTest {
                 new DiagnosisPromptBuilder(),
                 new DiagnosisResponseParser(),
                 llmClient,
-                objectMapper
+                objectMapper,
+                org.mockito.Mockito.mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
     }
 

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
@@ -50,7 +50,8 @@ class GithubAnalysisDetailServiceTest {
         githubAnalysisDetailService = new GithubAnalysisDetailService(
                 githubAnalysisRepository,
                 objectMapper,
-                Clock.fixed(FIXED_NOW, ZoneOffset.UTC)
+                Clock.fixed(FIXED_NOW, ZoneOffset.UTC),
+                org.mockito.Mockito.mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
     }
 

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -67,7 +67,8 @@ class GithubAnalysisServiceTest {
                 new SynthesisPromptBuilder(),
                 new SynthesisResponseParser(),
                 new GithubAnalysisPayloadJson(),
-                llmClient
+                llmClient,
+                mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
 
         triageJson = """

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -110,7 +110,8 @@ class RoadmapCommandServiceTest {
                 new RoadmapResponseParser(),
                 llmClient,
                 objectMapper,
-                transactionTemplate
+                transactionTemplate,
+                org.mockito.Mockito.mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
     }
 

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapProgressCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapProgressCommandServiceTest.java
@@ -40,6 +40,9 @@ class RoadmapProgressCommandServiceTest {
     @Mock
     private ProgressLogRepository progressLogRepository;
 
+    @Mock
+    private com.back.coach.domain.context.service.ContextSnapshotPublisher contextSnapshotPublisher;
+
     @InjectMocks
     private RoadmapProgressCommandService roadmapProgressCommandService;
 

--- a/backend/src/test/java/com/back/coach/domain/user/service/ProfileServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/user/service/ProfileServiceTest.java
@@ -63,7 +63,8 @@ class ProfileServiceTest {
                 userProfileRepository,
                 userSkillRepository,
                 jobRoleRepository,
-                objectMapper
+                objectMapper,
+                org.mockito.Mockito.mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
     }
 


### PR DESCRIPTION
## Summary

v1 프로필/GitHub 보정/진단/로드맵/진도 저장 후 v2 Coach가 읽을 `PROFILE`, `PLAN` snapshot을 자동 생성한다.

> ⚠️ **이 PR이 머지되지 않으면 Coach 세션이 시작되지 않습니다.** active snapshot이 없으면 `SNAPSHOT_NOT_FOUND` 에러로 `/coach` 진입 실패.

## 변경 사항

### 신규 `ContextSnapshotPublisher`
- `afterCommit` 훅으로 v1 저장 흐름과 격리, 실패는 swallow + `log.warn`
- `publishProfile`: profile + skills + 최신 github + 최신 diagnosis 합본 조립
- `publishPlan`: 최신 roadmap + diagnosis sourceRefs 조립
- payload는 `docs/16_v2_context_snapshot_contract.md` 기준 검증 통과

### Wiring (6개 서비스)
- `ProfileService.saveProfile` → `publishProfile`
- `GithubAnalysisDetailService.saveCorrections` → `publishProfile`
- `GithubAnalysisService.run` → `publishProfile`
- `DiagnosisCommandService.createDiagnosis` → `publishProfile`
- `RoadmapCommandService.createRoadmap` → `publishPlan`
- `RoadmapProgressCommandService.appendProgress` → `publishPlan`

### 테스트
- 영향받는 단위 테스트 6개 ctor 갱신 (mock publisher 추가)
- `ContextSnapshotPublisherIntegrationTest` 3건 추가 (profile/plan/version 증가)

## 완료 조건 (이슈 본문 기준)

- [x] 프로필 저장, GitHub 보정 저장, 진단 생성 후 `PROFILE` snapshot 갱신
- [x] 로드맵 생성, 진도 저장 후 `PLAN` snapshot 갱신
- [x] snapshot payload는 `docs/16` contract 준수
- [x] 기존 active snapshot의 `valid_to`를 닫고 새 version을 active로 저장
- [x] snapshot 생성 실패가 v1 핵심 저장 흐름을 깨지 않도록 실패 정책 정리 (`afterCommit` + swallow)

## Test plan

- [x] 단위 테스트 6개 GREEN
- [x] `ContextSnapshotPublisherIntegrationTest` 3건 GREEN
- [x] 수동: 프로필 저장 → `/coach` 진입 시 `SNAPSHOT_NOT_FOUND` 없이 세션 시작

## 관련

- 선행: #200 Context Snapshot 저장 기반
- 후속: snapshot churn dedup 정책 (보류, 별도 이슈로 분리 예정)
- 문서: `docs/16_v2_context_snapshot_contract.md`, `docs/18_v2_session_version_policy.md`

Closes #284
