### PR TITLE
fix(coach): Coach 세션 시작 시 placeholder snapshot self-heal

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
@@ -4,12 +4,16 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.context.entity.UserContextSnapshot;
 import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.context.service.ContextSnapshotPublisher;
 import com.back.coach.global.code.ChatSessionStatus;
 import com.back.coach.global.code.ContextType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,19 +21,38 @@ import java.util.List;
 @Service
 public class CoachSessionService {
 
+    private static final Logger log = LoggerFactory.getLogger(CoachSessionService.class);
+
+    // Publisher가 생성하는 진짜 PROFILE/PLAN payload는 최소 700+ bytes (profile + skills + github + diagnosis 합본).
+    // SQL seed / 빈 객체 placeholder는 250–300 bytes 영역. 안전한 gap 으로 500 byte 임계값 사용.
+    static final int PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD = 500;
+
     private final ChatSessionRepository chatSessionRepository;
     private final UserContextSnapshotRepository contextSnapshotRepository;
+    private final ContextSnapshotPublisher contextSnapshotPublisher;
+    private final TransactionTemplate transactionTemplate;
 
     public CoachSessionService(
             ChatSessionRepository chatSessionRepository,
-            UserContextSnapshotRepository contextSnapshotRepository
+            UserContextSnapshotRepository contextSnapshotRepository,
+            ContextSnapshotPublisher contextSnapshotPublisher,
+            TransactionTemplate transactionTemplate
     ) {
         this.chatSessionRepository = chatSessionRepository;
         this.contextSnapshotRepository = contextSnapshotRepository;
+        this.contextSnapshotPublisher = contextSnapshotPublisher;
+        this.transactionTemplate = transactionTemplate;
     }
 
-    @Transactional
+    // 트랜잭션 밖에서 self-heal publish 먼저 실행 후, 짧은 auto-tx로 세션 생성.
+    // self-heal: SQL seed / migration 등으로 placeholder snapshot이 남아 있는 경우
+    //            publisher가 트리거되지 않아 빈 컨텍스트로 세션이 시작되는 버그 방어.
     public ChatSession startSession(Long userId) {
+        refreshSnapshotsIfPlaceholder(userId);
+        return transactionTemplate.execute(status -> doStartSession(userId));
+    }
+
+    private ChatSession doStartSession(Long userId) {
         UserContextSnapshot profileSnapshot = contextSnapshotRepository
                 .findActiveByUserIdAndContextType(userId, ContextType.PROFILE)
                 .orElseThrow(() -> new ServiceException(
@@ -51,6 +74,35 @@ public class CoachSessionService {
         );
 
         return chatSessionRepository.save(session);
+    }
+
+    /**
+     * Placeholder snapshot이 이미 존재할 때만 publisher 호출 (self-heal).
+     * snapshot이 아예 없는 경우는 v1 입력 미완 = 사용자에게 SNAPSHOT_NOT_FOUND를 그대로 노출.
+     * outer tx 밖에서 동기 실행되므로 새 active snapshot이 즉시 가시화된다.
+     * payload가 풍부하면 skip → churn 0.
+     */
+    private void refreshSnapshotsIfPlaceholder(Long userId) {
+        contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE)
+                .filter(this::isPlaceholder)
+                .ifPresent(stale -> {
+                    log.info("PROFILE snapshot self-heal: publishing for userId={} (current bytes={})",
+                            userId, stale.getPayload() == null ? 0 : stale.getPayload().length());
+                    contextSnapshotPublisher.publishProfile(userId);
+                });
+
+        contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN)
+                .filter(this::isPlaceholder)
+                .ifPresent(stale -> {
+                    log.info("PLAN snapshot self-heal: publishing for userId={} (current bytes={})",
+                            userId, stale.getPayload() == null ? 0 : stale.getPayload().length());
+                    contextSnapshotPublisher.publishPlan(userId);
+                });
+    }
+
+    private boolean isPlaceholder(UserContextSnapshot snapshot) {
+        String payload = snapshot.getPayload();
+        return payload == null || payload.length() < PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -175,6 +175,51 @@ class CoachSessionServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("self-heal: PROFILE snapshot이 placeholder면 startSession이 publisher를 강제 호출해 새 version을 만든다")
+    void selfHealRefreshesPlaceholderProfileSnapshot() {
+        // placeholder payload(< 500 bytes) — SQL seed / migration 흔적 가정
+        seedSnapshot(ContextType.PROFILE, 1, "{}");
+        seedSnapshot(ContextType.PLAN, 1);
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        // self-heal 호출이 PROFILE을 새 version으로 발행했으므로, 세션은 v2 이상에 pin된다
+        assertThat(session.getProfileVersion()).isGreaterThan(1);
+        // PLAN은 padded(>=500 bytes)이므로 self-heal 안 됨 → v1 유지
+        assertThat(session.getRoadmapVersion()).isEqualTo(1);
+        // 새 PROFILE active snapshot이 placeholder가 아니어야 함 (이번 환경에선 publisher가 채워줌)
+        UserContextSnapshot active = contextSnapshotRepository
+                .findActiveByUserIdAndContextType(userId, ContextType.PROFILE)
+                .orElseThrow();
+        assertThat(active.getVersion()).isEqualTo(session.getProfileVersion());
+    }
+
+    @Test
+    @DisplayName("self-heal: PLAN snapshot이 placeholder면 startSession이 publisher를 강제 호출해 새 version을 만든다")
+    void selfHealRefreshesPlaceholderPlanSnapshot() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1, "{}");
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        assertThat(session.getProfileVersion()).isEqualTo(1);
+        assertThat(session.getRoadmapVersion()).isGreaterThan(1);
+    }
+
+    @Test
+    @DisplayName("self-heal: 두 snapshot 모두 풍부하면 publisher가 호출되지 않고 기존 version에 pin")
+    void noSelfHealWhenSnapshotsAlreadyRich() {
+        seedSnapshot(ContextType.PROFILE, 7);
+        seedSnapshot(ContextType.PLAN, 5);
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        // 풍부한 payload → publisher 안 돔 → seed한 version 그대로
+        assertThat(session.getProfileVersion()).isEqualTo(7);
+        assertThat(session.getRoadmapVersion()).isEqualTo(5);
+    }
+
+    @Test
     @DisplayName("getActiveSession: ACTIVE 세션이 없으면 SESSION_NOT_FOUND")
     void getActiveSessionThrowsWhenNoActive() {
         assertThatThrownBy(() -> coachSessionService.getActiveSession(userId))
@@ -208,9 +253,20 @@ class CoachSessionServiceIntegrationTest {
     }
 
     private void seedSnapshot(ContextType type, int version) {
+        // CoachSessionService.startSession은 payload < 500 bytes를 placeholder로 보고 self-heal publish를 트리거한다.
+        // 기존 테스트들은 "이 seed version으로 세션이 시작된다"를 검증하므로, 실데이터 사이즈를 흉내내는 padding payload를 사용한다.
+        seedSnapshot(type, version, paddedPayload(type));
+    }
+
+    private void seedSnapshot(ContextType type, int version, String payload) {
         UserContextSnapshot snapshot = UserContextSnapshot.create(
-                userId, type, version, "{}", Instant.now()
+                userId, type, version, payload, Instant.now()
         );
         contextSnapshotRepository.save(snapshot);
+    }
+
+    private static String paddedPayload(ContextType type) {
+        // 500 bytes 이상이면 publisher self-heal이 트리거되지 않는다 (PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD).
+        return "{\"contextType\":\"" + type.name() + "\",\"_padding\":\"" + "x".repeat(600) + "\"}";
     }
 }


