### PR TITLE
fix(auth): OAuth invalid_request 진단 로그 보강 (#143)

### DIFF
--- a/backend/src/main/java/com/back/coach/global/security/oauth2/CoachOAuth2LoginFailureHandler.java
+++ b/backend/src/main/java/com/back/coach/global/security/oauth2/CoachOAuth2LoginFailureHandler.java
@@ -39,6 +39,9 @@ public class CoachOAuth2LoginFailureHandler implements AuthenticationFailureHand
                                         HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
         log.warn("OAuth2 authentication failed: {}", exception.getMessage());
+        if (log.isDebugEnabled()) {
+            log.debug("OAuth2 authentication failure detail", exception);
+        }
         String message = extractMessage(exception);
         String encoded = URLEncoder.encode(message, StandardCharsets.UTF_8);
         response.sendRedirect(frontendBaseUrl + "/login?error=" + encoded);

--- a/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/back/coach/global/security/oauth2/CookieOAuth2AuthorizationRequestRepository.java
@@ -109,21 +109,49 @@ public class CookieOAuth2AuthorizationRequestRepository
     }
 
     private OAuth2AuthorizationRequest tryDeserialize(String cookieValue) {
+        byte[] raw;
         try {
-            byte[] raw = Base64.getUrlDecoder().decode(cookieValue);
-            if (raw.length < 4 + 32) return null;
-            ByteBuffer buf = ByteBuffer.wrap(raw);
-            int len = buf.getInt();
-            if (len <= 0 || len > raw.length - 4 - 32) return null;
-            byte[] payloadBytes = new byte[len];
-            buf.get(payloadBytes);
-            byte[] expectedSig = new byte[32];
-            buf.get(expectedSig);
-            byte[] actualSig = sign(payloadBytes);
-            if (!MessageDigest.isEqual(expectedSig, actualSig)) {
-                return null;
-            }
-            CookiePayload p = mapper.readValue(payloadBytes, CookiePayload.class);
+            raw = Base64.getUrlDecoder().decode(cookieValue);
+        } catch (IllegalArgumentException e) {
+            log.warn("oauth2_auth_request base64 decode 실패: {}", e.getMessage());
+            return null;
+        }
+        if (raw.length < 4 + 32) {
+            log.warn("oauth2_auth_request size 비정상: {} bytes (minimum {})", raw.length, 4 + 32);
+            return null;
+        }
+        ByteBuffer buf = ByteBuffer.wrap(raw);
+        int len = buf.getInt();
+        if (len <= 0 || len > raw.length - 4 - 32) {
+            log.warn("oauth2_auth_request payloadLen 비정상: declared={} raw={}", len, raw.length);
+            return null;
+        }
+        byte[] payloadBytes = new byte[len];
+        buf.get(payloadBytes);
+        byte[] expectedSig = new byte[32];
+        buf.get(expectedSig);
+        byte[] actualSig;
+        try {
+            actualSig = sign(payloadBytes);
+        } catch (Exception e) {
+            log.warn("oauth2_auth_request HMAC 계산 실패: {}", e.getMessage());
+            return null;
+        }
+        if (!MessageDigest.isEqual(expectedSig, actualSig)) {
+            log.warn("oauth2_auth_request HMAC mismatch — JwtProperties.secret 불일치(재시작·환경 변경) 또는 변조 가능");
+            return null;
+        }
+        CookiePayload p;
+        try {
+            p = mapper.readValue(payloadBytes, CookiePayload.class);
+        } catch (Exception e) {
+            log.warn("oauth2_auth_request JSON parse 실패: {}", e.getMessage());
+            return null;
+        }
+        log.debug("oauth2_auth_request 복원 성공 redirectUri={} attrsKeys={}",
+                p.redirectUri(),
+                p.attributes() == null ? "[]" : p.attributes().keySet());
+        try {
             return OAuth2AuthorizationRequest.authorizationCode()
                     .authorizationUri(p.authorizationUri())
                     .clientId(p.clientId())
@@ -135,7 +163,7 @@ public class CookieOAuth2AuthorizationRequestRepository
                     .authorizationRequestUri(p.authorizationRequestUri())
                     .build();
         } catch (Exception e) {
-            log.warn("oauth2_auth_request deserialization exception: {}", e.getMessage());
+            log.warn("oauth2_auth_request 빌더 실패: {}", e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## 요약
- `CookieOAuth2AuthorizationRequestRepository.tryDeserialize`의 각 실패 경로(base64 decode, size 검증, payloadLen, HMAC 계산, HMAC mismatch, JSON parse, 빌더)에 구체적인 `warn` 로그 추가
- `CoachOAuth2LoginFailureHandler`에 `log.isDebugEnabled()` 조건부 스택트레이스 출력 추가
- 기존에는 실패 시 `null` 반환만 하고 원인을 알 수 없었음 → 이제 로그 한 줄로 실패 지점 특정 가능

## Test
- [ ] 기존 OAuth 통합 테스트 통과 확인
- [ ] 로컬에서 잘못된 cookie 값으로 요청 시 warn 로그 출력 확인


Related: #143