### PR TITLE
feat(coach): Slice 10 프론트 — 대화 히스토리 복원 + 세션 목록 사이드바 (#292)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2222,3 +2222,149 @@ a {
   color: var(--muted);
   font-size: 11px;
 }
+
+/* ===== Coach Slice 10 — sessions sidebar + history layout ===== */
+
+.coach-layout {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  height: calc(100vh - 56px);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 16px 24px 24px;
+}
+
+.coach-layout .coach-screen {
+  flex: 1;
+  min-width: 0;
+  max-width: none;
+  height: auto;
+  margin: 0;
+  padding: 0;
+}
+
+.coach-sidebar {
+  width: 260px;
+  flex: 0 0 260px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.coach-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.coach-sidebar-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.coach-sidebar-new {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--foreground);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.coach-sidebar-new:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.coach-sidebar-empty {
+  padding: 16px 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.coach-sidebar-empty[data-tone="danger"] {
+  color: var(--danger, #b54545);
+}
+
+.coach-sidebar-list {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.coach-sidebar-item {
+  margin-bottom: 4px;
+}
+
+.coach-sidebar-link {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: inherit;
+  text-decoration: none;
+  border: 1px solid transparent;
+}
+
+.coach-sidebar-link:hover {
+  background: var(--accent-soft);
+}
+
+.coach-sidebar-item[data-active="true"] .coach-sidebar-link {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.coach-sidebar-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.coach-sidebar-label {
+  font-weight: 600;
+}
+
+.coach-sidebar-item[data-status="closed"] .coach-sidebar-label {
+  color: var(--muted);
+}
+
+.coach-sidebar-version {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.coach-sidebar-date {
+  color: var(--muted);
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+@media (max-width: 720px) {
+  .coach-layout {
+    flex-direction: column;
+    height: auto;
+    min-height: calc(100vh - 56px);
+  }
+
+  .coach-sidebar {
+    width: 100%;
+    flex: 0 0 auto;
+    max-height: 160px;
+  }
+
+  .coach-layout .coach-screen {
+    min-height: 60vh;
+  }
+}
+

--- a/frontend/src/features/coach/api.ts
+++ b/frontend/src/features/coach/api.ts
@@ -1,12 +1,25 @@
 import { apiClient } from "@/lib/api";
 import type {
+  CoachMessageHistory,
   CoachMessageResponse,
   CoachSession,
+  CoachSessionSummary,
   ReplanResult
 } from "@/features/coach/types";
 
 export function getActiveSession(signal?: AbortSignal) {
   return apiClient.get<CoachSession>("/api/coach/sessions/active", { signal });
+}
+
+export function getSessions(signal?: AbortSignal) {
+  return apiClient.get<CoachSessionSummary[]>("/api/coach/sessions", { signal });
+}
+
+export function getSessionMessages(sessionId: string, signal?: AbortSignal) {
+  return apiClient.get<CoachMessageHistory[]>(
+    `/api/coach/sessions/${sessionId}/messages`,
+    { signal }
+  );
 }
 
 export function createSession(signal?: AbortSignal) {

--- a/frontend/src/features/coach/coach-chat-view.tsx
+++ b/frontend/src/features/coach/coach-chat-view.tsx
@@ -19,14 +19,17 @@ import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import {
   closeSession,
   confirmReplan,
+  getSessionMessages,
   sendMessage
 } from "@/features/coach/api";
 import {
   classifyCoachError,
   isAbortError
 } from "@/features/coach/coach-errors";
+import { CoachSessionsSidebar } from "@/features/coach/coach-sessions-sidebar";
 import type {
   ChatBubble,
+  CoachMessageHistory,
   CoachMessageResponse,
   ReplanProposal
 } from "@/features/coach/types";
@@ -47,6 +50,16 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
   const [authRequired, setAuthRequired] = useState(false);
   const [sessionClosed, setSessionClosed] = useState(false);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(true);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [trackedSessionId, setTrackedSessionId] = useState(sessionId);
+
+  if (trackedSessionId !== sessionId) {
+    setTrackedSessionId(sessionId);
+    setBubbles([]);
+    setHistoryLoading(true);
+    setHistoryError(null);
+  }
 
   const abortRef = useRef<AbortController | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
@@ -80,6 +93,42 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
       abortRef.current?.abort();
     };
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    getSessionMessages(sessionId, controller.signal)
+      .then((messages) => {
+        if (cancelled) return;
+        setBubbles(messages.map(historyMessageToBubble));
+      })
+      .catch((error) => {
+        if (cancelled || isAbortError(error)) return;
+        if (isUnauthorizedError(error)) {
+          setAuthRequired(true);
+          return;
+        }
+        if (error instanceof ApiError && error.code === "SESSION_NOT_FOUND") {
+          setHistoryError("이 세션을 찾을 수 없습니다. 세션 목록에서 다시 선택해 주세요.");
+          return;
+        }
+        if (error instanceof ApiError && error.code === "FORBIDDEN") {
+          setHistoryError("이 세션에 접근할 권한이 없습니다.");
+          return;
+        }
+        const info = classifyCoachError(error);
+        setHistoryError(info.title);
+      })
+      .finally(() => {
+        if (!cancelled) setHistoryLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [sessionId]);
 
   const handleAbort = useCallback(() => {
     abortRef.current?.abort();
@@ -234,25 +283,30 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
 
   if (sessionClosed) {
     return (
-      <section className="screen-shell coach-screen">
-        <div className="panel" data-tone="danger">
-          <p>이미 종료된 세션입니다. 새 세션을 시작해 주세요.</p>
-        </div>
-        <div className="action-row">
-          <button
-            className="action-link primary"
-            type="button"
-            onClick={() => router.replace("/coach")}
-          >
-            새 세션 시작
-          </button>
-        </div>
-      </section>
+      <div className="coach-layout">
+        <CoachSessionsSidebar activeSessionId={sessionId} />
+        <section className="screen-shell coach-screen">
+          <div className="panel" data-tone="danger">
+            <p>이미 종료된 세션입니다. 새 세션을 시작해 주세요.</p>
+          </div>
+          <div className="action-row">
+            <button
+              className="action-link primary"
+              type="button"
+              onClick={() => router.replace("/coach")}
+            >
+              새 세션 시작
+            </button>
+          </div>
+        </section>
+      </div>
     );
   }
 
   return (
-    <section className="coach-screen">
+    <div className="coach-layout">
+      <CoachSessionsSidebar activeSessionId={sessionId} />
+      <section className="coach-screen">
       <header className="coach-header">
         <h2 className="coach-title">코치</h2>
         <button
@@ -269,7 +323,15 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
         ref={scrollerRef}
         onScroll={handleScroll}
       >
-        {bubbles.length === 0 ? (
+        {historyLoading ? (
+          <div className="coach-empty">
+            <p>이전 대화를 불러오는 중…</p>
+          </div>
+        ) : historyError ? (
+          <div className="coach-empty" data-tone="danger">
+            <p>{historyError}</p>
+          </div>
+        ) : bubbles.length === 0 ? (
           <div className="coach-empty">
             <p>무엇이 궁금한가요? 학습 진행 상황·로드맵 조정·막힌 부분을 자유롭게 말해 보세요.</p>
           </div>
@@ -361,8 +423,18 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
           </button>
         )}
       </form>
-    </section>
+      </section>
+    </div>
   );
+}
+
+function historyMessageToBubble(message: CoachMessageHistory): ChatBubble {
+  return {
+    id: `h-${message.messageId}`,
+    role: message.role,
+    text: message.messageText,
+    route: message.route ?? undefined
+  };
 }
 
 type ReplanCardProps = {

--- a/frontend/src/features/coach/coach-sessions-sidebar.tsx
+++ b/frontend/src/features/coach/coach-sessions-sidebar.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { getSessions } from "@/features/coach/api";
+import { classifyCoachError } from "@/features/coach/coach-errors";
+import type { CoachSessionSummary } from "@/features/coach/types";
+import { isUnauthorizedError } from "@/lib/auth";
+
+type SidebarProps = {
+  activeSessionId: string;
+};
+
+export function CoachSessionsSidebar({ activeSessionId }: SidebarProps) {
+  const router = useRouter();
+  const [sessions, setSessions] = useState<CoachSessionSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    getSessions(controller.signal)
+      .then((data) => {
+        if (!cancelled) setSessions(data);
+      })
+      .catch((err) => {
+        if (cancelled || (err instanceof DOMException && err.name === "AbortError")) return;
+        if (isUnauthorizedError(err)) {
+          setError("로그인이 필요합니다.");
+          return;
+        }
+        const info = classifyCoachError(err);
+        setError(info.title);
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [activeSessionId]);
+
+  return (
+    <aside className="coach-sidebar" aria-label="Coach 세션 목록">
+      <header className="coach-sidebar-header">
+        <h3>세션</h3>
+        <button
+          type="button"
+          className="coach-sidebar-new"
+          onClick={() => router.push("/coach")}
+        >
+          + 새 세션
+        </button>
+      </header>
+
+      {error ? (
+        <p className="coach-sidebar-empty" data-tone="danger">{error}</p>
+      ) : sessions === null ? (
+        <p className="coach-sidebar-empty">불러오는 중…</p>
+      ) : sessions.length === 0 ? (
+        <p className="coach-sidebar-empty">아직 세션이 없습니다.</p>
+      ) : (
+        <ul className="coach-sidebar-list">
+          {sessions.map((session) => {
+            const isActive = session.sessionId === activeSessionId;
+            const isClosed = session.status === "CLOSED";
+            return (
+              <li
+                key={session.sessionId}
+                className="coach-sidebar-item"
+                data-active={isActive ? "true" : undefined}
+                data-status={session.status.toLowerCase()}
+              >
+                <Link
+                  href={`/coach/sessions/${session.sessionId}`}
+                  className="coach-sidebar-link"
+                >
+                  <div className="coach-sidebar-row">
+                    <span className="coach-sidebar-label">
+                      {isClosed ? "종료됨" : "활성"}
+                    </span>
+                    <span className="coach-sidebar-version">
+                      v{session.profileVersion}/{session.roadmapVersion}
+                    </span>
+                  </div>
+                  <div className="coach-sidebar-date">
+                    {formatStartedAt(session.startedAt)}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+function formatStartedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false
+  });
+}

--- a/frontend/src/features/coach/types.ts
+++ b/frontend/src/features/coach/types.ts
@@ -39,3 +39,25 @@ export type ChatBubble = {
   replanProposal?: ReplanProposal | null;
   pending?: boolean;
 };
+
+export type ChatSessionStatus = "ACTIVE" | "CLOSED";
+
+export type CoachSessionSummary = {
+  sessionId: string;
+  profileVersion: number;
+  roadmapVersion: number;
+  status: ChatSessionStatus;
+  startedAt: string;
+  endedAt: string | null;
+};
+
+export type CoachMessageRole = "USER" | "COACH";
+
+export type CoachMessageHistory = {
+  messageId: string;
+  role: CoachMessageRole;
+  messageText: string;
+  route: CoachRoute | null;
+  detectedIntent: string | null;
+  createdAt: string;
+};


### PR DESCRIPTION
Closes #292

## Summary

PR #311이 백엔드 `GET /api/coach/sessions`와 `GET /api/coach/sessions/{sessionId}/messages`를 추가했다. 이 PR은 그 백엔드를 활용해 새로고침/탭 이동 시 대화 복구와 세션 전환 UX를 마무리한다.

> Tier 1 우선순위 — 사용자는 streaming 없는 건 참아도 새로고침에 대화 날아가는 건 못 참기 때문 (#292 본문 인용).

## 변경

### types
- `CoachSessionSummary`, `CoachMessageHistory`, `ChatSessionStatus`, `CoachMessageRole` 추가

### api
- `getSessions()` → `GET /api/coach/sessions`
- `getSessionMessages(sessionId)` → `GET /api/coach/sessions/{id}/messages`

### coach-chat-view
- 진입 시 `getSessionMessages`로 history fetch → `ChatBubble`로 hydrate
- "이전 대화를 불러오는 중…" / 에러 상태 분기 추가
- `SESSION_NOT_FOUND`, `FORBIDDEN` 인라인 메시지 매핑
- `sessionId` 변경 시 fetch 재실행 + 이전 요청 `AbortController.abort()`

### coach-sessions-sidebar (신규)
- 세션 목록 카드, ACTIVE/CLOSED 라벨, 현재 세션 강조
- "+ 새 세션" 버튼 → `/coach` 라우팅 (entry가 active or 신규 생성)
- 401 처리, 비어있는 상태/에러 상태

### layout/CSS
- `/coach/sessions/[sessionId]`를 `사이드바(260px) + chat(flex)` 2단 레이아웃으로 전환
- `coach-layout`, `coach-sidebar-*` 스타일 추가
- 720px 이하 모바일은 사이드바를 상단으로 이동 (max-height 160px)

## 검증

- `npx tsc --noEmit` ✅
- `npm run build` ✅

## Test plan

- [ ] 로그인 → `/coach` 진입 → 활성 세션 자동 redirect 확인
- [ ] 메시지 몇 개 보낸 뒤 새로고침 → 대화 복원되는지 확인
- [ ] 사이드바에서 다른 세션 클릭 → 채팅 영역 전환 + history 재로드
- [ ] "+ 새 세션" → `/coach` 이동 후 신규 세션 생성/active redirect
- [ ] 다른 사용자 sessionId 접근 시 인라인 FORBIDDEN 메시지

Related #292