### PR DESCRIPTION
## 무엇

Coach 세션 시작 시점에 active PROFILE/PLAN snapshot이 placeholder(payload < 500 bytes)면 `ContextSnapshotPublisher`를 동기 호출해 새 version을 발행하도록 self-heal 로직을 추가한다.

짧게말하면 그냥 (dev에서 테스트할 때) context로딩이 안 되는 케이스 방지하는 거. 혹시라도 시연에서 비슷한 경우가 일어나는 일 방지용

## 왜

오늘 dev 시연 중 다음 현상 재현:
- 사용자가 이미 profile/roadmap을 보유했지만, Coach가 컨텍스트를 인식하지 못하고 "진단을 받으세요 / 학습 계획이 없습니다" 같은 일반 답변만 반환

원인:
- SQL seed/마이그레이션으로 placeholder PROFILE/PLAN snapshot이 남아 있는 상태 (282/249 bytes의 빈 객체)
- v1 트리거(프로필 저장 / 진도 클릭 등)가 그 이후로 한 번도 안 돌아 `ContextSnapshotPublisher`가 발행 안 됨
- `CoachSessionService.startSession()`이 placeholder snapshot의 version에 pin → 세션 = 빈 컨텍스트 → Coach LLM은 빈 prompt body 받음

## 변경

| 파일 | 변경 |
|------|------|
| `CoachSessionService` | `@Transactional` 제거 → `TransactionTemplate`로 세션 저장 격리 (#283 패턴). 진입 시 `refreshSnapshotsIfPlaceholder` 호출 |
| `CoachSessionServiceIntegrationTest` | `seedSnapshot`에 padded payload(>500 bytes) 적용으로 기존 12개 회귀 보호 + self-heal 3건 신규 추가 |

`refreshSnapshotsIfPlaceholder` 동작:
- active PROFILE/PLAN snapshot 조회 (별 tx)
- 존재 + payload < 500 bytes → `publisher.publishProfile/Plan` 동기 호출 (outer tx 없으므로 afterCommit 훅 없이 즉시 실행)
- snapshot 부재 → skip (기존대로 `SNAPSHOT_NOT_FOUND` 노출, v1 입력 유도 의도 유지)
- 풍부한 payload → skip (churn 0)

임계값 500 bytes 휴리스틱:
- 진짜 publisher가 발행한 PROFILE = profile + skills + github finalTechProfile + diagnosisSummary 합본 → 최소 700+ bytes
- SQL seed/빈 객체 placeholder = 250–300 bytes 영역
- 안전한 gap

## 메모리 정책과의 호환

`snapshot_publish_churn_decision.md`에서 "lazy/always-on-read는 의미론 손실 큼, 도입 거절"이라고 정해뒀음.
본 PR은 lazy가 아니고, **event-on-write 정책 그대로 + placeholder 감지 시에만 safety net**으로 작동. 결정 준수.

## 검증

- `CoachSessionServiceIntegrationTest` 15/15 GREEN (기존 12 + 신규 3)
- 신규 케이스:
  - `selfHealRefreshesPlaceholderProfileSnapshot` — PROFILE placeholder → publisher 호출 → 새 version pin
  - `selfHealRefreshesPlaceholderPlanSnapshot` — PLAN placeholder도 동일
  - `noSelfHealWhenSnapshotsAlreadyRich` — 풍부한 snapshot이면 publisher 안 돔, seed version 그대로

## 관련
- #283 트랜잭션 분리 패턴과 일관 (TransactionTemplate)
-