### PR TITLE
test(deploy): 배포 smoke runner 추가

### DIFF
--- a/docs/13_v1_smoke_test_checklist.md
+++ b/docs/13_v1_smoke_test_checklist.md
@@ -47,6 +47,14 @@ v1 시연 핵심 흐름을 같은 기준으로 수동 검증하기 위한 체크
 - [ ] 실패 시 active 전환을 중단하고 기존 active color를 유지한다.
 - [ ] active 전환 후 같은 smoke를 한 번 더 실행한다.
 
+실행 예시:
+
+```powershell
+.\scripts\smoke\deploy-smoke.ps1 `
+  -AppBaseUrl "https://APP_DOMAIN" `
+  -ApiBaseUrl "https://API_DOMAIN"
+```
+
 ### 시연 전 Full Rehearsal
 
 full rehearsal은 실제 사용자가 보는 흐름을 확인하는 수동 검증이다. 매 배포마다 실행하지 않고 시연 전 또는 큰 기능 변경 후 수행한다.

--- a/docs/13_v1_smoke_test_checklist.md
+++ b/docs/13_v1_smoke_test_checklist.md
@@ -33,6 +33,31 @@ v1 시연 핵심 흐름을 같은 기준으로 수동 검증하기 위한 체크
 - [ ] 401 응답은 로그인 CTA 또는 로그인 화면으로 복구 가능하고, 일반 API 오류와 구분된다.
 - [ ] 실패한 단계가 있으면 blocker 양식에 요청, 응답, 화면 경로, 관련 ID, 로그를 기록한다.
 
+## 운영 배포 Smoke / 시연 Rehearsal 기준
+
+### 배포 직후 Deploy Smoke
+
+배포 직후 smoke는 짧고 반복 가능한 자동 검증으로 수행한다. 목적은 새 배포가 운영 도메인에서 최소한의 접속, health, CORS 기준을 깨지 않았는지 빠르게 확인하는 것이다.
+
+- [ ] `APP_BASE_URL`, `API_BASE_URL`이 배포 대상 도메인 또는 inactive color를 가리키는지 확인한다.
+- [ ] frontend root 응답이 2xx 또는 3xx인지 확인한다.
+- [ ] backend `/actuator/health` 응답이 200이고 `status`가 `UP`인지 확인한다.
+- [ ] backend `/actuator/info` 등 공개 API 경로가 응답하는지 확인한다.
+- [ ] frontend origin 기준 CORS preflight가 통과하는지 확인한다.
+- [ ] 실패 시 active 전환을 중단하고 기존 active color를 유지한다.
+- [ ] active 전환 후 같은 smoke를 한 번 더 실행한다.
+
+### 시연 전 Full Rehearsal
+
+full rehearsal은 실제 사용자가 보는 흐름을 확인하는 수동 검증이다. 매 배포마다 실행하지 않고 시연 전 또는 큰 기능 변경 후 수행한다.
+
+- [ ] 실제 운영 도메인에서 GitHub 로그인 OAuth callback을 확인한다.
+- [ ] 실제 운영 도메인에서 저장소 연결 OAuth callback을 확인한다.
+- [ ] 실제 GitHub API와 AI Gateway 응답을 포함해 v1 핵심 흐름을 끝까지 수행한다.
+- [ ] v2 Coach 진입이 필요한 시연이면 active snapshot 기준 세션 생성까지 확인한다.
+- [ ] 외부 API 지연 시간과 사용자 입장에서 멈춘 것처럼 보이는 구간을 기록한다.
+- [ ] token, cookie, API key, OAuth secret 원문은 문서, 로그 캡처, PR에 남기지 않는다.
+
 ## v1 흐름 체크리스트
 
 ### 1. 로그인 / 인증 복구

