### PR TITLE
infra(deploy): Terraform 기반 시연용 Blue-Green 배포 인프라 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,17 @@ Thumbs.db
 .env
 .env.deploy
 *.env.local
+*.tfvars
+!*.tfvars.example
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraform/
 
 # Spring Boot 로컬 시크릿 프로필 (application-secret.yml.example 만 commit)
 application-secret.yml

--- a/infra/terraform/demo-bluegreen/.terraform.lock.hcl
+++ b/infra/terraform/demo-bluegreen/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/demo-bluegreen/README.md
+++ b/infra/terraform/demo-bluegreen/README.md
@@ -1,0 +1,104 @@
+# Demo Blue-Green Terraform
+
+시연용 단일 EC2 Blue-Green 배포 인프라를 만드는 Terraform 구성이다. #302의 `docker/docker-compose.deploy.yml`을 EC2에서 실행할 수 있도록 서버, 보안 그룹, Elastic IP, IAM instance profile, Docker 설치 user data를 준비한다.
+
+## 범위
+
+포함:
+
+- EC2 instance
+- Security Group
+- Elastic IP
+- IAM role / instance profile
+- Ubuntu 24.04 LTS AMI 조회
+- Docker, Docker Compose plugin 설치 user data
+- `/opt/coach` 배포 디렉터리 준비
+
+제외:
+
+- RDS / ElastiCache
+- ALB target group 기반 Blue-Green
+- CloudFront / S3 정적 배포
+- Route53 record 생성
+- GitHub Actions CD 자동화
+
+## 준비
+
+```powershell
+cd infra/terraform/demo-bluegreen
+Copy-Item terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars`에는 실제 값을 넣는다. 이 파일은 Git에 올리지 않는다.
+
+확인할 값:
+
+- `key_name`: AWS에 이미 생성된 EC2 key pair 이름
+- `allowed_ssh_cidr`: 가능하면 내 IP `/32`
+- `allowed_http_cidr`: 시연 접근을 허용할 CIDR
+- `vpc_id`, `subnet_id`: 기본 VPC를 쓰지 않을 때만 지정
+
+## 명령
+
+```powershell
+terraform init
+terraform fmt -check
+terraform validate
+terraform plan -var-file="terraform.tfvars"
+```
+
+실제 리소스 생성은 AWS 계정, 비용, 도메인, secret 주입 방식이 확정된 뒤 실행한다.
+
+```powershell
+terraform apply -var-file="terraform.tfvars"
+```
+
+## 출력
+
+`terraform apply` 후 다음 값을 확인한다.
+
+- `elastic_ip`
+- `ssh_host`
+- `frontend_blue_url`
+- `frontend_green_url`
+- `backend_blue_url`
+- `backend_green_url`
+- `deploy_directory`
+
+기본 포트는 #302 deploy compose와 맞춘다.
+
+- frontend blue: `3001`
+- frontend green: `3002`
+- backend blue: `8081`
+- backend green: `8082`
+
+## OAuth Callback
+
+도메인을 연결한 뒤 GitHub OAuth App callback URL을 운영 도메인 기준으로 등록한다.
+
+- 로그인 OAuth App: `https://API_DOMAIN/login/oauth2/code/github`
+- 저장소 연결 OAuth App: `https://APP_DOMAIN/github/callback`
+
+Elastic IP만 사용하는 1차 검증에서는 GitHub OAuth callback이 HTTPS 도메인을 요구하는지 먼저 확인한다. HTTPS 도메인이 필요하면 Route53, reverse proxy, TLS 설정을 #303 또는 후속 배포 작업에서 붙인다.
+
+## 배포 파일
+
+user data는 EC2에 `/opt/coach`와 하위 디렉터리를 만든다. #303 CD workflow에서는 이 위치에 다음 파일을 배치하는 흐름으로 잡는다.
+
+- `docker/docker-compose.deploy.yml`
+- `docker/.env.deploy`
+- `scripts/smoke/deploy-smoke.ps1`
+
+secret은 image에 bake하지 않고 `docker/.env.deploy` 또는 GitHub Actions secret에서 runtime env로만 주입한다.
+
+## 금지
+
+다음 파일과 값은 repo에 커밋하지 않는다.
+
+- `terraform.tfvars`
+- `*.tfstate`
+- AWS access key / secret key
+- OAuth client secret
+- JWT secret
+- AI Gateway API key
+- 실제 production `.env.deploy`

