### PR TITLE
ci(deploy): GitHub Actions Blue-Green 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-demo-bluegreen.yml
+++ b/.github/workflows/deploy-demo-bluegreen.yml
@@ -1,0 +1,213 @@
+name: deploy-demo-bluegreen
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_color:
+        description: "Deploy target color. Use auto to deploy inactive color."
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - blue
+          - green
+
+concurrency:
+  group: deploy-demo-bluegreen
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  REGISTRY: ghcr.io
+  REMOTE_DIR: /opt/coach
+
+jobs:
+  deploy:
+    name: deploy demo blue-green
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate deployment inputs
+        env:
+          EC2_HOST_SECRET: ${{ secrets.EC2_HOST }}
+          EC2_USER_SECRET: ${{ secrets.EC2_USER }}
+          EC2_SSH_PRIVATE_KEY_SECRET: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          DEPLOY_ENV_FILE_SECRET: ${{ secrets.DEPLOY_ENV_FILE }}
+          APP_BASE_URL_VAR: ${{ vars.APP_BASE_URL }}
+          API_BASE_URL_VAR: ${{ vars.API_BASE_URL }}
+          NEXT_PUBLIC_API_BASE_URL_VAR: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID_VAR: ${{ vars.NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID }}
+          NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI_VAR: ${{ vars.NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI }}
+        run: |
+          set -euo pipefail
+
+          require_value() {
+            local name="$1"
+            local value="$2"
+            if [ -z "$value" ]; then
+              echo "::error::${name} is required"
+              exit 1
+            fi
+          }
+
+          require_value "secrets.EC2_HOST" "$EC2_HOST_SECRET"
+          require_value "secrets.EC2_SSH_PRIVATE_KEY" "$EC2_SSH_PRIVATE_KEY_SECRET"
+          require_value "secrets.DEPLOY_ENV_FILE" "$DEPLOY_ENV_FILE_SECRET"
+          require_value "vars.NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID" "$NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID_VAR"
+          require_value "vars.NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI" "$NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI_VAR"
+
+          ec2_user="${EC2_USER_SECRET:-ubuntu}"
+          app_base_url="${APP_BASE_URL_VAR:-http://${EC2_HOST_SECRET}}"
+          api_base_url="${API_BASE_URL_VAR:-$app_base_url}"
+          next_public_api_base_url="${NEXT_PUBLIC_API_BASE_URL_VAR:-$api_base_url}"
+
+          {
+            echo "EC2_HOST=$EC2_HOST_SECRET"
+            echo "EC2_USER=$ec2_user"
+            echo "APP_BASE_URL=$app_base_url"
+            echo "API_BASE_URL=$api_base_url"
+            echo "NEXT_PUBLIC_API_BASE_URL=$next_public_api_base_url"
+            echo "NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=$NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID_VAR"
+            echo "NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=$NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI_VAR"
+          } >> "$GITHUB_ENV"
+
+      - name: Derive image tags
+        run: |
+          set -euo pipefail
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          repo="$(printf '%s' "${GITHUB_REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')"
+          tag="${GITHUB_SHA::12}"
+
+          {
+            echo "BACKEND_IMAGE=${REGISTRY}/${owner}/${repo}-backend:${tag}"
+            echo "FRONTEND_IMAGE=${REGISTRY}/${owner}/${repo}-frontend:${tag}"
+          } >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ env.BACKEND_IMAGE }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ${{ env.FRONTEND_IMAGE }}
+          build-args: |
+            NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
+            NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=${{ env.NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID }}
+            NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=${{ env.NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI }}
+
+      - name: Configure SSH
+        env:
+          EC2_SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$EC2_SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$EC2_HOST" >> ~/.ssh/known_hosts
+
+      - name: Sync deployment files
+        env:
+          DEPLOY_ENV_FILE: ${{ secrets.DEPLOY_ENV_FILE }}
+        run: |
+          set -euo pipefail
+          bundle_dir="$RUNNER_TEMP/coach-deploy"
+          rm -rf "$bundle_dir"
+          mkdir -p "$bundle_dir/docker" "$bundle_dir/scripts/smoke" "$bundle_dir/scripts/deploy"
+
+          cp docker/docker-compose.deploy.yml "$bundle_dir/docker/docker-compose.deploy.yml"
+          printf '%s\n' "$DEPLOY_ENV_FILE" > "$bundle_dir/docker/.env.deploy"
+          cp scripts/smoke/deploy-smoke.ps1 "$bundle_dir/scripts/smoke/deploy-smoke.ps1"
+          cp scripts/deploy/*.sh "$bundle_dir/scripts/deploy/"
+
+          tar -C "$bundle_dir" -czf "$RUNNER_TEMP/coach-deploy.tar.gz" .
+          scp -i ~/.ssh/deploy_key "$RUNNER_TEMP/coach-deploy.tar.gz" "$EC2_USER@$EC2_HOST:/tmp/coach-deploy.tar.gz"
+          ssh -i ~/.ssh/deploy_key "$EC2_USER@$EC2_HOST" \
+            "sudo mkdir -p '$REMOTE_DIR' && sudo tar -xzf /tmp/coach-deploy.tar.gz -C '$REMOTE_DIR' && sudo chown -R '$EC2_USER' '$REMOTE_DIR' && chmod +x '$REMOTE_DIR'/scripts/deploy/*.sh"
+
+      - name: Determine target color
+        id: target
+        env:
+          REQUESTED_COLOR: ${{ inputs.target_color }}
+        run: |
+          set -euo pipefail
+          target_color="$(ssh -i ~/.ssh/deploy_key "$EC2_USER@$EC2_HOST" "cd '$REMOTE_DIR' && ./scripts/deploy/resolve-target-color.sh '$REQUESTED_COLOR'")"
+          ports="$(ssh -i ~/.ssh/deploy_key "$EC2_USER@$EC2_HOST" "cd '$REMOTE_DIR' && ./scripts/deploy/color-ports.sh '$target_color'")"
+
+          {
+            echo "target_color=$target_color"
+            echo "$ports"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Target color: $target_color"
+          echo "$ports"
+
+      - name: Deploy inactive color
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          TARGET_COLOR: ${{ steps.target.outputs.target_color }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key "$EC2_USER@$EC2_HOST" \
+            "GITHUB_ACTOR='$GITHUB_ACTOR' GHCR_TOKEN='$GHCR_TOKEN' BACKEND_IMAGE='$BACKEND_IMAGE' FRONTEND_IMAGE='$FRONTEND_IMAGE' TARGET_COLOR='$TARGET_COLOR' REMOTE_DIR='$REMOTE_DIR' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd "$REMOTE_DIR"
+          printf '%s\n' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          ./scripts/deploy/set-compose-images.sh "$BACKEND_IMAGE" "$FRONTEND_IMAGE"
+          docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml up -d postgres redis
+          docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml pull "backend-${TARGET_COLOR}" "frontend-${TARGET_COLOR}"
+          docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml up -d "backend-${TARGET_COLOR}" "frontend-${TARGET_COLOR}"
+          docker image prune -f
+          REMOTE
+
+      - name: Smoke inactive color
+        env:
+          TARGET_FRONTEND_PORT: ${{ steps.target.outputs.frontend_port }}
+          TARGET_BACKEND_PORT: ${{ steps.target.outputs.backend_port }}
+        run: |
+          set -euo pipefail
+          pwsh ./scripts/smoke/deploy-smoke.ps1 \
+            -AppBaseUrl "http://${EC2_HOST}:${TARGET_FRONTEND_PORT}" \
+            -ApiBaseUrl "http://${EC2_HOST}:${TARGET_BACKEND_PORT}" \
+            -Origin "$APP_BASE_URL"
+
+      - name: Switch active color
+        env:
+          TARGET_COLOR: ${{ steps.target.outputs.target_color }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_key "$EC2_USER@$EC2_HOST" \
+            "cd '$REMOTE_DIR' && sudo ./scripts/deploy/switch-active-color.sh '$TARGET_COLOR'"
+
+      - name: Smoke active endpoint
+        run: |
+          set -euo pipefail
+          pwsh ./scripts/smoke/deploy-smoke.ps1 \
+            -AppBaseUrl "$APP_BASE_URL" \
+            -ApiBaseUrl "$API_BASE_URL" \
+            -Origin "$APP_BASE_URL"

--- a/docker/.env.deploy.example
+++ b/docker/.env.deploy.example
@@ -2,9 +2,9 @@
 BACKEND_IMAGE=coach-backend:local
 FRONTEND_IMAGE=coach-frontend:local
 
-# Public endpoints
-APP_URL=http://localhost:3001
-API_URL=http://localhost:8081
+# Public endpoints through Nginx active color routing.
+APP_URL=http://localhost
+API_URL=http://localhost
 
 # Blue/green host ports
 BACKEND_BLUE_PORT=8081
@@ -31,8 +31,8 @@ REDIS_PORT=6379
 
 # Backend runtime
 SPRING_PROFILES_ACTIVE=prod,oauth
-CORS_ALLOWED_ORIGINS=http://localhost:3001
-FRONTEND_URL=http://localhost:3001
+CORS_ALLOWED_ORIGINS=http://localhost
+FRONTEND_URL=http://localhost
 JWT_SECRET=change-me-to-a-long-random-production-secret
 
 # GitHub OAuth - login
@@ -50,6 +50,6 @@ AI_GATEWAY_MODEL=glm-4.5-flash
 
 # Frontend build-time public config.
 # These values are baked into the frontend image during docker build.
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8081
+NEXT_PUBLIC_API_BASE_URL=http://localhost
 NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID=your-production-connection-oauth-client-id
-NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost:3001/github/callback
+NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI=http://localhost/github/callback

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,17 +33,49 @@ docker compose --env-file docker/.env.deploy -f docker/docker-compose.deploy.yml
 
 기본 포트는 다음과 같다.
 
+- nginx active endpoint: `80`
 - backend blue: `8081`
 - backend green: `8082`
 - frontend blue: `3001`
 - frontend green: `3002`
 
-inactive color 배포, smoke 검증, active switch는 후속 #303 GitHub Actions CD workflow에서 붙인다.
+inactive color 배포, smoke 검증, active switch는 #303 GitHub Actions CD workflow에서 수행한다. Nginx active switch는 `/opt/coach/ACTIVE_COLOR` 기준으로 현재 active color를 기록하고, `/api`, `/actuator`, `/oauth2`, `/login/oauth2`는 backend active color로, 나머지 요청은 frontend active color로 proxy한다.
+
+## GHCR 기반 CD
+
+#303 CD workflow는 backend/frontend image를 GHCR에 push하고 EC2에서 pull한다.
+
+필요한 GitHub Secrets:
+
+- `EC2_HOST`
+- `EC2_USER` (없으면 `ubuntu`)
+- `EC2_SSH_PRIVATE_KEY`
+- `DEPLOY_ENV_FILE`
+
+필요한 GitHub Variables:
+
+- `APP_BASE_URL`
+- `API_BASE_URL`
+- `NEXT_PUBLIC_API_BASE_URL`
+- `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID`
+- `NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI`
+
+GHCR package 권한이 막히면 같은 workflow 구조에서 image 전달 방식만 `docker save`/`scp`/`docker load`로 바꾸는 것을 fallback으로 둔다.
 
 ## Smoke
 
 ```powershell
 .\scripts\smoke\deploy-smoke.ps1 `
   -AppBaseUrl "http://localhost:3001" `
-  -ApiBaseUrl "http://localhost:8081"
+  -ApiBaseUrl "http://localhost:8081" `
+  -Origin "http://localhost"
+```
+
+active switch 이후에는 Nginx endpoint를 대상으로 확인한다.
+
+```powershell
+.\scripts\smoke\deploy-smoke.ps1 `
+  -AppBaseUrl "http://localhost" `
+  -ApiBaseUrl "http://localhost" `
+  -Origin "http://localhost"
 ```

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -7,8 +7,8 @@ x-backend-env: &backend-env
   DATABASE_PASSWORD: ${DATABASE_PASSWORD:-coach}
   REDIS_HOST: ${REDIS_HOST:-redis}
   REDIS_PORT: ${REDIS_PORT:-6379}
-  CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3001}
-  FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3001}
+  CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost}
+  FRONTEND_URL: ${FRONTEND_URL:-http://localhost}
   JWT_SECRET: ${JWT_SECRET:-change-me-to-a-long-random-production-secret}
   GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
   GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}

--- a/infra/terraform/demo-bluegreen/README.md
+++ b/infra/terraform/demo-bluegreen/README.md
@@ -1,6 +1,6 @@
 # Demo Blue-Green Terraform
 
-시연용 단일 EC2 Blue-Green 배포 인프라를 만드는 Terraform 구성이다. #302의 `docker/docker-compose.deploy.yml`을 EC2에서 실행할 수 있도록 서버, 보안 그룹, Elastic IP, IAM instance profile, Docker 설치 user data를 준비한다.
+시연용 단일 EC2 Blue-Green 배포 인프라를 만드는 Terraform 구성이다. #302의 `docker/docker-compose.deploy.yml`을 EC2에서 실행할 수 있도록 서버, 보안 그룹, Elastic IP, IAM instance profile, Docker/Nginx 설치 user data를 준비한다.
 
 ## 범위
 
@@ -11,7 +11,7 @@
 - Elastic IP
 - IAM role / instance profile
 - Ubuntu 24.04 LTS AMI 조회
-- Docker, Docker Compose plugin 설치 user data
+- Docker, Docker Compose plugin, Nginx 설치 user data
 - `/opt/coach` 배포 디렉터리 준비
 
 제외:
@@ -20,7 +20,7 @@
 - ALB target group 기반 Blue-Green
 - CloudFront / S3 정적 배포
 - Route53 record 생성
-- GitHub Actions CD 자동화
+- GitHub Actions CD workflow 구현 자체
 
 ## 준비
 
@@ -63,10 +63,12 @@ terraform apply -var-file="terraform.tfvars"
 - `frontend_green_url`
 - `backend_blue_url`
 - `backend_green_url`
+- `public_http_url`
 - `deploy_directory`
 
-기본 포트는 #302 deploy compose와 맞춘다.
+기본 포트는 #302 deploy compose와 #303 Nginx active switch 기준에 맞춘다.
 
+- nginx active endpoint: `80`
 - frontend blue: `3001`
 - frontend green: `3002`
 - backend blue: `8081`
@@ -79,7 +81,7 @@ terraform apply -var-file="terraform.tfvars"
 - 로그인 OAuth App: `https://API_DOMAIN/login/oauth2/code/github`
 - 저장소 연결 OAuth App: `https://APP_DOMAIN/github/callback`
 
-Elastic IP만 사용하는 1차 검증에서는 GitHub OAuth callback이 HTTPS 도메인을 요구하는지 먼저 확인한다. HTTPS 도메인이 필요하면 Route53, reverse proxy, TLS 설정을 #303 또는 후속 배포 작업에서 붙인다.
+Elastic IP만 사용하는 1차 검증에서는 GitHub OAuth callback이 HTTPS 도메인을 요구하는지 먼저 확인한다. #303은 HTTP Nginx active switch까지만 다루고, HTTPS 인증서 자동화는 도메인 확정 후 후속 작업으로 붙인다.
 
 ## 배포 파일
 
@@ -87,9 +89,29 @@ user data는 EC2에 `/opt/coach`와 하위 디렉터리를 만든다. #303 CD wo
 
 - `docker/docker-compose.deploy.yml`
 - `docker/.env.deploy`
+- `scripts/deploy/*.sh`
 - `scripts/smoke/deploy-smoke.ps1`
 
 secret은 image에 bake하지 않고 `docker/.env.deploy` 또는 GitHub Actions secret에서 runtime env로만 주입한다.
+
+## #303 CD 기준
+
+GitHub Actions workflow는 backend/frontend image를 GHCR에 push한 뒤 EC2의 inactive color에서 pull/up 한다. inactive color smoke가 통과하면 `scripts/deploy/switch-active-color.sh`가 Nginx upstream을 전환하고 `/opt/coach/ACTIVE_COLOR`를 갱신한다.
+
+GitHub Secrets:
+
+- `EC2_HOST`
+- `EC2_USER` (없으면 `ubuntu`)
+- `EC2_SSH_PRIVATE_KEY`
+- `DEPLOY_ENV_FILE`
+
+GitHub Variables:
+
+- `APP_BASE_URL`
+- `API_BASE_URL`
+- `NEXT_PUBLIC_API_BASE_URL`
+- `NEXT_PUBLIC_GITHUB_CONNECTION_CLIENT_ID`
+- `NEXT_PUBLIC_GITHUB_CONNECTION_REDIRECT_URI`
 
 ## 금지
 

--- a/infra/terraform/demo-bluegreen/main.tf
+++ b/infra/terraform/demo-bluegreen/main.tf
@@ -61,6 +61,14 @@ resource "aws_security_group" "demo" {
   }
 
   ingress {
+    description = "Nginx HTTP"
+    from_port   = var.http_port
+    to_port     = var.http_port
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_http_cidr]
+  }
+
+  ingress {
     description = "Frontend blue"
     from_port   = var.app_blue_port
     to_port     = var.app_blue_port

--- a/infra/terraform/demo-bluegreen/outputs.tf
+++ b/infra/terraform/demo-bluegreen/outputs.tf
@@ -18,6 +18,11 @@ output "frontend_blue_url" {
   value       = "http://${aws_eip.demo.public_ip}:${var.app_blue_port}"
 }
 
+output "public_http_url" {
+  description = "Public Nginx URL for the active color."
+  value       = "http://${aws_eip.demo.public_ip}:${var.http_port}"
+}
+
 output "frontend_green_url" {
   description = "Frontend green URL."
   value       = "http://${aws_eip.demo.public_ip}:${var.app_green_port}"

--- a/infra/terraform/demo-bluegreen/templates/user-data.sh.tftpl
+++ b/infra/terraform/demo-bluegreen/templates/user-data.sh.tftpl
@@ -4,7 +4,7 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -y
-apt-get install -y ca-certificates curl git gnupg unzip
+apt-get install -y ca-certificates curl git gnupg nginx unzip
 
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
@@ -18,11 +18,15 @@ apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 systemctl enable --now docker
+systemctl enable --now nginx
 usermod -aG docker ubuntu
 
 install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}"
 install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/docker"
 install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/scripts"
+install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/scripts/deploy"
+install -d -m 0755 -o ubuntu -g ubuntu "${deploy_dir}/scripts/smoke"
+printf 'blue\n' > "${deploy_dir}/ACTIVE_COLOR"
 
 cat > "${deploy_dir}/README.txt" <<'EOT'
 Coach demo deployment host.
@@ -30,9 +34,11 @@ Coach demo deployment host.
 Expected files:
 - docker/docker-compose.deploy.yml
 - docker/.env.deploy
+- scripts/deploy/*.sh
 - scripts/smoke/deploy-smoke.ps1
 
 Secrets must be provided at runtime and must not be baked into Docker images.
 EOT
 
 chown ubuntu:ubuntu "${deploy_dir}/README.txt"
+chown ubuntu:ubuntu "${deploy_dir}/ACTIVE_COLOR"

--- a/infra/terraform/demo-bluegreen/terraform.tfvars.example
+++ b/infra/terraform/demo-bluegreen/terraform.tfvars.example
@@ -17,6 +17,7 @@ vpc_id    = null
 subnet_id = null
 
 # Must match docker/docker-compose.deploy.yml host ports.
+http_port       = 80
 app_blue_port   = 3001
 app_green_port  = 3002
 api_blue_port   = 8081

--- a/infra/terraform/demo-bluegreen/variables.tf
+++ b/infra/terraform/demo-bluegreen/variables.tf
@@ -52,6 +52,12 @@ variable "allowed_http_cidr" {
   default     = "0.0.0.0/0"
 }
 
+variable "http_port" {
+  description = "Public HTTP port for Nginx active color routing."
+  type        = number
+  default     = 80
+}
+
 variable "app_blue_port" {
   description = "Host port for frontend blue container."
   type        = number

--- a/scripts/deploy/color-ports.sh
+++ b/scripts/deploy/color-ports.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+color="${1:-}"
+deploy_dir="${COACH_DEPLOY_DIR:-/opt/coach}"
+env_file="${2:-${COACH_ENV_FILE:-${deploy_dir}/docker/.env.deploy}}"
+
+if [ "$color" != "blue" ] && [ "$color" != "green" ]; then
+  echo "color must be blue or green. value=${color}" >&2
+  exit 1
+fi
+
+read_env_value() {
+  local key="$1"
+  local default_value="$2"
+  local line value
+
+  line="$(grep -E "^${key}=" "$env_file" 2>/dev/null | tail -n 1 || true)"
+  if [ -z "$line" ]; then
+    printf '%s\n' "$default_value"
+    return
+  fi
+
+  value="${line#*=}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s\n' "$value"
+}
+
+if [ "$color" = "blue" ]; then
+  frontend_port="$(read_env_value FRONTEND_BLUE_PORT 3001)"
+  backend_port="$(read_env_value BACKEND_BLUE_PORT 8081)"
+else
+  frontend_port="$(read_env_value FRONTEND_GREEN_PORT 3002)"
+  backend_port="$(read_env_value BACKEND_GREEN_PORT 8082)"
+fi
+
+for port in "$frontend_port" "$backend_port"; do
+  if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+    echo "port must be numeric. value=${port}" >&2
+    exit 1
+  fi
+done
+
+printf 'frontend_port=%s\n' "$frontend_port"
+printf 'backend_port=%s\n' "$backend_port"

--- a/scripts/deploy/resolve-target-color.sh
+++ b/scripts/deploy/resolve-target-color.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+requested="${1:-auto}"
+deploy_dir="${COACH_DEPLOY_DIR:-/opt/coach}"
+active_file="${COACH_ACTIVE_COLOR_FILE:-${deploy_dir}/ACTIVE_COLOR}"
+
+normalize_color() {
+  case "${1:-}" in
+    blue|green)
+      printf '%s\n' "$1"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "$requested" = "blue" ] || [ "$requested" = "green" ]; then
+  printf '%s\n' "$requested"
+  exit 0
+fi
+
+if [ "$requested" != "auto" ]; then
+  echo "target color must be auto, blue, or green. value=${requested}" >&2
+  exit 1
+fi
+
+active_color=""
+if [ -f "$active_file" ]; then
+  active_color="$(tr -d '[:space:]' < "$active_file" || true)"
+fi
+
+if ! normalize_color "$active_color" >/dev/null 2>&1; then
+  printf '%s\n' "blue"
+  exit 0
+fi
+
+if [ "$active_color" = "blue" ]; then
+  printf '%s\n' "green"
+else
+  printf '%s\n' "blue"
+fi

--- a/scripts/deploy/set-compose-images.sh
+++ b/scripts/deploy/set-compose-images.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backend_image="${1:-}"
+frontend_image="${2:-}"
+deploy_dir="${COACH_DEPLOY_DIR:-/opt/coach}"
+env_file="${3:-${COACH_ENV_FILE:-${deploy_dir}/docker/.env.deploy}}"
+
+if [ -z "$backend_image" ] || [ -z "$frontend_image" ]; then
+  echo "usage: set-compose-images.sh <backend-image> <frontend-image> [env-file]" >&2
+  exit 1
+fi
+
+if [ ! -f "$env_file" ]; then
+  echo "env file not found: $env_file" >&2
+  exit 1
+fi
+
+tmp_file="$(mktemp)"
+grep -v -E '^(BACKEND_IMAGE|FRONTEND_IMAGE)=' "$env_file" > "$tmp_file" || true
+{
+  printf 'BACKEND_IMAGE=%s\n' "$backend_image"
+  printf 'FRONTEND_IMAGE=%s\n' "$frontend_image"
+} >> "$tmp_file"
+
+cat "$tmp_file" > "$env_file"
+rm -f "$tmp_file"

--- a/scripts/deploy/switch-active-color.sh
+++ b/scripts/deploy/switch-active-color.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_color="${1:-}"
+deploy_dir="${COACH_DEPLOY_DIR:-/opt/coach}"
+env_file="${COACH_ENV_FILE:-${deploy_dir}/docker/.env.deploy}"
+active_file="${COACH_ACTIVE_COLOR_FILE:-${deploy_dir}/ACTIVE_COLOR}"
+
+if [ "$target_color" != "blue" ] && [ "$target_color" != "green" ]; then
+  echo "target color must be blue or green. value=${target_color}" >&2
+  exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+  exec sudo \
+    COACH_DEPLOY_DIR="$deploy_dir" \
+    COACH_ENV_FILE="$env_file" \
+    COACH_ACTIVE_COLOR_FILE="$active_file" \
+    "$0" "$target_color"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+eval "$("$script_dir/color-ports.sh" "$target_color" "$env_file")"
+
+nginx_config="/etc/nginx/sites-available/coach.conf"
+nginx_enabled="/etc/nginx/sites-enabled/coach.conf"
+
+cat > "$nginx_config" <<NGINX
+server {
+    listen 80 default_server;
+    server_name _;
+
+    client_max_body_size 20m;
+
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Forwarded-Host \$host;
+    proxy_set_header X-Forwarded-Port \$server_port;
+
+    location = /api {
+        proxy_pass http://127.0.0.1:${backend_port};
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:${backend_port};
+    }
+
+    location /actuator/ {
+        proxy_pass http://127.0.0.1:${backend_port};
+    }
+
+    location /oauth2/ {
+        proxy_pass http://127.0.0.1:${backend_port};
+    }
+
+    location /login/oauth2/ {
+        proxy_pass http://127.0.0.1:${backend_port};
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:${frontend_port};
+    }
+}
+NGINX
+
+rm -f /etc/nginx/sites-enabled/default
+ln -sfn "$nginx_config" "$nginx_enabled"
+
+nginx -t
+systemctl reload nginx || systemctl restart nginx
+
+printf '%s\n' "$target_color" > "$active_file"
+chmod 0644 "$active_file"
+
+echo "active color switched to ${target_color}"


### PR DESCRIPTION
﻿## 무엇
- GHCR 기반 backend/frontend image build & push workflow를 추가했습니다.
- EC2 inactive color 배포, deploy smoke, Nginx active color switch, post-switch smoke 흐름을 추가했습니다.
- Terraform user data와 보안 그룹에 Nginx HTTP 진입점을 보강하고 CD secrets/variables 기준을 문서화했습니다.

## 왜
- 시연 전 수동 배포 실수를 줄이고, 배포 후 smoke 검증과 active 전환을 반복 가능하게 만들기 위해 필요합니다.
- 사용자는 blue/green 포트가 아니라 고정 HTTP endpoint로 접속하고, 성공한 color만 active로 전환됩니다.

## 검증
- `bash -n scripts/deploy/*.sh`
- `git diff --check`
- `docker compose -f docker/docker-compose.deploy.yml config`
- `docker compose --env-file docker/.env.deploy.example -f docker/docker-compose.deploy.yml config`
- `terraform -chdir=infra/terraform/demo-bluegreen fmt -check`
- `terraform -chdir=infra/terraform/demo-bluegreen validate`
- `docker run --rm -v ${PWD}:/repo -w /repo rhysd/actionlint:latest .github/workflows/deploy-demo-bluegreen.yml`

Closes #303