--- a/scripts/smoke/deploy-smoke.ps1
+++ b/scripts/smoke/deploy-smoke.ps1
@@ -1,0 +1,193 @@
+param(
+    [string] $AppBaseUrl = $env:APP_BASE_URL,
+    [string] $ApiBaseUrl = $env:API_BASE_URL,
+    [string] $Origin = $env:SMOKE_ORIGIN,
+    [int] $TimeoutSeconds = 10
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Normalize-BaseUrl {
+    param(
+        [string] $Value,
+        [string] $Fallback,
+        [string] $Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        $Value = $Fallback
+    }
+
+    $normalized = $Value.Trim().TrimEnd("/")
+    if (-not [Uri]::IsWellFormedUriString($normalized, [UriKind]::Absolute)) {
+        throw "$Name must be an absolute http(s) URL. Value: $normalized"
+    }
+
+    $uri = [Uri] $normalized
+    if ($uri.Scheme -notin @("http", "https")) {
+        throw "$Name must use http or https. Value: $normalized"
+    }
+
+    return $normalized
+}
+
+function Get-HeaderValue {
+    param(
+        [Parameter(Mandatory = $true)] $Response,
+        [Parameter(Mandatory = $true)] [string] $Name
+    )
+
+    $value = $Response.Headers[$Name]
+    if ($null -eq $value) {
+        return ""
+    }
+
+    if ($value -is [array]) {
+        return ($value -join ",")
+    }
+
+    return [string] $value
+}
+
+function Get-ResponseContentText {
+    param([Parameter(Mandatory = $true)] $Response)
+
+    if ($Response.Content -is [byte[]]) {
+        return [System.Text.Encoding]::UTF8.GetString($Response.Content)
+    }
+
+    return [string] $Response.Content
+}
+
+function Invoke-SmokeRequest {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Name,
+        [Parameter(Mandatory = $true)] [string] $Uri,
+        [string] $Method = "GET",
+        [hashtable] $Headers = @{}
+    )
+
+    try {
+        return Invoke-WebRequest `
+            -Uri $Uri `
+            -Method $Method `
+            -Headers $Headers `
+            -TimeoutSec $TimeoutSeconds `
+            -UseBasicParsing
+    } catch {
+        throw "$Name request failed: $($_.Exception.Message)"
+    }
+}
+
+function Assert-StatusRange {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Name,
+        [Parameter(Mandatory = $true)] $Response,
+        [int] $Min = 200,
+        [int] $MaxExclusive = 400
+    )
+
+    $statusCode = [int] $Response.StatusCode
+    if ($statusCode -lt $Min -or $statusCode -ge $MaxExclusive) {
+        throw "$Name returned unexpected status $statusCode"
+    }
+}
+
+function Write-Pass {
+    param([Parameter(Mandatory = $true)] [string] $Message)
+    Write-Host "[PASS] $Message"
+}
+
+function Write-Fail {
+    param([Parameter(Mandatory = $true)] [string] $Message)
+    Write-Host "[FAIL] $Message" -ForegroundColor Red
+    $script:failures.Add($Message) | Out-Null
+}
+
+$appBase = Normalize-BaseUrl -Value $AppBaseUrl -Fallback "http://localhost:3000" -Name "APP_BASE_URL"
+$apiBase = Normalize-BaseUrl -Value $ApiBaseUrl -Fallback "http://localhost:8080" -Name "API_BASE_URL"
+
+if ([string]::IsNullOrWhiteSpace($Origin)) {
+    $Origin = $appBase
+}
+$originBase = Normalize-BaseUrl -Value $Origin -Fallback $appBase -Name "SMOKE_ORIGIN"
+
+$script:failures = [System.Collections.Generic.List[string]]::new()
+
+Write-Host "Deploy smoke target"
+Write-Host "APP_BASE_URL=$appBase"
+Write-Host "API_BASE_URL=$apiBase"
+Write-Host "SMOKE_ORIGIN=$originBase"
+Write-Host ""
+
+try {
+    $frontendResponse = Invoke-SmokeRequest -Name "frontend root" -Uri $appBase
+    Assert-StatusRange -Name "frontend root" -Response $frontendResponse
+    Write-Pass "frontend root responded with HTTP $([int] $frontendResponse.StatusCode)"
+} catch {
+    Write-Fail $_.Exception.Message
+}
+
+try {
+    $healthResponse = Invoke-SmokeRequest -Name "backend health" -Uri "$apiBase/actuator/health"
+    Assert-StatusRange -Name "backend health" -Response $healthResponse -MaxExclusive 300
+
+    $health = Get-ResponseContentText -Response $healthResponse | ConvertFrom-Json
+    if (-not ($health.PSObject.Properties.Name -contains "status")) {
+        throw "backend health response does not include status"
+    }
+    if ($health.status -ne "UP") {
+        throw "backend health status is $($health.status)"
+    }
+
+    Write-Pass "backend health is UP"
+} catch {
+    Write-Fail $_.Exception.Message
+}
+
+try {
+    $infoResponse = Invoke-SmokeRequest -Name "backend info" -Uri "$apiBase/actuator/info"
+    Assert-StatusRange -Name "backend info" -Response $infoResponse -MaxExclusive 300
+    Write-Pass "backend info endpoint responded with HTTP $([int] $infoResponse.StatusCode)"
+} catch {
+    Write-Fail $_.Exception.Message
+}
+
+try {
+    $corsHeaders = @{
+        Origin = $originBase
+        "Access-Control-Request-Method" = "GET"
+        "Access-Control-Request-Headers" = "Content-Type"
+    }
+    $corsResponse = Invoke-SmokeRequest `
+        -Name "CORS preflight" `
+        -Uri "$apiBase/actuator/health" `
+        -Method "OPTIONS" `
+        -Headers $corsHeaders
+
+    Assert-StatusRange -Name "CORS preflight" -Response $corsResponse -MaxExclusive 300
+
+    $allowOrigin = Get-HeaderValue -Response $corsResponse -Name "Access-Control-Allow-Origin"
+    $allowCredentials = Get-HeaderValue -Response $corsResponse -Name "Access-Control-Allow-Credentials"
+
+    if ($allowOrigin -ne $originBase -and $allowOrigin -ne "*") {
+        throw "CORS preflight returned Access-Control-Allow-Origin='$allowOrigin'"
+    }
+    if ($allowCredentials.ToLowerInvariant() -ne "true") {
+        throw "CORS preflight did not allow credentials"
+    }
+
+    Write-Pass "CORS preflight allowed $originBase"
+} catch {
+    Write-Fail $_.Exception.Message
+}
+
+if ($script:failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Deploy smoke failed with $($script:failures.Count) failure(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Deploy smoke passed."


### PR DESCRIPTION
﻿## 무엇
- #306 기준으로 배포 직후 실행할 PowerShell deploy smoke runner를 추가했다.
- `docs/13_v1_smoke_test_checklist.md`에 deploy smoke와 시연 전 full rehearsal 기준을 분리해 정리했다.

## 왜
- #303 Blue-Green 배포에서 inactive color를 active로 전환하기 전에 최소 접속, health, CORS를 빠르게 확인하기 위해 필요하다.
- 실제 GitHub OAuth와 AI Gateway full rehearsal은 #304에서 수동 검증으로 유지한다.

## 검증
- 임시 HTTP 서버 기준 runner PASS 확인
- 잘못된 URL 기준 runner FAIL 및 non-zero exit 확인
- 현재 로컬 `localhost:8080` backend health/info/CORS 통과 확인
- 현재 로컬 `localhost:3000` frontend root 500은 runner가 실패로 감지함
