### PR TITLE
chore(roadmap): 최대 주차 수 상수를 application.yml로 단일화 (#185)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/controller/RoadmapDetailController.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.roadmap.controller;
 
+import com.back.coach.domain.roadmap.dto.RoadmapConstraintsResponse;
 import com.back.coach.domain.roadmap.dto.RoadmapDetailResponse;
 import com.back.coach.domain.roadmap.dto.RoadmapDetailSnapshot;
 import com.back.coach.domain.roadmap.dto.RoadmapSummaryResponse;
@@ -7,6 +8,7 @@ import com.back.coach.domain.roadmap.service.RoadmapDetailSnapshotService;
 import com.back.coach.global.response.ApiResponse;
 import com.back.coach.global.security.AuthenticatedUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,13 +24,21 @@ public class RoadmapDetailController {
 
     private final RoadmapDetailSnapshotService roadmapDetailSnapshotService;
     private final ObjectMapper objectMapper;
+    private final int maxWeeks;
 
     public RoadmapDetailController(
             RoadmapDetailSnapshotService roadmapDetailSnapshotService,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            @Value("${roadmap.max-weeks}") int maxWeeks
     ) {
         this.roadmapDetailSnapshotService = roadmapDetailSnapshotService;
         this.objectMapper = objectMapper;
+        this.maxWeeks = maxWeeks;
+    }
+
+    @GetMapping("/constraints")
+    public ApiResponse<RoadmapConstraintsResponse> getConstraints() {
+        return ApiResponse.success(new RoadmapConstraintsResponse(maxWeeks));
     }
 
     @GetMapping

--- a/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapConstraintsResponse.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/dto/RoadmapConstraintsResponse.java
@@ -1,0 +1,3 @@
+package com.back.coach.domain.roadmap.dto;
+
+public record RoadmapConstraintsResponse(int maxWeeks) {}

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -8,10 +8,17 @@ import com.back.coach.domain.user.entity.UserProfile;
 import java.time.LocalDate;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RoadmapPromptBuilder {
+
+    private final int maxWeeks;
+
+    public RoadmapPromptBuilder(@Value("${roadmap.max-weeks}") int maxWeeks) {
+        this.maxWeeks = maxWeeks;
+    }
 
     public String build(Input input) {
         Integer weeklyStudyHours = input.weeklyStudyHours() == null
@@ -46,7 +53,7 @@ public class RoadmapPromptBuilder {
                 - tasks[].type must be one of READ_DOCS, BUILD_EXAMPLE, WRITE_NOTE, APPLY_PROJECT, REVIEW.
                 - materials[].type must be one of DOCS, ARTICLE, REPOSITORY, VIDEO, TEMPLATE.
                 - Do not include progress status.
-                - Generate at most 8 weeks total.
+                - Generate at most %d weeks total.
                 - Your output budget is 8192 tokens. Complete the entire JSON within this limit — do not truncate mid-object.
 
                 User context:
@@ -61,6 +68,7 @@ public class RoadmapPromptBuilder {
                 - strengths: %s
                 - recommendations: %s
                 """.formatted(
+                maxWeeks,
                 input.jobRole().getRoleCode(),
                 input.diagnosis().getCurrentLevel(),
                 valueOrUnknown(weeklyStudyHours),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -67,6 +67,9 @@ ai:
     max-concurrent-calls: 4
     queue-timeout-seconds: 180
 
+roadmap:
+  max-weeks: 8
+
 coach:
   async:
     analysis:

--- a/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapDetailControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/controller/RoadmapDetailControllerTest.java
@@ -48,10 +48,18 @@ class RoadmapDetailControllerTest {
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new RoadmapDetailController(roadmapDetailSnapshotService, objectMapper))
+                .standaloneSetup(new RoadmapDetailController(roadmapDetailSnapshotService, objectMapper, 8))
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
+    }
+
+    @Test
+    void getConstraints_returnsMaxWeeksFromConfig() throws Exception {
+        mockMvc.perform(get("/api/roadmaps/constraints")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.maxWeeks").value(8));
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -106,7 +106,7 @@ class RoadmapCommandServiceTest {
                 learningRoadmapRepository,
                 roadmapWeekRepository,
                 resultVersionService,
-                new RoadmapPromptBuilder(),
+                new RoadmapPromptBuilder(8),
                 new RoadmapResponseParser(),
                 llmClient,
                 objectMapper,

--- a/frontend/src/features/roadmap/api.ts
+++ b/frontend/src/features/roadmap/api.ts
@@ -1,11 +1,16 @@
 import { apiClient } from "@/lib/api";
 import type {
   Roadmap,
+  RoadmapConstraints,
   RoadmapRequest,
   RoadmapProgressRequest,
   RoadmapProgressResponse,
   RoadmapSummary
 } from "@/features/roadmap/types";
+
+export function getRoadmapConstraints() {
+  return apiClient.get<RoadmapConstraints>("/api/roadmaps/constraints");
+}
 
 export function createRoadmap(payload: RoadmapRequest) {
   return apiClient.post<Roadmap>("/api/roadmaps", payload);

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -9,6 +9,7 @@ import { ApiError, apiClient } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/auth";
 import { getMyProfile } from "@/features/profile/api";
 import { getDashboard } from "@/features/dashboard/api";
+import { getRoadmapConstraints } from "@/features/roadmap/api";
 import { StatePanel } from "@/components/state-panel";
 
 type CreateState =
@@ -22,14 +23,14 @@ function getErrorMessage(error: unknown): string {
   return "오류가 발생했습니다. 다시 시도해주세요.";
 }
 
-const MAX_WEEKS = 8;
+const FALLBACK_MAX_WEEKS = 8;
 
 function getTomorrowDateValue() {
   return new Date(Date.now() + 86400000).toISOString().split("T")[0];
 }
 
-function getMaxDateValue() {
-  return new Date(Date.now() + MAX_WEEKS * 7 * 86400000)
+function getMaxDateValue(maxWeeks: number) {
+  return new Date(Date.now() + maxWeeks * 7 * 86400000)
     .toISOString()
     .split("T")[0];
 }
@@ -45,6 +46,7 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
   const [diagnosisSummary, setDiagnosisSummary] = useState<string | null>(null);
   const [weeklyStudyHours, setWeeklyStudyHours] = useState("");
   const [targetDate, setTargetDate] = useState("");
+  const [maxWeeks, setMaxWeeks] = useState<number>(FALLBACK_MAX_WEEKS);
   const loaded = useRef(false);
   const targetDateInputRef = useRef<HTMLInputElement>(null);
 
@@ -52,6 +54,12 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
     if (loaded.current) return;
     loaded.current = true;
     targetDateInputRef.current?.setAttribute("min", getTomorrowDateValue());
+
+    getRoadmapConstraints()
+      .then((constraints) => setMaxWeeks(constraints.maxWeeks))
+      .catch(() => {
+        // fallback 값을 그대로 사용
+      });
 
     // 프로필에서 학습 시간/목표일 기본값 로드
     getMyProfile()
@@ -121,10 +129,10 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
       setState({ status: "error", message: "목표 날짜는 오늘 이후여야 합니다." });
       return;
     }
-    if (new Date(targetDate) > new Date(getMaxDateValue())) {
+    if (new Date(targetDate) > new Date(getMaxDateValue(maxWeeks))) {
       setState({
         status: "error",
-        message: `목표 날짜는 최대 ${MAX_WEEKS}주 이내여야 합니다.`
+        message: `목표 날짜는 최대 ${maxWeeks}주 이내여야 합니다.`
       });
       return;
     }
@@ -223,11 +231,11 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
         </label>
 
         <label>
-          <span>목표 날짜 (최대 {MAX_WEEKS}주)</span>
+          <span>목표 날짜 (최대 {maxWeeks}주)</span>
           <input
             type="date"
             ref={targetDateInputRef}
-            max={getMaxDateValue()}
+            max={getMaxDateValue(maxWeeks)}
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
             disabled={isSubmitting}

--- a/frontend/src/features/roadmap/types.ts
+++ b/frontend/src/features/roadmap/types.ts
@@ -69,6 +69,10 @@ export type RoadmapProgressResponse = {
   status: ProgressStatus;
 };
 
+export type RoadmapConstraints = {
+  maxWeeks: number;
+};
+
 export type RoadmapSummary = {
   roadmapId: string;
   version: number;


### PR DESCRIPTION
Closes #185 

## 요약
- 최대 주차 수가 무한히 늘어나면 output token이 길어짐. 최대 주차 수를 제한해야 할 필요성 존재 -> 8주로 제한
- `roadmap.max-weeks: 8` application.yml에 설정 키 추가 하드코딩 제거
- `RoadmapPromptBuilder`: `@Value` 주입으로 프롬프트 내 주차 제한 동적화
- `RoadmapDetailController`: `GET /api/roadmaps/constraints` 엔드포인트 추가 → `{ maxWeeks }` 반환
- 프론트엔드: `getRoadmapConstraints()` API 호출 후 `maxWeeks` 동적 반영, 실패 시 fallback 8 유지

## 검증
- [ ] `RoadmapDetailControllerTest.getConstraints_returnsMaxWeeksFromConfig` 통과
- [ ] `RoadmapCommandServiceTest`: `RoadmapPromptBuilder(8)` 생성자 정상 동작
- [ ] 로드맵 생성 화면 진입 시 `/constraints` 호출 → 날짜 max 제한 반영 확인

