### PR TITLE
refactor(llm): GitHub 분석과 진단 LLM 호출 트랜잭션 분리

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
@@ -26,7 +26,7 @@ import com.back.coach.global.exception.ServiceException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
 import java.util.List;
@@ -46,6 +46,7 @@ public class DiagnosisCommandService {
     private final DiagnosisResponseParser diagnosisResponseParser;
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
     private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public DiagnosisCommandService(
@@ -61,6 +62,7 @@ public class DiagnosisCommandService {
             DiagnosisResponseParser diagnosisResponseParser,
             LlmClient llmClient,
             ObjectMapper objectMapper,
+            TransactionTemplate transactionTemplate,
             ContextSnapshotPublisher contextSnapshotPublisher
     ) {
         this.userProfileRepository = userProfileRepository;
@@ -75,29 +77,32 @@ public class DiagnosisCommandService {
         this.diagnosisResponseParser = diagnosisResponseParser;
         this.llmClient = llmClient;
         this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
         this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
-    @Transactional
     public DiagnosisDetailResponse createDiagnosis(Long userId, DiagnosisRequest request) {
-        UserProfile profile = userProfileRepository.findByIdAndUserId(request.profileId(), userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
-        GithubAnalysis githubAnalysis = githubAnalysisRepository.findByIdAndUserId(request.githubAnalysisId(), userId)
-                .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
-        JobRole jobRole = jobRoleRepository.findById(profile.getJobRoleId())
-                .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
-        List<UserSkill> userSkills = userSkillRepository
-                .findByUserIdAndSourceTypeOrderBySkillNameAsc(userId, SkillSourceType.USER_INPUT);
-        List<SkillRequirement> skillRequirements = skillRequirementRepository
-                .findByJobRoleIdOrderByImportanceDescSkillNameAsc(profile.getJobRoleId());
-        GithubAnalysisPayload githubAnalysisPayload = parseGithubAnalysisPayload(githubAnalysis);
+        DiagnosisInputs inputs = transactionTemplate.execute(status -> {
+            UserProfile profile = userProfileRepository.findByIdAndUserId(request.profileId(), userId)
+                    .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+            GithubAnalysis githubAnalysis = githubAnalysisRepository.findByIdAndUserId(request.githubAnalysisId(), userId)
+                    .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+            JobRole jobRole = jobRoleRepository.findById(profile.getJobRoleId())
+                    .orElseThrow(() -> new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR));
+            List<UserSkill> userSkills = userSkillRepository
+                    .findByUserIdAndSourceTypeOrderBySkillNameAsc(userId, SkillSourceType.USER_INPUT);
+            List<SkillRequirement> skillRequirements = skillRequirementRepository
+                    .findByJobRoleIdOrderByImportanceDescSkillNameAsc(profile.getJobRoleId());
+            GithubAnalysisPayload githubAnalysisPayload = parseGithubAnalysisPayload(githubAnalysis);
+            return new DiagnosisInputs(profile, githubAnalysis, jobRole, userSkills, skillRequirements, githubAnalysisPayload);
+        });
 
         String prompt = diagnosisPromptBuilder.build(new DiagnosisPromptBuilder.Input(
-                jobRole,
-                profile,
-                userSkills,
-                skillRequirements,
-                githubAnalysisPayload.finalTechProfile()
+                inputs.jobRole(),
+                inputs.profile(),
+                inputs.userSkills(),
+                inputs.skillRequirements(),
+                inputs.githubAnalysisPayload().finalTechProfile()
         ));
         DiagnosisResponseParser.DiagnosisResult diagnosisResult =
                 diagnosisResponseParser.parse(llmClient.complete(prompt));
@@ -106,22 +111,23 @@ public class DiagnosisCommandService {
                 diagnosisResult.strengths(),
                 diagnosisResult.recommendations()
         );
-        CapabilityDiagnosis savedDiagnosis = capabilityDiagnosisRepository.save(
-                CapabilityDiagnosis.create(
-                        userId,
-                        profile.getId(),
-                        githubAnalysis.getId(),
-                        profile.getJobRoleId(),
-                        resultVersionService.nextCapabilityDiagnosisVersion(userId),
-                        profile.getCurrentLevel(),
-                        diagnosisResult.summary(),
-                        toJson(diagnosisPayload)
-                )
-        );
 
-        contextSnapshotPublisher.publishProfile(userId);
-
-        return toResponse(savedDiagnosis, jobRole, diagnosisPayload);
+        return transactionTemplate.execute(status -> {
+            CapabilityDiagnosis savedDiagnosis = capabilityDiagnosisRepository.save(
+                    CapabilityDiagnosis.create(
+                            userId,
+                            inputs.profile().getId(),
+                            inputs.githubAnalysis().getId(),
+                            inputs.profile().getJobRoleId(),
+                            resultVersionService.nextCapabilityDiagnosisVersion(userId),
+                            inputs.profile().getCurrentLevel(),
+                            diagnosisResult.summary(),
+                            toJson(diagnosisPayload)
+                    )
+            );
+            contextSnapshotPublisher.publishProfile(userId);
+            return toResponse(savedDiagnosis, inputs.jobRole(), diagnosisPayload);
+        });
     }
 
     private GithubAnalysisPayload parseGithubAnalysisPayload(GithubAnalysis githubAnalysis) {
@@ -165,4 +171,13 @@ public class DiagnosisCommandService {
     private Instant createdAtOrNow(CapabilityDiagnosis diagnosis) {
         return diagnosis.getCreatedAt() == null ? Instant.now() : diagnosis.getCreatedAt();
     }
+
+    private record DiagnosisInputs(
+            UserProfile profile,
+            GithubAnalysis githubAnalysis,
+            JobRole jobRole,
+            List<UserSkill> userSkills,
+            List<SkillRequirement> skillRequirements,
+            GithubAnalysisPayload githubAnalysisPayload
+    ) {}
 }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -52,6 +52,7 @@ public class GithubAnalysisService {
     private final SynthesisResponseParser synthesisResponseParser;
     private final GithubAnalysisPayloadJson payloadJson;
     private final LlmClient llmClient;
+    private final TransactionTemplate transactionTemplate;
     private final ContextSnapshotPublisher contextSnapshotPublisher;
 
     public GithubAnalysisService(GithubConnectionRepository connectionRepo,
@@ -66,6 +67,7 @@ public class GithubAnalysisService {
                                  SynthesisResponseParser synthesisResponseParser,
                                  GithubAnalysisPayloadJson payloadJson,
                                  LlmClient llmClient,
+                                 TransactionTemplate transactionTemplate,
                                  ContextSnapshotPublisher contextSnapshotPublisher) {
         this.connectionRepo = connectionRepo;
         this.projectRepo = projectRepo;
@@ -79,58 +81,45 @@ public class GithubAnalysisService {
         this.synthesisResponseParser = synthesisResponseParser;
         this.payloadJson = payloadJson;
         this.llmClient = llmClient;
+        this.transactionTemplate = transactionTemplate;
         this.contextSnapshotPublisher = contextSnapshotPublisher;
     }
 
-    @Transactional
     public GithubAnalysisResult run(Long userId, Long githubConnectionId,
                                     List<Long> selectedRepoIds, List<Long> coreRepoIds) {
         long analysisStartMs = System.currentTimeMillis();
         validateInputs(selectedRepoIds, coreRepoIds);
-        if (!connectionRepo.existsByIdAndUserId(githubConnectionId, userId)) {
-            throw new ServiceException(ErrorCode.FORBIDDEN);
-        }
-
-        Map<Long, GithubProject> projectsById = projectRepo
-                .findByUserIdAndGithubConnectionId(userId, githubConnectionId).stream()
-                .collect(Collectors.toMap(GithubProject::getId, p -> p));
-
-        List<GithubProject> selected = pickProjects(projectsById, selectedRepoIds);
-        List<GithubProject> coreProjects = pickProjects(projectsById, coreRepoIds);
-
-        List<StaticSignalAggregator.RepoSignalInput> signalInputs = selected.stream()
-                .map(p -> new StaticSignalAggregator.RepoSignalInput(
-                        p.getPrimaryLanguage(), parseMetadata(p.getMetadataPayload())))
-                .toList();
-        GithubAnalysisPayload.StaticSignals signals = signalAggregator.aggregate(signalInputs);
+        AnalysisInputs inputs = transactionTemplate.execute(status ->
+                loadInputs(userId, githubConnectionId, selectedRepoIds, coreRepoIds)
+        );
 
         List<GithubAnalysisPayload.RepoSummary> repoSummaries = new ArrayList<>();
         long triageElapsedMs = 0, summaryElapsedMs = 0;
         int triagePromptBytes = 0, summaryPromptBytes = 0;
 
-        for (GithubProject core : coreProjects) {
+        for (RepoAnalysisInput core : inputs.coreProjects()) {
             long repoStartMs = System.currentTimeMillis();
-            RepoMetadata metadata = parseMetadata(core.getMetadataPayload());
+            RepoMetadata metadata = core.metadata();
             if (isEmptyMetadata(metadata)) {
-                log.warn("분석 skip: 메타데이터 없음 repo={}", core.getRepoFullName());
+                log.warn("분석 skip: 메타데이터 없음 repo={}", core.repoFullName());
                 continue;
             }
             ChampionTriageService.TriageResult triage;
             try {
                 long triageStartMs = System.currentTimeMillis();
-                triage = triageService.triage(core.getRepoFullName(), core.getRepoUrl(), metadata);
+                triage = triageService.triage(core.repoFullName(), core.repoUrl(), metadata);
                 triageElapsedMs += System.currentTimeMillis() - triageStartMs;
                 log.debug("Triage completed: repo={}, elapsedMs={}, champions={}",
-                        core.getRepoFullName(), triageElapsedMs, triage.champions().size());
+                        core.repoFullName(), triageElapsedMs, triage.champions().size());
             } catch (ServiceException e) {
-                log.warn("분석 skip: 기여 커밋 없음 repo={}", core.getRepoFullName());
+                log.warn("분석 skip: 기여 커밋 없음 repo={}", core.repoFullName());
                 continue;
             }
 
             List<ResolvedChampion> resolved = resolveChampions(triage.champions(), metadata);
             String summaryPrompt = summaryPromptBuilder.build(
-                    String.valueOf(core.getId()), core.getRepoFullName(),
-                    core.getPrimaryLanguage(), resolved);
+                    String.valueOf(core.id()), core.repoFullName(),
+                    core.primaryLanguage(), resolved);
             summaryPromptBytes += summaryPrompt.getBytes().length;
             long summaryStartMs = System.currentTimeMillis();
             String summaryResponse = llmClient.complete(summaryPrompt);
@@ -138,11 +127,11 @@ public class GithubAnalysisService {
             repoSummaries.add(summaryResponseParser.parse(summaryResponse));
             long repoElapsedMs = System.currentTimeMillis() - repoStartMs;
             log.debug("Repo analysis completed: repo={}, totalElapsedMs={}",
-                    core.getRepoFullName(), repoElapsedMs);
+                    core.repoFullName(), repoElapsedMs);
         }
 
         long synthesisStartMs = System.currentTimeMillis();
-        String synthesisPrompt = synthesisPromptBuilder.build(signals, repoSummaries);
+        String synthesisPrompt = synthesisPromptBuilder.build(inputs.signals(), repoSummaries);
         int synthesisPromptBytes = synthesisPrompt.getBytes().length;
         log.debug("Synthesis prompt built: bytes={}", synthesisPromptBytes);
         String synthesisResponse = llmClient.complete(synthesisPrompt);
@@ -151,17 +140,20 @@ public class GithubAnalysisService {
         log.debug("Synthesis completed: elapsedMs={}", synthesisElapsedMs);
 
         GithubAnalysisPayload payload = new GithubAnalysisPayload(
-                signals, repoSummaries,
+                inputs.signals(), repoSummaries,
                 synthesis.techTags(), synthesis.depthEstimates(), synthesis.evidences(),
                 List.of(), synthesis.finalTechProfile()
         );
 
-        int version = nextVersion(userId);
-        String summary = composeSummary(synthesis.finalTechProfile());
-        GithubAnalysis saved = analysisRepo.save(
-                GithubAnalysis.create(userId, githubConnectionId, version, summary, payloadJson.toJson(payload))
-        );
-        contextSnapshotPublisher.publishProfile(userId);
+        GithubAnalysis saved = transactionTemplate.execute(status -> {
+            int version = nextVersion(userId);
+            String summary = composeSummary(synthesis.finalTechProfile());
+            GithubAnalysis savedAnalysis = analysisRepo.save(
+                    GithubAnalysis.create(userId, githubConnectionId, version, summary, payloadJson.toJson(payload))
+            );
+            contextSnapshotPublisher.publishProfile(userId);
+            return savedAnalysis;
+        });
         long totalElapsedMs = System.currentTimeMillis() - analysisStartMs;
         AnalysisMetrics metrics = new AnalysisMetrics(
                 totalElapsedMs,
@@ -177,6 +169,40 @@ public class GithubAnalysisService {
                 totalElapsedMs, repoSummaries.size(), metrics);
         return new GithubAnalysisResult(saved.getId(), saved.getVersion(), payload, saved.getSummary(),
                 saved.getCreatedAt() == null ? Instant.now() : saved.getCreatedAt(), metrics);
+    }
+
+    private AnalysisInputs loadInputs(Long userId, Long githubConnectionId,
+                                      List<Long> selectedRepoIds, List<Long> coreRepoIds) {
+        if (!connectionRepo.existsByIdAndUserId(githubConnectionId, userId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+
+        Map<Long, GithubProject> projectsById = projectRepo
+                .findByUserIdAndGithubConnectionId(userId, githubConnectionId).stream()
+                .collect(Collectors.toMap(GithubProject::getId, p -> p));
+
+        List<RepoAnalysisInput> selected = pickProjects(projectsById, selectedRepoIds).stream()
+                .map(this::toRepoInput)
+                .toList();
+        List<RepoAnalysisInput> coreProjects = pickProjects(projectsById, coreRepoIds).stream()
+                .map(this::toRepoInput)
+                .toList();
+
+        List<StaticSignalAggregator.RepoSignalInput> signalInputs = selected.stream()
+                .map(p -> new StaticSignalAggregator.RepoSignalInput(p.primaryLanguage(), p.metadata()))
+                .toList();
+        GithubAnalysisPayload.StaticSignals signals = signalAggregator.aggregate(signalInputs);
+        return new AnalysisInputs(signals, coreProjects);
+    }
+
+    private RepoAnalysisInput toRepoInput(GithubProject project) {
+        return new RepoAnalysisInput(
+                project.getId(),
+                project.getRepoFullName(),
+                project.getRepoUrl(),
+                project.getPrimaryLanguage(),
+                parseMetadata(project.getMetadataPayload())
+        );
     }
 
     private void validateInputs(List<Long> selectedRepoIds, List<Long> coreRepoIds) {
@@ -313,5 +339,18 @@ public class GithubAnalysisService {
             long summaryElapsedMs,
             int synthesisPromptBytes,
             long synthesisElapsedMs
+    ) {}
+
+    private record AnalysisInputs(
+            GithubAnalysisPayload.StaticSignals signals,
+            List<RepoAnalysisInput> coreProjects
+    ) {}
+
+    private record RepoAnalysisInput(
+            Long id,
+            String repoFullName,
+            String repoUrl,
+            String primaryLanguage,
+            RepoMetadata metadata
     ) {}
 }

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
@@ -34,6 +34,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -103,6 +108,7 @@ class DiagnosisCommandServiceTest {
                 new DiagnosisResponseParser(),
                 llmClient,
                 objectMapper,
+                transactionTemplate(),
                 org.mockito.Mockito.mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
     }
@@ -309,5 +315,22 @@ class DiagnosisCommandServiceTest {
                   "recommendations": ["Redis 캐시와 TTL 기반 설계를 먼저 학습"]
                 }
                 """;
+    }
+
+    private static TransactionTemplate transactionTemplate() {
+        return new TransactionTemplate(new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+            }
+        });
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -20,6 +20,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
@@ -68,6 +73,7 @@ class GithubAnalysisServiceTest {
                 new SynthesisResponseParser(),
                 new GithubAnalysisPayloadJson(),
                 llmClient,
+                transactionTemplate(),
                 mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
         );
 
@@ -209,5 +215,22 @@ class GithubAnalysisServiceTest {
     private static GithubAnalysis withId(GithubAnalysis a, long id) {
         ReflectionTestUtils.setField(a, "id", id);
         return a;
+    }
+
+    private static TransactionTemplate transactionTemplate() {
+        return new TransactionTemplate(new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+            }
+        });
     }
 }


### PR DESCRIPTION
## 무엇
- Closes #283
- GitHub 분석과 진단 생성 흐름을 조회 트랜잭션, LLM 호출, 저장 트랜잭션으로 분리했습니다.
- 저장 트랜잭션 안에서 version 계산과 결과 저장을 수행하도록 유지했습니다.
- Context Snapshot publish 호출은 저장 트랜잭션 안에 남겨 기존 afterCommit 정책을 유지했습니다.

## 왜
- GitHub 분석/진단 LLM 호출이 길어질 때 DB connection을 장시간 점유하지 않도록 하기 위함입니다.
- #282 수동 smoke에서 LLM 대기 시간이 실제로 길게 관찰되어 v1 시연 안정성에 직접 영향을 줍니다.

## 검증
- `cd backend; .\gradlew.bat test --tests *DiagnosisCommandServiceTest --tests *GithubAnalysisServiceTest --tests *V1ResultFlowIntegrationTest --tests *GithubAnalysisFlowIntegrationTest`

## 제외
- prompt 품질 개선
- provider 교체
- Redis 비동기 polling
- frontend UX 변경