--- a/infra/terraform/demo-bluegreen/main.tf
+++ b/infra/terraform/demo-bluegreen/main.tf
@@ -1,0 +1,172 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = merge(
+    {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    },
+    var.tags
+  )
+}
+
+data "aws_vpc" "default" {
+  count   = var.vpc_id == null ? 1 : 0
+  default = true
+}
+
+locals {
+  vpc_id = var.vpc_id != null ? var.vpc_id : data.aws_vpc.default[0].id
+}
+
+data "aws_subnets" "selected" {
+  filter {
+    name   = "vpc-id"
+    values = [local.vpc_id]
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "demo" {
+  name        = "${local.name_prefix}-sg"
+  description = "Security group for ${local.name_prefix} single EC2 blue-green demo"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = var.ssh_port
+    to_port     = var.ssh_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  ingress {
+    description = "Frontend blue"
+    from_port   = var.app_blue_port
+    to_port     = var.app_blue_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_http_cidr]
+  }
+
+  ingress {
+    description = "Frontend green"
+    from_port   = var.app_green_port
+    to_port     = var.app_green_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_http_cidr]
+  }
+
+  ingress {
+    description = "Backend blue"
+    from_port   = var.api_blue_port
+    to_port     = var.api_blue_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_http_cidr]
+  }
+
+  ingress {
+    description = "Backend green"
+    from_port   = var.api_green_port
+    to_port     = var.api_green_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_http_cidr]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-sg"
+  }
+}
+
+resource "aws_iam_role" "ec2" {
+  name = "${local.name_prefix}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${local.name_prefix}-ec2-profile"
+  role = aws_iam_role.ec2.name
+}
+
+resource "aws_instance" "demo" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  subnet_id                   = var.subnet_id != null ? var.subnet_id : tolist(data.aws_subnets.selected.ids)[0]
+  vpc_security_group_ids      = [aws_security_group.demo.id]
+  iam_instance_profile        = aws_iam_instance_profile.ec2.name
+  associate_public_ip_address = true
+  user_data_replace_on_change = true
+
+  user_data = templatefile("${path.module}/templates/user-data.sh.tftpl", {
+    deploy_dir = "/opt/coach"
+  })
+
+  root_block_device {
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ec2"
+  }
+}
+
+resource "aws_eip" "demo" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${local.name_prefix}-eip"
+  }
+}
+
+resource "aws_eip_association" "demo" {
+  instance_id   = aws_instance.demo.id
+  allocation_id = aws_eip.demo.id
+}

--- a/infra/terraform/demo-bluegreen/outputs.tf
+++ b/infra/terraform/demo-bluegreen/outputs.tf
@@ -1,0 +1,39 @@
+output "instance_id" {
+  description = "EC2 instance id."
+  value       = aws_instance.demo.id
+}
+
+output "elastic_ip" {
+  description = "Elastic IP address for DNS connection."
+  value       = aws_eip.demo.public_ip
+}
+
+output "ssh_host" {
+  description = "SSH host command target."
+  value       = "ubuntu@${aws_eip.demo.public_ip}"
+}
+
+output "frontend_blue_url" {
+  description = "Frontend blue URL."
+  value       = "http://${aws_eip.demo.public_ip}:${var.app_blue_port}"
+}
+
+output "frontend_green_url" {
+  description = "Frontend green URL."
+  value       = "http://${aws_eip.demo.public_ip}:${var.app_green_port}"
+}
+
+output "backend_blue_url" {
+  description = "Backend blue URL."
+  value       = "http://${aws_eip.demo.public_ip}:${var.api_blue_port}"
+}
+
+output "backend_green_url" {
+  description = "Backend green URL."
+  value       = "http://${aws_eip.demo.public_ip}:${var.api_green_port}"
+}
+
+output "deploy_directory" {
+  description = "Directory prepared by user data for compose deployment files."
+  value       = "/opt/coach"
+}

