### PR TITLE
chore(docker): backend/frontend production Dockerfile과 배포 compose 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 
 # Environment
 .env
+.env.deploy
 *.env.local
 
 # Spring Boot 로컬 시크릿 프로필 (application-secret.yml.example 만 commit)

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,11 @@
+.gradle
+build
+*.log
+
+.env
+.env.*
+
+src/main/resources/application-secret.yml
+src/main/resources/application-secret.yaml
+
+Dockerfile

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,6 +37,9 @@ EXPOSE 8080
 
 ENV SPRING_PROFILES_ACTIVE=prod
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl -fsS http://localhost:8080/actuator/health | grep -q '"status":"UP"' || exit 1
+
 ENTRYPOINT ["java", \
   "-XX:+UseZGC", \
   "-XX:MaxRAMPercentage=75", \

--- a/docker/.env.deploy.example
+++ b/docker/.env.deploy.example
@@ -1,0 +1,55 @@
+# Images
+BACKEND_IMAGE=coach-backend:local
+FRONTEND_IMAGE=coach-frontend:local
+
+# Public endpoints
+APP_URL=http://localhost:3001
+API_URL=http://localhost:8081
+
+# Blue/green host ports
+BACKEND_BLUE_PORT=8081
+BACKEND_GREEN_PORT=8082
+FRONTEND_BLUE_PORT=3001
+FRONTEND_GREEN_PORT=3002
+
+# Local-only database/cache host ports for EC2 diagnostics.
+# Services communicate through Docker network names internally.
+POSTGRES_HOST_PORT=15432
+REDIS_HOST_PORT=16379
+
+# PostgreSQL
+POSTGRES_DB=coachdb
+POSTGRES_USER=coach
+POSTGRES_PASSWORD=change-me
+DATABASE_URL=jdbc:postgresql://postgres:5432/coachdb
+DATABASE_USERNAME=coach
+DATABASE_PASSWORD=change-me
+
+# Redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Backend runtime
+SPRING_PROFILES_ACTIVE=prod,oauth
+CORS_ALLOWED_ORIGINS=http://localhost:3001
+FRONTEND_URL=http://localhost:3001
+JWT_SECRET=change-me-to-a-long-random-production-secret
+
+# GitHub OAuth - login
+GITHUB_CLIENT_ID=your-production-login-oauth-client-id
+GITHUB_CLIENT_SECRET=your-production-login-oauth-client-secret
+
+# GitHub OAuth - repository connection
+GITHUB_CONNECTION_CLIENT_ID=your-production-connection-oauth-client-id
+GITHUB_CONNECTION_CLIENT_SECRET=your-production-connection-oauth-client-secret
+
+# AI provider / gateway
+AI_GATEWAY_API_KEY=your-ai-gateway-api-key
+AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co
+AI_GATEWAY_MODEL=glm-4.5-flash
+
+# Frontend build-time public config.
+# These values are baked into the frontend image during docker build.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8081
+NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=your-production-connection-oauth-client-id
+NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3001/github/callback

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,49 @@
+# Docker Deploy Notes
+
+이 디렉터리는 시연용 단일 EC2 Blue-Green 배포에서 사용할 실행 기준을 둔다.
+
+## 환경 파일
+
+```powershell
+Copy-Item docker/.env.deploy.example docker/.env.deploy
+```
+
+`docker/.env.deploy`에는 운영 도메인, OAuth client id/secret, JWT secret, AI Gateway key를 채운다. 이 파일은 Git에 올리지 않는다.
+
+## 이미지 빌드
+
+```powershell
+docker build -t coach-backend:local ./backend
+
+docker build `
+  --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8081 `
+  --build-arg NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=dummy `
+  --build-arg NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3001/github/callback `
+  -t coach-frontend:local ./frontend
+```
+
+`NEXT_PUBLIC_*` 값은 frontend build 시점에 client bundle에 포함된다. OAuth secret, JWT secret, AI Gateway key는 image에 넣지 않고 runtime env로만 주입한다.
+
+## Blue-Green 실행 기준
+
+```powershell
+docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml up -d postgres redis
+docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml up -d backend-blue frontend-blue
+```
+
+기본 포트는 다음과 같다.
+
+- backend blue: `8081`
+- backend green: `8082`
+- frontend blue: `3001`
+- frontend green: `3002`
+
+inactive color 배포, smoke 검증, active switch는 후속 #303 GitHub Actions CD workflow에서 붙인다.
+
+## Smoke
+
+```powershell
+.\scripts\smoke\deploy-smoke.ps1 `
+  -AppBaseUrl "http://localhost:3001" `
+  -ApiBaseUrl "http://localhost:8081"
+```

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -1,0 +1,122 @@
+name: coach-deploy
+
+x-backend-env: &backend-env
+  SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod,oauth}
+  DATABASE_URL: ${DATABASE_URL:-jdbc:postgresql://postgres:5432/coachdb}
+  DATABASE_USERNAME: ${DATABASE_USERNAME:-coach}
+  DATABASE_PASSWORD: ${DATABASE_PASSWORD:-coach}
+  REDIS_HOST: ${REDIS_HOST:-redis}
+  REDIS_PORT: ${REDIS_PORT:-6379}
+  CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3001}
+  FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3001}
+  JWT_SECRET: ${JWT_SECRET:-change-me-to-a-long-random-production-secret}
+  GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
+  GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+  GITHUB_CONNECTION_CLIENT_ID: ${GITHUB_CONNECTION_CLIENT_ID:-}
+  GITHUB_CONNECTION_CLIENT_SECRET: ${GITHUB_CONNECTION_CLIENT_SECRET:-}
+  AI_GATEWAY_API_KEY: ${AI_GATEWAY_API_KEY:-}
+  AI_GATEWAY_BASE_URL: ${AI_GATEWAY_BASE_URL:-https://aigw.alpha.grepp.co}
+  AI_GATEWAY_MODEL: ${AI_GATEWAY_MODEL:-glm-4.5-flash}
+
+x-backend-depends-on: &backend-depends-on
+  postgres:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+
+x-frontend-env: &frontend-env
+  NODE_ENV: production
+  PORT: 3000
+  HOSTNAME: 0.0.0.0
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: coach-deploy-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-coachdb}
+      POSTGRES_USER: ${POSTGRES_USER:-coach}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-coach}
+    ports:
+      - "127.0.0.1:${POSTGRES_HOST_PORT:-15432}:5432"
+    volumes:
+      - coach-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: coach-deploy-redis
+    command: redis-server --appendonly yes
+    ports:
+      - "127.0.0.1:${REDIS_HOST_PORT:-16379}:6379"
+    volumes:
+      - coach-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  backend-blue:
+    image: ${BACKEND_IMAGE:-coach-backend:local}
+    container_name: coach-deploy-backend-blue
+    environment:
+      <<: *backend-env
+      DEPLOY_COLOR: blue
+    ports:
+      - "${BACKEND_BLUE_PORT:-8081}:8080"
+    depends_on: *backend-depends-on
+    restart: unless-stopped
+
+  backend-green:
+    image: ${BACKEND_IMAGE:-coach-backend:local}
+    container_name: coach-deploy-backend-green
+    environment:
+      <<: *backend-env
+      DEPLOY_COLOR: green
+    ports:
+      - "${BACKEND_GREEN_PORT:-8082}:8080"
+    depends_on: *backend-depends-on
+    restart: unless-stopped
+
+  frontend-blue:
+    image: ${FRONTEND_IMAGE:-coach-frontend:local}
+    container_name: coach-deploy-frontend-blue
+    environment:
+      <<: *frontend-env
+      DEPLOY_COLOR: blue
+    ports:
+      - "${FRONTEND_BLUE_PORT:-3001}:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+    restart: unless-stopped
+
+  frontend-green:
+    image: ${FRONTEND_IMAGE:-coach-frontend:local}
+    container_name: coach-deploy-frontend-green
+    environment:
+      <<: *frontend-env
+      DEPLOY_COLOR: green
+    ports:
+      - "${FRONTEND_GREEN_PORT:-3002}:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  coach-postgres-data:
+  coach-redis-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+*.log
+
+.env
+.env.*
+
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:24-alpine AS deps
+WORKDIR /app
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:24-alpine AS builder
+WORKDIR /app
+
+ARG NEXT_PUBLIC_API_BASE_URL
+ARG NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID
+ARG NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI
+
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL} \
+    NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=${NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID} \
+    NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=${NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+FROM node:24-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup -S nextjs && adduser -S nextjs -G nextjs
+
+COPY --from=builder --chown=nextjs:nextjs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nextjs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
-module.exports = nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  output: "standalone",
+  reactStrictMode: true,
+};
 
 export default nextConfig;


### PR DESCRIPTION
﻿## 무엇
- backend production image 기준에 `.dockerignore`와 actuator healthcheck를 보강했다.
- frontend production Dockerfile을 추가하고 Next standalone output 기준으로 정리했다.
- EC2 단일 서버에서 사용할 blue/green deploy compose와 `.env.deploy.example`, 실행 메모를 추가했다.

## 왜
- #303 GitHub Actions CD 자동 배포가 사용할 backend/frontend 실행 단위가 필요하다.
- inactive color 배포 후 #306 deploy smoke로 검증하고 active switch할 수 있는 포트/컨테이너 기준을 먼저 고정하기 위해 필요하다.

## 검증
- `docker build -t coach-backend:local ./backend`
- `docker build --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 --build-arg NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=dummy --build-arg NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3000/github/callback -t coach-frontend:local ./frontend`
- `docker compose --env-file docker/.env.deploy.example -f docker/docker-compose.deploy.yml config --quiet`
- `docker compose --env-file docker/.env.deploy.example -f docker/docker-compose.deploy.yml up -d postgres redis backend-blue frontend-blue`
- `./scripts/smoke/deploy-smoke.ps1 -AppBaseUrl http://localhost:3001 -ApiBaseUrl http://localhost:8081`

Closes #302
