### PR TITLE
feat(coach): Coach 세션 목록과 메시지 히스토리 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachMessageController.java
@@ -1,24 +1,28 @@
 package com.back.coach.domain.coach.controller;
 
+import com.back.coach.domain.coach.dto.CoachMessageHistoryResponse;
 import com.back.coach.domain.coach.dto.CoachMessageRequest;
 import com.back.coach.domain.coach.dto.CoachMessageResponse;
+import com.back.coach.domain.coach.entity.CoachConversation;
 import com.back.coach.domain.coach.service.CoachMessageService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping(
         path = "/api/coach/sessions/{sessionId}/messages",
-        produces = MediaType.APPLICATION_JSON_VALUE,
-        consumes = MediaType.APPLICATION_JSON_VALUE
+        produces = MediaType.APPLICATION_JSON_VALUE
 )
 public class CoachMessageController {
 
@@ -28,7 +32,19 @@ public class CoachMessageController {
         this.coachMessageService = coachMessageService;
     }
 
-    @PostMapping
+    @GetMapping
+    public ApiResponse<List<CoachMessageHistoryResponse>> getMessages(
+            @PathVariable Long sessionId,
+            Authentication authentication
+    ) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        List<CoachConversation> messages = coachMessageService.getMessages(user.userId(), sessionId);
+        return ApiResponse.success(messages.stream()
+                .map(CoachMessageHistoryResponse::from)
+                .toList());
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<CoachMessageResponse> sendMessage(
             @PathVariable Long sessionId,
             @Valid @RequestBody CoachMessageRequest request,

--- a/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/controller/CoachSessionController.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.coach.controller;
 
 import com.back.coach.domain.coach.dto.CoachSessionResponse;
+import com.back.coach.domain.coach.dto.CoachSessionSummaryResponse;
 import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.service.CoachSessionService;
 import com.back.coach.global.response.ApiResponse;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(path = "/api/coach/sessions", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -39,6 +42,15 @@ public class CoachSessionController {
         AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
         ChatSession session = coachSessionService.getActiveSession(user.userId());
         return ApiResponse.success(CoachSessionResponse.from(session));
+    }
+
+    @GetMapping
+    public ApiResponse<List<CoachSessionSummaryResponse>> getSessions(Authentication authentication) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        List<CoachSessionSummaryResponse> sessions = coachSessionService.getSessions(user.userId()).stream()
+                .map(CoachSessionSummaryResponse::from)
+                .toList();
+        return ApiResponse.success(sessions);
     }
 
     @DeleteMapping("/{sessionId}")

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageHistoryResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachMessageHistoryResponse.java
@@ -1,0 +1,27 @@
+package com.back.coach.domain.coach.dto;
+
+import com.back.coach.domain.coach.entity.CoachConversation;
+import com.back.coach.global.code.CoachMessageRole;
+import com.back.coach.global.code.CoachRoute;
+
+import java.time.Instant;
+
+public record CoachMessageHistoryResponse(
+        String messageId,
+        CoachMessageRole role,
+        String messageText,
+        CoachRoute route,
+        String detectedIntent,
+        Instant createdAt
+) {
+    public static CoachMessageHistoryResponse from(CoachConversation conversation) {
+        return new CoachMessageHistoryResponse(
+                String.valueOf(conversation.getId()),
+                conversation.getRole(),
+                conversation.getMessageText(),
+                conversation.getRoute(),
+                conversation.getDetectedIntent(),
+                conversation.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/dto/CoachSessionSummaryResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/dto/CoachSessionSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.back.coach.domain.coach.dto;
+
+import com.back.coach.domain.coach.entity.ChatSession;
+import com.back.coach.global.code.ChatSessionStatus;
+
+import java.time.Instant;
+
+public record CoachSessionSummaryResponse(
+        String sessionId,
+        Integer profileVersion,
+        Integer roadmapVersion,
+        ChatSessionStatus status,
+        Instant startedAt,
+        Instant endedAt
+) {
+    public static CoachSessionSummaryResponse from(ChatSession session) {
+        return new CoachSessionSummaryResponse(
+                String.valueOf(session.getId()),
+                session.getProfileVersion(),
+                session.getRoadmapVersion(),
+                session.getStatus(),
+                session.getStartedAt(),
+                session.getEndedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/repository/ChatSessionRepository.java
@@ -4,6 +4,7 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.global.code.ChatSessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> {
@@ -12,4 +13,6 @@ public interface ChatSessionRepository extends JpaRepository<ChatSession, Long> 
             Long userId,
             ChatSessionStatus status
     );
+
+    List<ChatSession> findByUserIdOrderByStartedAtDesc(Long userId);
 }

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Service
 public class CoachMessageService {
@@ -47,6 +48,18 @@ public class CoachMessageService {
     }
 
     public record MessageResult(CoachConversation coachMessage, ReplanProposal proposal) {}
+
+    @Transactional(readOnly = true)
+    public List<CoachConversation> getMessages(Long userId, Long sessionId) {
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isOwnedBy(userId)) {
+            throw new ServiceException(ErrorCode.FORBIDDEN);
+        }
+
+        return coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+    }
 
     @Transactional
     public MessageResult sendMessage(Long userId, Long sessionId, String userMessage) {

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 
 @Service
 public class CoachSessionService {
@@ -57,6 +58,11 @@ public class CoachSessionService {
         return chatSessionRepository
                 .findFirstByUserIdAndStatusOrderByStartedAtDesc(userId, ChatSessionStatus.ACTIVE)
                 .orElseThrow(() -> new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatSession> getSessions(Long userId) {
+        return chatSessionRepository.findByUserIdOrderByStartedAtDesc(userId);
     }
 
     @Transactional

--- a/backend/src/test/java/com/back/coach/domain/coach/controller/CoachMessageControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/CoachMessageControllerTest.java
@@ -3,6 +3,7 @@ package com.back.coach.domain.coach.controller;
 import com.back.coach.domain.coach.entity.CoachConversation;
 import com.back.coach.domain.coach.entity.ReplanProposal;
 import com.back.coach.domain.coach.service.CoachMessageService;
+import com.back.coach.global.code.CoachMessageRole;
 import com.back.coach.global.code.CoachRoute;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.GlobalExceptionHandler;
@@ -26,6 +27,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.nullValue;
@@ -34,6 +36,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -180,6 +183,80 @@ class CoachMessageControllerTest {
                 .andExpect(jsonPath("$.code").value("FORBIDDEN"));
     }
 
+    @Test
+    void getMessages_returnsMessagesInTimeOrder() throws Exception {
+        CoachConversation userMessage = userMessage(
+                9000L, 10001L, 1L,
+                "오늘 무엇부터 공부하면 좋을까?",
+                Instant.parse("2026-05-08T09:00:00Z")
+        );
+        CoachConversation coachMessage = coachMessage(
+                9001L, 10001L, 1L,
+                "이번 주는 Redis TTL과 캐시 무효화 개념부터 정리하는 것이 좋습니다.",
+                CoachRoute.SIMPLE_GUIDE,
+                Instant.parse("2026-05-08T09:00:03Z")
+        );
+        given(coachMessageService.getMessages(1L, 10001L))
+                .willReturn(List.of(userMessage, coachMessage));
+
+        mockMvc.perform(get("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].messageId").value("9000"))
+                .andExpect(jsonPath("$.data[0].role").value("USER"))
+                .andExpect(jsonPath("$.data[0].messageText").value("오늘 무엇부터 공부하면 좋을까?"))
+                .andExpect(jsonPath("$.data[0].route").value(nullValue()))
+                .andExpect(jsonPath("$.data[0].detectedIntent").value(nullValue()))
+                .andExpect(jsonPath("$.data[0].createdAt").value("2026-05-08T09:00:00Z"))
+                .andExpect(jsonPath("$.data[1].messageId").value("9001"))
+                .andExpect(jsonPath("$.data[1].role").value("COACH"))
+                .andExpect(jsonPath("$.data[1].route").value("SIMPLE_GUIDE"))
+                .andExpect(jsonPath("$.data[1].detectedIntent").value("CHECK_TODAY_PLAN"))
+                .andExpect(jsonPath("$.data[1].createdAt").value("2026-05-08T09:00:03Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(coachMessageService).getMessages(1L, 10001L);
+    }
+
+    @Test
+    void getMessages_whenSessionNotFound_returnsNotFound() throws Exception {
+        given(coachMessageService.getMessages(1L, 10001L))
+                .willThrow(new ServiceException(ErrorCode.SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    void getMessages_whenSessionBelongsToAnotherUser_returnsForbidden() throws Exception {
+        given(coachMessageService.getMessages(1L, 10001L))
+                .willThrow(new ServiceException(ErrorCode.FORBIDDEN));
+
+        mockMvc.perform(get("/api/coach/sessions/{sessionId}/messages", 10001L)
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    private CoachConversation userMessage(
+            Long id,
+            Long sessionId,
+            Long userId,
+            String messageText,
+            Instant createdAt
+    ) {
+        CoachConversation conversation = CoachConversation.user(sessionId, userId, messageText);
+        ReflectionTestUtils.setField(conversation, "id", id);
+        ReflectionTestUtils.setField(conversation, "role", CoachMessageRole.USER);
+        ReflectionTestUtils.setField(conversation, "createdAt", createdAt);
+        return conversation;
+    }
+
     private CoachConversation coachMessage(
             Long id,
             Long sessionId,
@@ -187,10 +264,22 @@ class CoachMessageControllerTest {
             String responseText,
             CoachRoute route
     ) {
+        return coachMessage(id, sessionId, userId, responseText, route, Instant.parse("2026-05-08T09:00:00Z"));
+    }
+
+    private CoachConversation coachMessage(
+            Long id,
+            Long sessionId,
+            Long userId,
+            String responseText,
+            CoachRoute route,
+            Instant createdAt
+    ) {
         CoachConversation conversation = CoachConversation.coach(
                 sessionId, userId, responseText, route, "CHECK_TODAY_PLAN"
         );
         ReflectionTestUtils.setField(conversation, "id", id);
+        ReflectionTestUtils.setField(conversation, "createdAt", createdAt);
         return conversation;
     }
 

--- a/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/controller/CoachSessionControllerTest.java
@@ -23,7 +23,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.Instant;
+import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
@@ -112,6 +114,45 @@ class CoachSessionControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+    }
+
+    @Test
+    void getSessions_returnsSessionsLatestFirst() throws Exception {
+        ChatSession active = session(10002L, 1L, 4, 3, Instant.parse("2026-05-08T09:00:00Z"));
+        ChatSession closed = session(10001L, 1L, 3, 2, Instant.parse("2026-05-07T09:00:00Z"));
+        closed.close(Instant.parse("2026-05-07T10:00:00Z"));
+        given(coachSessionService.getSessions(1L)).willReturn(List.of(active, closed));
+
+        mockMvc.perform(get("/api/coach/sessions")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].sessionId").value("10002"))
+                .andExpect(jsonPath("$.data[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data[0].profileVersion").value(4))
+                .andExpect(jsonPath("$.data[0].roadmapVersion").value(3))
+                .andExpect(jsonPath("$.data[0].startedAt").value("2026-05-08T09:00:00Z"))
+                .andExpect(jsonPath("$.data[0].endedAt").value(nullValue()))
+                .andExpect(jsonPath("$.data[1].sessionId").value("10001"))
+                .andExpect(jsonPath("$.data[1].status").value("CLOSED"))
+                .andExpect(jsonPath("$.data[1].endedAt").value("2026-05-07T10:00:00Z"))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(coachSessionService).getSessions(1L);
+    }
+
+    @Test
+    void getSessions_whenNoSessions_returnsEmptyList() throws Exception {
+        given(coachSessionService.getSessions(1L)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/coach/sessions")
+                        .principal(authentication(1L))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(0))
+                .andExpect(jsonPath("$.meta").isMap());
+
+        verify(coachSessionService).getSessions(1L);
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -154,4 +154,56 @@ class CoachMessageServiceIntegrationTest {
         // @Transactional로 묶여 있어 USER 행도 롤백됨 — 시도-기록 둘 다 안 남는 게 안전
         assertThat(rows).isEmpty();
     }
+
+    @Test
+    @DisplayName("getMessages: 저장된 USER/COACH 메시지를 시간순으로 조회")
+    void getMessagesReturnsStoredMessagesInTimeOrder() {
+        given(llmClient.complete(anyString())).willReturn(
+                "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\",\"detectedIntent\":\"CHECK_TODAY_PLAN\"}"
+        );
+        coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
+
+        List<CoachConversation> messages = coachMessageService.getMessages(userId, sessionId);
+
+        assertThat(messages).hasSize(2);
+        assertThat(messages.get(0).getRole()).isEqualTo(CoachMessageRole.USER);
+        assertThat(messages.get(0).getMessageText()).isEqualTo("오늘 뭐 공부할까?");
+        assertThat(messages.get(1).getRole()).isEqualTo(CoachMessageRole.COACH);
+        assertThat(messages.get(1).getRoute()).isEqualTo(CoachRoute.SIMPLE_GUIDE);
+        assertThat(messages.get(1).getDetectedIntent()).isEqualTo("CHECK_TODAY_PLAN");
+    }
+
+    @Test
+    @DisplayName("getMessages: 닫힌 세션도 히스토리 조회 가능")
+    void getMessagesAllowsClosedSession() {
+        given(llmClient.complete(anyString())).willReturn(
+                "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
+        );
+        coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
+        ChatSession session = chatSessionRepository.findById(sessionId).orElseThrow();
+        session.close(Instant.now());
+        chatSessionRepository.save(session);
+
+        List<CoachConversation> messages = coachMessageService.getMessages(userId, sessionId);
+
+        assertThat(messages).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("getMessages: 다른 사용자의 세션이면 FORBIDDEN")
+    void getMessagesByOtherUserForbidden() {
+        Long otherUserId = userId + 99999L;
+
+        assertThatThrownBy(() -> coachMessageService.getMessages(otherUserId, sessionId))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("getMessages: 존재하지 않는 sessionId면 SESSION_NOT_FOUND")
+    void getMessagesNonexistentSessionFails() {
+        assertThatThrownBy(() -> coachMessageService.getMessages(userId, 999_999_999L))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_NOT_FOUND);
+    }
 }

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -179,6 +180,31 @@ class CoachSessionServiceIntegrationTest {
         assertThatThrownBy(() -> coachSessionService.getActiveSession(userId))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SESSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getSessions: ACTIVE/CLOSED 세션을 최신순으로 반환")
+    void getSessionsReturnsActiveAndClosedSessionsLatestFirst() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1);
+        ChatSession older = coachSessionService.startSession(userId);
+        coachSessionService.closeSession(userId, older.getId());
+        ChatSession newer = coachSessionService.startSession(userId);
+
+        List<ChatSession> sessions = coachSessionService.getSessions(userId);
+
+        assertThat(sessions).extracting(ChatSession::getId)
+                .containsExactly(newer.getId(), older.getId());
+        assertThat(sessions).extracting(ChatSession::getStatus)
+                .containsExactly(ChatSessionStatus.ACTIVE, ChatSessionStatus.CLOSED);
+    }
+
+    @Test
+    @DisplayName("getSessions: 세션이 없으면 빈 목록")
+    void getSessionsReturnsEmptyListWhenNoSession() {
+        List<ChatSession> sessions = coachSessionService.getSessions(userId);
+
+        assertThat(sessions).isEmpty();
     }
 
     private void seedSnapshot(ContextType type, int version) {

--- a/docs/20_v2_coach_api_contract.md
+++ b/docs/20_v2_coach_api_contract.md
@@ -73,7 +73,37 @@ POST /api/coach/sessions
 
 ---
 
-### 4.2 메시지 전송 (단일 응답)
+### 4.2 세션 목록 조회
+
+```
+GET /api/coach/sessions
+```
+
+응답 body
+```json
+{
+  "data": [
+    {
+      "sessionId": "string",
+      "profileVersion": 3,
+      "roadmapVersion": 2,
+      "status": "ACTIVE",
+      "startedAt": "2026-05-07T09:00:00Z",
+      "endedAt": null
+    }
+  ]
+}
+```
+
+규칙
+- 현재 사용자의 세션만 반환한다.
+- `startedAt` 내림차순으로 정렬한다.
+- `ACTIVE`, `CLOSED` 세션을 모두 포함한다.
+- 세션이 없으면 빈 배열을 반환한다.
+
+---
+
+### 4.3 메시지 전송 (단일 응답)
 
 ```
 POST /api/coach/sessions/{sessionId}/messages
@@ -131,7 +161,50 @@ POST /api/coach/sessions/{sessionId}/messages
 
 ---
 
-### 4.3 재계획 확인 (사용자 동의)
+### 4.4 메시지 히스토리 조회
+
+```
+GET /api/coach/sessions/{sessionId}/messages
+```
+
+응답 body
+```json
+{
+  "data": [
+    {
+      "messageId": "string",
+      "role": "USER",
+      "messageText": "오늘 무엇부터 공부하면 좋을까?",
+      "route": null,
+      "detectedIntent": null,
+      "createdAt": "2026-05-08T09:00:00Z"
+    },
+    {
+      "messageId": "string",
+      "role": "COACH",
+      "messageText": "이번 주는 Redis TTL과 캐시 무효화 개념부터 정리하는 것이 좋습니다.",
+      "route": "SIMPLE_GUIDE",
+      "detectedIntent": "CHECK_TODAY_PLAN",
+      "createdAt": "2026-05-08T09:00:03Z"
+    }
+  ]
+}
+```
+
+규칙
+- `sessionId`가 현재 사용자 소유가 아니면 `403 FORBIDDEN`.
+- 종료된 세션도 히스토리 조회는 허용한다.
+- 메시지는 `createdAt` 오름차순으로 반환한다.
+
+에러
+| 코드 | HTTP | 조건 |
+| --- | --- | --- |
+| `SESSION_NOT_FOUND` | 404 | sessionId 없음 |
+| `FORBIDDEN` | 403 | 다른 사용자의 세션 |
+
+---
+
+### 4.5 재계획 확인 (사용자 동의)
 
 ```
 POST /api/coach/sessions/{sessionId}/replan
@@ -181,7 +254,7 @@ POST /api/coach/sessions/{sessionId}/replan
 
 ---
 
-### 4.4 스트리밍 응답 (선택)
+### 4.6 스트리밍 응답 (선택)
 
 ```
 GET /api/coach/sessions/{sessionId}/stream
@@ -201,13 +274,13 @@ data: {"messageId":"string","route":"SIMPLE_GUIDE","replanProposal":null}
 ```
 
 규칙
-- 스트리밍은 4.2의 단일 응답과 동일한 처리 경로를 사용한다.
+- 스트리밍은 4.3의 단일 응답과 동일한 처리 경로를 사용한다.
 - `done` 이벤트에 최종 `route`와 `replanProposal`을 포함한다.
 - 스트리밍 중 오류는 `event: error`로 전달하고 연결을 닫는다.
 
 ---
 
-### 4.5 세션 종료
+### 4.7 세션 종료
 
 ```
 DELETE /api/coach/sessions/{sessionId}

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -393,6 +393,22 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
 
   /api/coach/sessions:
+    get:
+      tags:
+        - Coach
+      summary: List Coach sessions
+      operationId: listCoachSessions
+      x-implementation-status: implemented
+      responses:
+        '200':
+          description: Coach sessions sorted by startedAt descending
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoachSessionListApiResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
     post:
       tags:
         - Coach
@@ -431,6 +447,28 @@ paths:
           $ref: '#/components/responses/ResourceNotFound'
 
   /api/coach/sessions/{sessionId}/messages:
+    get:
+      tags:
+        - Coach
+      summary: List Coach session messages
+      operationId: listCoachSessionMessages
+      x-implementation-status: implemented
+      parameters:
+        - $ref: '#/components/parameters/CoachSessionId'
+      responses:
+        '200':
+          description: Coach messages sorted by createdAt ascending
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoachMessageHistoryListApiResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+
     post:
       tags:
         - Coach
@@ -782,6 +820,49 @@ components:
         meta:
           $ref: '#/components/schemas/ApiMeta'
 
+    CoachSessionSummaryData:
+      type: object
+      required:
+        - sessionId
+        - profileVersion
+        - roadmapVersion
+        - status
+        - startedAt
+      properties:
+        sessionId:
+          type: string
+          example: '10001'
+        profileVersion:
+          type: integer
+          example: 3
+        roadmapVersion:
+          type: integer
+          example: 2
+        status:
+          $ref: '#/components/schemas/ChatSessionStatus'
+        startedAt:
+          type: string
+          format: date-time
+          example: '2026-05-07T09:00:00Z'
+        endedAt:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2026-05-07T10:00:00Z'
+
+    CoachSessionListApiResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachSessionSummaryData'
+        meta:
+          $ref: '#/components/schemas/ApiMeta'
+
     CoachMessageRequest:
       type: object
       required:
@@ -840,6 +921,48 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/CoachMessageResponseData'
+        meta:
+          $ref: '#/components/schemas/ApiMeta'
+
+    CoachMessageHistoryData:
+      type: object
+      required:
+        - messageId
+        - role
+        - messageText
+        - createdAt
+      properties:
+        messageId:
+          type: string
+          example: '9001'
+        role:
+          $ref: '#/components/schemas/CoachMessageRole'
+        messageText:
+          type: string
+          example: 오늘 무엇부터 공부하면 좋을까?
+        route:
+          allOf:
+            - $ref: '#/components/schemas/CoachRoute'
+          nullable: true
+        detectedIntent:
+          type: string
+          nullable: true
+          example: CHECK_TODAY_PLAN
+        createdAt:
+          type: string
+          format: date-time
+          example: '2026-05-08T09:00:00Z'
+
+    CoachMessageHistoryListApiResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CoachMessageHistoryData'
         meta:
           $ref: '#/components/schemas/ApiMeta'
 


### PR DESCRIPTION
﻿## 무엇
- `GET /api/coach/sessions`로 현재 사용자의 Coach 세션 목록을 최신순으로 조회할 수 있게 했습니다.
- `GET /api/coach/sessions/{sessionId}/messages`로 세션별 메시지 히스토리를 시간순으로 조회할 수 있게 했습니다.
- 다른 사용자의 세션 메시지 조회는 `403 FORBIDDEN`으로 차단하고, 종료된 세션은 히스토리 조회를 허용합니다.
- `docs/20_v2_coach_api_contract.md`와 `docs/openapi.yml`에 조회 계약을 반영했습니다.

## 왜
- v2 Coach는 새로고침이나 탭 이동 후에도 대화 세션과 메시지를 복원할 수 있어야 시연이 안정적입니다.
- streaming이나 프론트 사이드바 없이도 저장/재조회 기반을 먼저 닫기 위한 작업입니다.

## 검증
- `cd backend; .\gradlew.bat test --tests "*CoachSessionControllerTest" --tests "*CoachMessageControllerTest" --tests "*CoachSessionServiceIntegrationTest" --tests "*CoachMessageServiceIntegrationTest"`
- `git diff --check`
- `docker run --rm -v ${PWD}:/work -w /work mikefarah/yq:4 eval '.' docs/openapi.yml`

Closes #305
