### PR TITLE
fix(github): 연결 단계 metadata fetch 제거, 분석 시점으로 이동 (#229)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -3,10 +3,12 @@ package com.back.coach.domain.github.service;
 import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.entity.GithubProject;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
 import com.back.coach.domain.github.repository.GithubConnectionRepository;
 import com.back.coach.domain.github.repository.GithubProjectRepository;
+import com.back.coach.domain.github.service.fetcher.GithubMetadataFetcher;
 import com.back.coach.domain.github.service.summary.DiffPreprocessor;
 import com.back.coach.domain.github.service.summary.RepoSummaryPromptBuilder;
 import com.back.coach.domain.github.service.summary.RepoSummaryResponseParser;
@@ -17,6 +19,7 @@ import com.back.coach.domain.github.service.triage.ChampionTriageService;
 import com.back.coach.external.llm.LlmClient;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +57,7 @@ public class GithubAnalysisService {
     private final LlmClient llmClient;
     private final TransactionTemplate transactionTemplate;
     private final ContextSnapshotPublisher contextSnapshotPublisher;
+    private final GithubMetadataFetcher metadataFetcher;
 
     public GithubAnalysisService(GithubConnectionRepository connectionRepo,
                                  GithubProjectRepository projectRepo,
@@ -68,7 +72,8 @@ public class GithubAnalysisService {
                                  GithubAnalysisPayloadJson payloadJson,
                                  LlmClient llmClient,
                                  TransactionTemplate transactionTemplate,
-                                 ContextSnapshotPublisher contextSnapshotPublisher) {
+                                 ContextSnapshotPublisher contextSnapshotPublisher,
+                                 GithubMetadataFetcher metadataFetcher) {
         this.connectionRepo = connectionRepo;
         this.projectRepo = projectRepo;
         this.analysisRepo = analysisRepo;
@@ -83,12 +88,19 @@ public class GithubAnalysisService {
         this.llmClient = llmClient;
         this.transactionTemplate = transactionTemplate;
         this.contextSnapshotPublisher = contextSnapshotPublisher;
+        this.metadataFetcher = metadataFetcher;
     }
 
     public GithubAnalysisResult run(Long userId, Long githubConnectionId,
                                     List<Long> selectedRepoIds, List<Long> coreRepoIds) {
         long analysisStartMs = System.currentTimeMillis();
         validateInputs(selectedRepoIds, coreRepoIds);
+
+        // Slice 6: 선택된 repo에 한해 metadata를 분석 시점에 fetch한다.
+        // #283 트랜잭션 분리 의도와 맞게 HTTP 호출은 트랜잭션 밖에서 수행하고,
+        // 각 projectRepo.save 만 짧은 auto-tx로 들어간다.
+        fetchAndPersistMetadataForSelected(userId, githubConnectionId, selectedRepoIds);
+
         AnalysisInputs inputs = transactionTemplate.execute(status ->
                 loadInputs(userId, githubConnectionId, selectedRepoIds, coreRepoIds)
         );
@@ -169,6 +181,43 @@ public class GithubAnalysisService {
                 totalElapsedMs, repoSummaries.size(), metrics);
         return new GithubAnalysisResult(saved.getId(), saved.getVersion(), payload, saved.getSummary(),
                 saved.getCreatedAt() == null ? Instant.now() : saved.getCreatedAt(), metrics);
+    }
+
+    private void fetchAndPersistMetadataForSelected(Long userId, Long githubConnectionId, List<Long> selectedRepoIds) {
+        GithubConnection connection = connectionRepo.findByIdAndUserId(githubConnectionId, userId)
+                .orElseThrow(() -> new ServiceException(ErrorCode.FORBIDDEN));
+
+        Set<Long> selectedIdSet = new HashSet<>(selectedRepoIds);
+        List<GithubProject> selected = projectRepo
+                .findByUserIdAndGithubConnectionId(userId, githubConnectionId).stream()
+                .filter(p -> selectedIdSet.contains(p.getId()))
+                .toList();
+        if (selected.size() != selectedRepoIds.size()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "선택된 저장소 일부가 사용자의 것이 아닙니다");
+        }
+
+        String token = connection.getAccessToken();
+        String login = connection.getGithubLogin();
+        for (GithubProject project : selected) {
+            String[] parts = project.getRepoFullName().split("/", 2);
+            if (parts.length < 2) {
+                log.warn("repo_full_name 형식 비정상, metadata fetch skip: {}", project.getRepoFullName());
+                continue;
+            }
+            String owner = parts[0];
+            String repo = parts[1];
+            try {
+                RepoMetadata metadata = metadataFetcher.fetch(token, owner, repo, login);
+                String json = METADATA_MAPPER.writeValueAsString(metadata);
+                project.updateMetadataPayload(json);
+                projectRepo.save(project);
+            } catch (JsonProcessingException e) {
+                log.warn("metadata 직렬화 실패 repo={} reason={}", project.getRepoFullName(), e.getMessage());
+            } catch (ServiceException e) {
+                log.warn("GitHub API 오류로 metadata fetch 실패 repo={} code={} message={}",
+                        project.getRepoFullName(), e.getErrorCode(), e.getMessage());
+            }
+        }
     }
 
     private AnalysisInputs loadInputs(Long userId, Long githubConnectionId,

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubConnectionService.java
@@ -4,17 +4,12 @@ import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.entity.GithubProject;
 import com.back.coach.domain.github.repository.GithubConnectionRepository;
 import com.back.coach.domain.github.repository.GithubProjectRepository;
-import com.back.coach.domain.github.service.fetcher.GithubMetadataFetcher;
 import com.back.coach.external.github.GithubApiClient;
 import com.back.coach.external.github.dto.GithubRepoDto;
 import com.back.coach.external.github.dto.GithubUserInfoDto;
 import com.back.coach.global.code.GithubAccessType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,23 +20,16 @@ import java.util.List;
 @Service
 public class GithubConnectionService {
 
-    private static final Logger log = LoggerFactory.getLogger(GithubConnectionService.class);
-
     private final GithubApiClient apiClient;
     private final GithubConnectionRepository connectionRepo;
     private final GithubProjectRepository projectRepo;
-    private final GithubMetadataFetcher metadataFetcher;
-    private final ObjectMapper objectMapper;
 
     public GithubConnectionService(GithubApiClient apiClient,
                                    GithubConnectionRepository connectionRepo,
-                                   GithubProjectRepository projectRepo,
-                                   GithubMetadataFetcher metadataFetcher) {
+                                   GithubProjectRepository projectRepo) {
         this.apiClient = apiClient;
         this.connectionRepo = connectionRepo;
         this.projectRepo = projectRepo;
-        this.metadataFetcher = metadataFetcher;
-        this.objectMapper = new ObjectMapper();
     }
 
     @Transactional
@@ -83,15 +71,10 @@ public class GithubConnectionService {
     private void syncRepos(Long userId, GithubConnection connection, String login, String accessToken) {
         List<GithubRepoDto> repos = apiClient.listUserRepos(accessToken);
         for (GithubRepoDto repo : repos) {
-            String[] parts = repo.fullName().split("/", 2);
-            String owner = parts[0];
-            String repoName = parts.length > 1 ? parts[1] : parts[0];
-
             String ownerType = repo.owner() != null && login.equals(repo.owner().login())
                     ? "owner"
                     : "collaborator";
-            GithubProject project = upsertProject(userId, connection.getId(), repo, ownerType);
-            fetchAndUpdateMetadata(project, accessToken, owner, repoName, login);
+            upsertProject(userId, connection.getId(), repo, ownerType);
         }
     }
 
@@ -109,21 +92,6 @@ public class GithubConnectionService {
                                         "repo upsert failed: " + repo.fullName()));
                     }
                 });
-    }
-
-    private void fetchAndUpdateMetadata(GithubProject project, String accessToken,
-                                         String owner, String repo, String login) {
-        try {
-            RepoMetadata metadata = metadataFetcher.fetch(accessToken, owner, repo, login);
-            String json = objectMapper.writeValueAsString(metadata);
-            project.updateMetadataPayload(json);
-            projectRepo.save(project);
-        } catch (JsonProcessingException e) {
-            log.error("Failed to serialize metadata for {}/{}: {}", owner, repo, e.getMessage());
-        } catch (ServiceException e) {
-            log.warn("GitHub API error fetching metadata for {}/{}: {} {}", owner, repo,
-                    e.getErrorCode(), e.getMessage());
-        }
     }
 
     public record ConnectResult(Long connectionId, String githubLogin, Instant connectedAt) {}

--- a/backend/src/test/java/com/back/coach/domain/github/controller/GithubConnectionControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/controller/GithubConnectionControllerTest.java
@@ -138,7 +138,8 @@ class GithubConnectionControllerTest extends ApiTestBase {
                 connections.get(0).getId(), user.getId());
         assertThat(projects).hasSize(1);
         assertThat(projects.get(0).getRepoFullName()).isEqualTo("testuser/cool-repo");
-        assertThat(projects.get(0).getMetadataPayload()).contains("languageBytes");
+        // Slice 6: 연결 단계에서는 metadata fetch 안 함. 분석 시점에 fetch.
+        assertThat(projects.get(0).getMetadataPayload()).doesNotContain("languageBytes");
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -1,10 +1,13 @@
 package com.back.coach.domain.github.service;
 
 import com.back.coach.domain.github.entity.GithubAnalysis;
+import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.entity.GithubProject;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
 import com.back.coach.domain.github.repository.GithubConnectionRepository;
 import com.back.coach.domain.github.repository.GithubProjectRepository;
+import com.back.coach.domain.github.service.fetcher.GithubMetadataFetcher;
+import com.back.coach.global.code.GithubAccessType;
 import com.back.coach.external.llm.LlmClient;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -28,6 +31,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -45,6 +49,7 @@ class GithubAnalysisServiceTest {
     GithubProjectRepository projectRepo;
     GithubAnalysisRepository analysisRepo;
     LlmClient llmClient;
+    GithubMetadataFetcher metadataFetcher;
 
     GithubAnalysisService service;
 
@@ -58,6 +63,7 @@ class GithubAnalysisServiceTest {
         projectRepo = mock(GithubProjectRepository.class);
         analysisRepo = mock(GithubAnalysisRepository.class);
         llmClient = mock(LlmClient.class);
+        metadataFetcher = mock(GithubMetadataFetcher.class);
 
         ChampionTriageService triageService = new ChampionTriageService(
                 llmClient, new ChampionTriagePromptBuilder(), new ChampionTriageResponseParser());
@@ -74,7 +80,8 @@ class GithubAnalysisServiceTest {
                 new GithubAnalysisPayloadJson(),
                 llmClient,
                 transactionTemplate(),
-                mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class)
+                mock(com.back.coach.domain.context.service.ContextSnapshotPublisher.class),
+                metadataFetcher
         );
 
         triageJson = """
@@ -96,7 +103,7 @@ class GithubAnalysisServiceTest {
     @Test
     @DisplayName("연결 소유권이 없으면 FORBIDDEN")
     void run_connectionNotOwned_throwsForbidden() {
-        given(connectionRepo.existsByIdAndUserId(CONNECTION_ID, USER_ID)).willReturn(false);
+        given(connectionRepo.findByIdAndUserId(CONNECTION_ID, USER_ID)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.run(USER_ID, CONNECTION_ID, List.of(1L), List.of(1L)))
                 .isInstanceOf(ServiceException.class)
@@ -169,19 +176,29 @@ class GithubAnalysisServiceTest {
     @Test
     @DisplayName("coreRepoIds가 selectedRepoIds의 부분집합이 아니면 INVALID_INPUT")
     void run_coreNotSubsetOfSelected_throws() {
-        given(connectionRepo.existsByIdAndUserId(CONNECTION_ID, USER_ID)).willReturn(true);
-
         assertThatThrownBy(() -> service.run(USER_ID, CONNECTION_ID, List.of(1L), List.of(2L)))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
     }
 
     private void primeRepos() {
+        GithubConnection connection = GithubConnection.connect(
+                USER_ID, "42", "user", GithubAccessType.OAUTH, "token-abc");
+        ReflectionTestUtils.setField(connection, "id", CONNECTION_ID);
+        given(connectionRepo.findByIdAndUserId(CONNECTION_ID, USER_ID)).willReturn(Optional.of(connection));
         given(connectionRepo.existsByIdAndUserId(CONNECTION_ID, USER_ID)).willReturn(true);
-        GithubProject project = makeProject(1L, "user/a", "Java",
-                "{\"languageBytes\":{\"Java\":1000},\"commits\":[{\"sha\":\"abc\",\"subject\":\"feat: OAuth\",\"bodyExcerpt\":\"\",\"paths\":[\"X.java\"],\"additions\":10,\"deletions\":0,\"diffExcerpt\":\"diff body\"}],\"pullRequests\":[],\"issues\":[]}");
+        GithubProject project = makeProject(1L, "user/a", "Java", "{}");
         given(projectRepo.findByUserIdAndGithubConnectionId(USER_ID, CONNECTION_ID))
                 .willReturn(List.of(project));
+        given(metadataFetcher.fetch(anyString(), anyString(), anyString(), anyString()))
+                .willReturn(sampleMetadata());
+    }
+
+    private static RepoMetadata sampleMetadata() {
+        RepoMetadata.CommitItem commit = new RepoMetadata.CommitItem(
+                "abc", "feat: OAuth", "", List.of("X.java"), 10, 0, "diff body");
+        return new RepoMetadata(null, Map.of("Java", 1000L), List.of(),
+                List.of(commit), List.of(), List.of());
     }
 
     private void primeLlm() {

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubConnectionServiceTest.java
@@ -4,19 +4,16 @@ import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.entity.GithubProject;
 import com.back.coach.domain.github.repository.GithubConnectionRepository;
 import com.back.coach.domain.github.repository.GithubProjectRepository;
-import com.back.coach.domain.github.service.fetcher.GithubMetadataFetcher;
 import com.back.coach.external.github.GithubApiClient;
 import com.back.coach.external.github.dto.GithubRepoDto;
 import com.back.coach.external.github.dto.GithubUserInfoDto;
 import com.back.coach.global.code.GithubAccessType;
-import com.back.coach.domain.github.service.RepoMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +26,6 @@ class GithubConnectionServiceTest {
     GithubApiClient apiClient;
     GithubConnectionRepository connectionRepo;
     GithubProjectRepository projectRepo;
-    GithubMetadataFetcher metadataFetcher;
     GithubConnectionService service;
 
     static final Long USER_ID = 1L;
@@ -39,12 +35,11 @@ class GithubConnectionServiceTest {
         apiClient = mock(GithubApiClient.class);
         connectionRepo = mock(GithubConnectionRepository.class);
         projectRepo = mock(GithubProjectRepository.class);
-        metadataFetcher = mock(GithubMetadataFetcher.class);
-        service = new GithubConnectionService(apiClient, connectionRepo, projectRepo, metadataFetcher);
+        service = new GithubConnectionService(apiClient, connectionRepo, projectRepo);
     }
 
     @Test
-    @DisplayName("신규 연결: GithubConnection + GithubProject 행 생성 + metadata fetch")
+    @DisplayName("신규 연결: GithubConnection + GithubProject 행 생성 (metadata fetch 없음)")
     void connect_newConnection_createsConnectionAndProjects() {
         given(apiClient.exchangeCode("code-abc")).willReturn("ghp_token");
         given(apiClient.getUserInfo("ghp_token")).willReturn(new GithubUserInfoDto(42L, "testuser"));
@@ -62,20 +57,16 @@ class GithubConnectionServiceTest {
         GithubProject savedProject = GithubProject.create(USER_ID, 10L, "N1", "testuser/repo-a",
                 "https://github.com/testuser/repo-a", "Java", "main", "owner");
         ReflectionTestUtils.setField(savedProject, "id", 100L);
-        given(projectRepo.save(any())).willReturn(savedProject);
         given(projectRepo.saveAndFlush(any())).willReturn(savedProject);
-        given(metadataFetcher.fetch(anyString(), anyString(), anyString(), anyString()))
-                .willReturn(sampleMetadata());
 
         GithubConnectionService.ConnectResult result = service.connect(USER_ID, "code-abc");
 
         assertThat(result.connectionId()).isEqualTo(10L);
         assertThat(result.githubLogin()).isEqualTo("testuser");
         verify(connectionRepo).save(any(GithubConnection.class));
-        verify(metadataFetcher, times(2)).fetch(eq("ghp_token"), eq("testuser"), anyString(), eq("testuser"));
-        // 2 repos: saveAndFlush(create) + save(metadata update) each
+        // Slice 6: 연결 단계에서 metadata 수집하지 않으므로 metadataFetcher 의존성 없음
         verify(projectRepo, times(2)).saveAndFlush(any(GithubProject.class));
-        verify(projectRepo, times(2)).save(any(GithubProject.class));
+        verify(projectRepo, never()).save(any(GithubProject.class));
     }
 
     @Test
@@ -111,16 +102,10 @@ class GithubConnectionServiceTest {
         assertThat(repos.get(0).getRepoFullName()).isEqualTo("testuser/repo");
     }
 
-    // ── helpers ──
-
     private static GithubConnection savedConnection(Long id, Long userId, String githubUserId,
                                                      String login, String token) {
         GithubConnection c = GithubConnection.connect(userId, githubUserId, login, GithubAccessType.OAUTH, token);
         ReflectionTestUtils.setField(c, "id", id);
         return c;
-    }
-
-    private static RepoMetadata sampleMetadata() {
-        return new RepoMetadata("# readme", Map.of("Java", 1000L), List.of(), List.of(), List.of(), List.of());
     }
 }


### PR DESCRIPTION
Closes #229

## 요약
- `GithubConnectionService.syncRepos`에서 `fetchAndUpdateMetadata` 제거. 연결 시 N개 repo만큼 GitHub API 직렬 호출하던 문제 해소 (N+1)
- `GithubAnalysisService.run` 시작 시 선택된 repo에 한해 `fetchAndPersistMetadataForSelected` 호출 — HTTP 호출은 트랜잭션 밖, 각 `projectRepo.save`는 auto-tx
- 소유권 검증 강화: `connectionRepo.findByIdAndUserId`로 Connection 실체 확인 후 token 사용

## 테스트
- [ ] `GithubConnectionControllerTest`: 연결 후 `metadataPayload`에 `languageBytes` 없음 확인
- [ ] `GithubAnalysisServiceTest`: `metadataFetcher` mock이 분석 호출 시 invoke됨 확인
- [ ] `GithubConnectionServiceTest`: `metadataFetcher` 의존성 없이 생성자 통과
