### PR TITLE
feat(coach): Slice 10 프론트 — 대화 히스토리 복원 + 세션 목록 사이드바 (#292)

### DIFF
--- a/frontend/src/features/coach/coach-sessions-sidebar.tsx
+++ b/frontend/src/features/coach/coach-sessions-sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
-import { getSessions } from "@/features/coach/api";
+import { createSession, getSessions } from "@/features/coach/api";
 import { classifyCoachError } from "@/features/coach/coach-errors";
 import type { CoachSessionSummary } from "@/features/coach/types";
 import { isUnauthorizedError } from "@/lib/auth";
@@ -17,6 +17,7 @@ export function CoachSessionsSidebar({ activeSessionId }: SidebarProps) {
   const router = useRouter();
   const [sessions, setSessions] = useState<CoachSessionSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -47,9 +48,19 @@ export function CoachSessionsSidebar({ activeSessionId }: SidebarProps) {
         <button
           type="button"
           className="coach-sidebar-new"
-          onClick={() => router.push("/coach")}
+          disabled={creating}
+          onClick={async () => {
+            setCreating(true);
+            try {
+              const created = await createSession();
+              router.push(`/coach/sessions/${created.sessionId}`);
+            } catch (err) {
+              setError(classifyCoachError(err).title);
+              setCreating(false);
+            }
+          }}
         >
-          + 새 세션
+          {creating ? "생성 중…" : "+ 새 세션"}
         </button>
       </header>
 


### PR DESCRIPTION
## Summary
- 새로고침/탭 이동 시 대화 내역 복원: 진입 시 `getSessionMessages`로 history fetch → `ChatBubble`로 hydrate
- 세션 목록 사이드바(`CoachSessionsSidebar`) 신규 추가: ACTIVE/CLOSED 라벨, 현재 세션 강조, 모바일 반응형
- `/coach/sessions/[sessionId]` 레이아웃을 사이드바(260px) + 채팅(flex) 2단으로 전환




## Test plan
- [ ] 세션 진입 후 새로고침 시 대화 내역 복원 확인
- [ ] 사이드바에서 다른 세션 클릭 시 전환 확인
- [ ] 사이드바 "+ 새 세션" 버튼으로 실제 새 세션 생성 확인
- [ ] 720px 이하 모바일에서 사이드바 상단 배치 확인
- [ ] `npx tsc --noEmit` / `npm run lint` 통과


Coach가 로드맵이나 프로필 등 컨텍스트를 인식하지 못할 시 -> 프로필 재저장+로드맵 progress저장 -> 새 session 생성하면 잘 됩니다.