--- a/infra/terraform/demo-bluegreen/templates/user-data.sh.tftpl
+++ b/infra/terraform/demo-bluegreen/templates/user-data.sh.tftpl
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install -y ca-certificates curl git gnupg unzip
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+. /etc/os-release
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $${VERSION_CODENAME} stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable --now docker
+usermod -aG docker ubuntu
+
+install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}"
+install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/docker"
+install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/scripts"
+
+cat > "${deploy_dir}/README.txt" <<'EOT'
+Coach demo deployment host.
+
+Expected files:
+- docker/docker-compose.deploy.yml
+- docker/.env.deploy
+- scripts/smoke/deploy-smoke.ps1
+
+Secrets must be provided at runtime and must not be baked into Docker images.
+EOT
+
+chown ubuntu:ubuntu "${deploy_dir}/README.txt"

--- a/infra/terraform/demo-bluegreen/terraform.tfvars.example
+++ b/infra/terraform/demo-bluegreen/terraform.tfvars.example
@@ -1,0 +1,27 @@
+aws_region   = "ap-northeast-2"
+project_name = "coach"
+environment  = "demo"
+
+instance_type       = "t3.small"
+root_volume_size_gb = 30
+
+# Existing EC2 key pair name. Set null when using SSM Session Manager only.
+key_name = "your-ec2-keypair-name"
+
+# Restrict these before applying in a real AWS account.
+allowed_ssh_cidr  = "0.0.0.0/0"
+allowed_http_cidr = "0.0.0.0/0"
+
+# Leave null to use the default VPC and the first subnet in it.
+vpc_id    = null
+subnet_id = null
+
+# Must match docker/docker-compose.deploy.yml host ports.
+app_blue_port   = 3001
+app_green_port  = 3002
+api_blue_port   = 8081
+api_green_port  = 8082
+
+tags = {
+  Owner = "team06"
+}

--- a/infra/terraform/demo-bluegreen/variables.tf
+++ b/infra/terraform/demo-bluegreen/variables.tf
@@ -1,0 +1,95 @@
+variable "aws_region" {
+  description = "AWS region for the demo deployment."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "Short project name used for resource names."
+  type        = string
+  default     = "coach"
+}
+
+variable "environment" {
+  description = "Deployment environment label."
+  type        = string
+  default     = "demo"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the single-node demo deployment."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "key_name" {
+  description = "Existing EC2 key pair name for SSH access. Leave null when using SSM only."
+  type        = string
+  default     = null
+}
+
+variable "vpc_id" {
+  description = "VPC id. Leave null to use the default VPC."
+  type        = string
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "Subnet id. Leave null to use the first subnet in the selected VPC."
+  type        = string
+  default     = null
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR allowed to SSH into the EC2 instance."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "allowed_http_cidr" {
+  description = "CIDR allowed to access demo app/API ports."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "app_blue_port" {
+  description = "Host port for frontend blue container."
+  type        = number
+  default     = 3001
+}
+
+variable "app_green_port" {
+  description = "Host port for frontend green container."
+  type        = number
+  default     = 3002
+}
+
+variable "api_blue_port" {
+  description = "Host port for backend blue container."
+  type        = number
+  default     = 8081
+}
+
+variable "api_green_port" {
+  description = "Host port for backend green container."
+  type        = number
+  default     = 8082
+}
+
+variable "ssh_port" {
+  description = "SSH port exposed on the EC2 instance."
+  type        = number
+  default     = 22
+}
+
+variable "root_volume_size_gb" {
+  description = "Root EBS volume size in GiB."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/demo-bluegreen/versions.tf
+++ b/infra/terraform/demo-bluegreen/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}


### PR DESCRIPTION
﻿## 무엇
- 시연용 단일 EC2 Blue-Green 인프라 Terraform 구성을 추가했다.
- EC2, Security Group, Elastic IP, IAM role/profile, Docker 준비 user data를 포함했다.
- `terraform.tfvars.example`과 README로 실행 기준, OAuth callback, state/secret 금지 기준을 정리했다.

## 왜
- #303 GitHub Actions CD가 배포할 AWS 실행 환경이 필요하다.
- #302의 production Docker image와 deploy compose를 올릴 단일 EC2 기반을 먼저 고정하기 위해 필요하다.

## 검증
- `terraform fmt -check -recursive infra/terraform/demo-bluegreen`
- `terraform init -backend=false`
- `terraform validate`

실제 `terraform apply`는 AWS 계정, SSH key, 도메인, secret 주입 방식이 확정된 뒤 수행한다.

Closes #301
