### PR TITLE
fix(infra): Slice 5 self-call sync 실행 + zombie RUNNING recovery (#321)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisAsyncOrchestrator.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisAsyncOrchestrator.java
@@ -1,15 +1,9 @@
 package com.back.coach.domain.github.service;
 
-import com.back.coach.domain.job.service.JobHistoryEntry;
-import com.back.coach.domain.job.service.JobHistoryService;
 import com.back.coach.domain.job.service.JobStatusService;
-import com.back.coach.domain.job.service.JobStatusSnapshot;
 import com.back.coach.global.code.JobStatus;
-import com.back.coach.global.config.AsyncExecutorConfig;
-import com.back.coach.global.exception.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,12 +11,11 @@ import java.util.UUID;
 
 /**
  * GitHub 분석 파이프라인을 비동기 잡으로 감싼다.
- * 호출 흐름:
- *   1. submit() 호출 → jobId 생성, REQUESTED 상태 저장, runAnalysisAsync에 위임
- *   2. runAnalysisAsync() (analysisTaskExecutor 풀에서 실행) → RUNNING 갱신
- *   3. GithubAnalysisService.run() 실행
- *   4. 성공: SUCCEEDED + resultId = analysisId / 실패: FAILED + error 메시지
- *   5. finalized(SUCCEEDED/FAILED) 시 JobHistoryService에 이력 기록
+ *
+ *   1. submit() — jobId 생성, REQUESTED 저장, worker로 위임 후 즉시 return
+ *   2. worker.runAnalysisAsync() — Spring proxy에 의해 analysisTaskExecutor 풀에서 비동기 실행
+ *
+ * orchestrator/worker 분리는 self-call → proxy 우회로 동기 실행되는 문제(#321 버그 A)를 막기 위함.
  */
 @Service
 public class GithubAnalysisAsyncOrchestrator {
@@ -30,69 +23,25 @@ public class GithubAnalysisAsyncOrchestrator {
     private static final Logger log = LoggerFactory.getLogger(GithubAnalysisAsyncOrchestrator.class);
 
     private static final String STEP_REQUESTED = "REQUEST_ACCEPTED";
-    private static final String STEP_RUNNING = "RUN_ANALYSIS";
-    private static final String STEP_DONE = "ANALYSIS_DONE";
     public static final String JOB_TYPE = "GITHUB_ANALYSIS";
 
-    private final GithubAnalysisService analysisService;
     private final JobStatusService jobStatusService;
-    private final JobHistoryService jobHistoryService;
+    private final GithubAnalysisAsyncWorker worker;
 
     public GithubAnalysisAsyncOrchestrator(
-            GithubAnalysisService analysisService,
             JobStatusService jobStatusService,
-            JobHistoryService jobHistoryService
+            GithubAnalysisAsyncWorker worker
     ) {
-        this.analysisService = analysisService;
         this.jobStatusService = jobStatusService;
-        this.jobHistoryService = jobHistoryService;
+        this.worker = worker;
     }
 
     public String submit(Long userId, Long githubConnectionId, List<Long> selectedRepoIds, List<Long> coreRepoIds) {
         String jobId = UUID.randomUUID().toString();
         jobStatusService.save(userId, jobId, JobStatus.REQUESTED, STEP_REQUESTED);
-        runAnalysisAsync(userId, jobId, githubConnectionId, selectedRepoIds, coreRepoIds);
+        log.debug("Analysis job submitted jobId={} userId={} repos={}", jobId, userId, selectedRepoIds);
+        // 외부 빈 호출 — Spring proxy 통과 → 진짜 @Async 발동
+        worker.runAnalysisAsync(userId, jobId, githubConnectionId, selectedRepoIds, coreRepoIds);
         return jobId;
-    }
-
-    @Async(AsyncExecutorConfig.ANALYSIS_TASK_EXECUTOR)
-    public void runAnalysisAsync(
-            Long userId,
-            String jobId,
-            Long githubConnectionId,
-            List<Long> selectedRepoIds,
-            List<Long> coreRepoIds
-    ) {
-        try {
-            jobStatusService.save(userId, jobId, JobStatus.RUNNING, STEP_RUNNING);
-            GithubAnalysisService.GithubAnalysisResult result =
-                    analysisService.run(userId, githubConnectionId, selectedRepoIds, coreRepoIds);
-            JobStatusSnapshot snapshot = jobStatusService.saveSuccess(
-                    userId, jobId, STEP_DONE, String.valueOf(result.id()));
-            recordHistorySafely(userId, snapshot);
-            log.debug("Analysis job succeeded jobId={} userId={} analysisId={}", jobId, userId, result.id());
-        } catch (ServiceException e) {
-            log.warn("Analysis job failed jobId={} userId={} code={} message={}",
-                    jobId, userId, e.getErrorCode(), e.getMessage());
-            JobStatusSnapshot snapshot = jobStatusService.saveFailure(
-                    userId, jobId, STEP_RUNNING, e.getMessage());
-            recordHistorySafely(userId, snapshot);
-        } catch (Exception e) {
-            log.warn("Analysis job failed jobId={} userId={} type={} message={}",
-                    jobId, userId, e.getClass().getSimpleName(), e.getMessage());
-            JobStatusSnapshot snapshot = jobStatusService.saveFailure(
-                    userId, jobId, STEP_RUNNING, "분석 중 예기치 못한 오류가 발생했습니다.");
-            recordHistorySafely(userId, snapshot);
-        }
-    }
-
-    private void recordHistorySafely(Long userId, JobStatusSnapshot snapshot) {
-        try {
-            JobHistoryEntry entry = JobHistoryService.from(JOB_TYPE, snapshot);
-            jobHistoryService.record(userId, entry);
-        } catch (Exception e) {
-            log.warn("JobHistory record failed userId={} jobId={} reason={}",
-                    userId, snapshot.jobId(), e.getMessage());
-        }
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisAsyncWorker.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisAsyncWorker.java
@@ -1,0 +1,86 @@
+package com.back.coach.domain.github.service;
+
+import com.back.coach.domain.job.service.JobHistoryEntry;
+import com.back.coach.domain.job.service.JobHistoryService;
+import com.back.coach.domain.job.service.JobStatusService;
+import com.back.coach.domain.job.service.JobStatusSnapshot;
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.global.config.AsyncExecutorConfig;
+import com.back.coach.global.exception.ServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * `@Async` 자기-호출(self-call)이 Spring AOP proxy를 우회해 동기 실행되는 문제를 막기 위해
+ * orchestrator와 worker를 별도 빈으로 분리한다.
+ * orchestrator.submit() → worker.runAnalysisAsync() (외부 호출 → proxy 적용 → 진짜 비동기 실행).
+ */
+@Service
+public class GithubAnalysisAsyncWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(GithubAnalysisAsyncWorker.class);
+
+    private static final String STEP_RUNNING = "RUN_ANALYSIS";
+    private static final String STEP_DONE = "ANALYSIS_DONE";
+
+    private final GithubAnalysisService analysisService;
+    private final JobStatusService jobStatusService;
+    private final JobHistoryService jobHistoryService;
+    private final String jobType;
+
+    public GithubAnalysisAsyncWorker(
+            GithubAnalysisService analysisService,
+            JobStatusService jobStatusService,
+            JobHistoryService jobHistoryService
+    ) {
+        this.analysisService = analysisService;
+        this.jobStatusService = jobStatusService;
+        this.jobHistoryService = jobHistoryService;
+        this.jobType = GithubAnalysisAsyncOrchestrator.JOB_TYPE;
+    }
+
+    @Async(AsyncExecutorConfig.ANALYSIS_TASK_EXECUTOR)
+    public void runAnalysisAsync(
+            Long userId,
+            String jobId,
+            Long githubConnectionId,
+            List<Long> selectedRepoIds,
+            List<Long> coreRepoIds
+    ) {
+        try {
+            jobStatusService.save(userId, jobId, JobStatus.RUNNING, STEP_RUNNING);
+            GithubAnalysisService.GithubAnalysisResult result =
+                    analysisService.run(userId, githubConnectionId, selectedRepoIds, coreRepoIds);
+            JobStatusSnapshot snapshot = jobStatusService.saveSuccess(
+                    userId, jobId, STEP_DONE, String.valueOf(result.id()));
+            recordHistorySafely(userId, snapshot);
+            log.debug("Analysis job succeeded jobId={} userId={} analysisId={}", jobId, userId, result.id());
+        } catch (ServiceException e) {
+            log.warn("Analysis job failed jobId={} userId={} code={} message={}",
+                    jobId, userId, e.getErrorCode(), e.getMessage());
+            JobStatusSnapshot snapshot = jobStatusService.saveFailure(
+                    userId, jobId, STEP_RUNNING, e.getMessage());
+            recordHistorySafely(userId, snapshot);
+        } catch (Exception e) {
+            log.warn("Analysis job failed jobId={} userId={} type={} message={}",
+                    jobId, userId, e.getClass().getSimpleName(), e.getMessage());
+            JobStatusSnapshot snapshot = jobStatusService.saveFailure(
+                    userId, jobId, STEP_RUNNING, "분석 중 예기치 못한 오류가 발생했습니다.");
+            recordHistorySafely(userId, snapshot);
+        }
+    }
+
+    private void recordHistorySafely(Long userId, JobStatusSnapshot snapshot) {
+        try {
+            JobHistoryEntry entry = JobHistoryService.from(jobType, snapshot);
+            jobHistoryService.record(userId, entry);
+        } catch (Exception e) {
+            log.warn("JobHistory record failed userId={} jobId={} reason={}",
+                    userId, snapshot.jobId(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/back/coach/domain/job/service/JobRecoveryService.java
+++ b/backend/src/main/java/com/back/coach/domain/job/service/JobRecoveryService.java
@@ -1,0 +1,139 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 백엔드 시작 시 zombie 잡(이전 인스턴스 종료 시 RUNNING/REQUESTED 상태로 남은 것)을 정리한다.
+ *
+ * 시나리오:
+ *   1. 잡 처리 중 백엔드 crash/재시작
+ *   2. in-memory @Async worker thread는 종료됨
+ *   3. Redis 잡 상태는 RUNNING/REQUESTED 그대로 (24h TTL까지 유지)
+ *   4. 사용자에게 "영원히 진행 중"으로 표시됨
+ *
+ * 해결: ApplicationReadyEvent 시점에 RUNNING/REQUESTED 잡을 모두 FAILED("backend restarted")로 마킹.
+ * 결과는 잡 이력(JobHistoryService)에도 기록되어 사용자가 "재시작으로 실패" 메시지를 확인할 수 있다.
+ *
+ * 가정: 단일 백엔드 인스턴스. 멀티 인스턴스 환경에선 다른 인스턴스가 처리 중인 잡까지 FAILED로
+ * 만들 위험 있음 → leader election + lease 기반으로 확장 필요 (현재 범위 밖).
+ */
+@Service
+public class JobRecoveryService {
+
+    private static final Logger log = LoggerFactory.getLogger(JobRecoveryService.class);
+    private static final String SCAN_PATTERN = JobStatusService.KEY_PREFIX + "*";
+    private static final int SCAN_BATCH = 100;
+    static final String RECOVERY_STEP = "RECOVERED_AFTER_RESTART";
+    static final String RECOVERY_ERROR = "백엔드 재시작으로 작업이 중단되었습니다. 다시 시도해주세요.";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final JobStatusService jobStatusService;
+    private final JobHistoryService jobHistoryService;
+    private final boolean recoveryEnabled;
+
+    public JobRecoveryService(
+            StringRedisTemplate redisTemplate,
+            ObjectMapper objectMapper,
+            JobStatusService jobStatusService,
+            JobHistoryService jobHistoryService,
+            @Value("${coach.job.recovery.enabled:true}") boolean recoveryEnabled
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+        this.jobStatusService = jobStatusService;
+        this.jobHistoryService = jobHistoryService;
+        this.recoveryEnabled = recoveryEnabled;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void recoverStaleJobsOnStartup() {
+        if (!recoveryEnabled) {
+            log.info("Job recovery disabled by config");
+            return;
+        }
+        log.info("Job recovery scan started (pattern={})", SCAN_PATTERN);
+        int scanned = 0;
+        int recovered = 0;
+        List<KeyEntry> stale = collectStale();
+        scanned = stale.size();
+        for (KeyEntry entry : stale) {
+            try {
+                JobStatusSnapshot failed = jobStatusService.saveFailure(
+                        entry.userId,
+                        entry.snapshot.jobId(),
+                        RECOVERY_STEP,
+                        RECOVERY_ERROR
+                );
+                jobHistoryService.record(entry.userId, JobHistoryService.from("UNKNOWN", failed));
+                recovered++;
+            } catch (Exception e) {
+                log.warn("Job recovery failed for key={} reason={}", entry.key, e.getMessage());
+            }
+        }
+        log.info("Job recovery scan completed: scanned={}, recovered={}", scanned, recovered);
+    }
+
+    private List<KeyEntry> collectStale() {
+        List<KeyEntry> result = new ArrayList<>();
+        ScanOptions options = ScanOptions.scanOptions().match(SCAN_PATTERN).count(SCAN_BATCH).build();
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                String key = cursor.next();
+                Optional<KeyEntry> parsed = parseEntry(key);
+                parsed.filter(e -> isStale(e.snapshot.status())).ifPresent(result::add);
+            }
+        } catch (Exception e) {
+            log.warn("Job recovery SCAN failed reason={}", e.getMessage());
+        }
+        return result;
+    }
+
+    private Optional<KeyEntry> parseEntry(String key) {
+        // key shape: job:status:{userId}:{jobId}
+        String suffix = key.substring(JobStatusService.KEY_PREFIX.length());
+        int sep = suffix.indexOf(':');
+        if (sep < 0) {
+            return Optional.empty();
+        }
+        Long userId;
+        try {
+            userId = Long.parseLong(suffix.substring(0, sep));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+        String payload = redisTemplate.opsForValue().get(key);
+        if (payload == null) {
+            return Optional.empty();
+        }
+        try {
+            JobStatusSnapshot snapshot = objectMapper.readValue(payload, JobStatusSnapshot.class);
+            return Optional.of(new KeyEntry(key, userId, snapshot));
+        } catch (JsonProcessingException e) {
+            log.warn("Job recovery payload deserialize failed key={} reason={}", key, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private boolean isStale(JobStatus status) {
+        return status == JobStatus.REQUESTED || status == JobStatus.RUNNING;
+    }
+
+    private record KeyEntry(String key, Long userId, JobStatusSnapshot snapshot) {
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisAsyncOrchestratorIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisAsyncOrchestratorIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.back.coach.domain.github.service;
+
+import com.back.coach.domain.job.service.JobStatusService;
+import com.back.coach.domain.job.service.JobStatusSnapshot;
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * orchestrator/worker 분리가 실제로 비동기로 동작하는지 검증.
+ * (Self-call 버그였다면 submit() 호출이 worker.run을 block했을 것이다.)
+ */
+@IntegrationTest
+class GithubAnalysisAsyncOrchestratorIntegrationTest {
+
+    private static final Long USER_ID = 9_999_002L;
+
+    @Autowired
+    private GithubAnalysisAsyncOrchestrator orchestrator;
+
+    @Autowired
+    private JobStatusService jobStatusService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private GithubAnalysisService analysisService;
+
+    @AfterEach
+    void cleanUp() {
+        redisTemplate.delete(redisTemplate.keys("job:status:" + USER_ID + ":*"));
+    }
+
+    @Test
+    @DisplayName("submit()은 worker 실행을 기다리지 않고 즉시 return한다 — 진짜 async 검증")
+    void submitReturnsImmediatelyWhileWorkerRunsAsync() throws Exception {
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch workerReleased = new CountDownLatch(1);
+        AtomicLong submitElapsedMs = new AtomicLong(-1);
+
+        // analysisService.run을 1초 block하도록 stub. submit이 이를 기다리면 sync, 안 기다리면 async.
+        given(analysisService.run(anyLong(), anyLong(), anyList(), anyList()))
+                .willAnswer(invocation -> {
+                    workerStarted.countDown();
+                    workerReleased.await(5, TimeUnit.SECONDS);
+                    return new GithubAnalysisService.GithubAnalysisResult(
+                            1L, 1, null, "summary", java.time.Instant.now(), null
+                    );
+                });
+
+        long startMs = System.currentTimeMillis();
+        String jobId = orchestrator.submit(USER_ID, 1L, List.of(1L), List.of(1L));
+        submitElapsedMs.set(System.currentTimeMillis() - startMs);
+
+        // submit은 매우 빠르게 (worker가 끝나기 전에) return해야 함
+        assertThat(submitElapsedMs.get())
+                .as("submit should return immediately (true async); was %d ms", submitElapsedMs.get())
+                .isLessThan(500L);
+        assertThat(jobId).isNotBlank();
+
+        // worker는 별도 thread에서 진행 중이어야 함
+        assertThat(workerStarted.await(2, TimeUnit.SECONDS))
+                .as("worker should start in background thread")
+                .isTrue();
+
+        // job 상태는 REQUESTED → RUNNING 으로 전이 가능 (worker가 첫 save를 했을 수 있음)
+        Optional<JobStatusSnapshot> snapshot = jobStatusService.find(USER_ID, jobId);
+        assertThat(snapshot).isPresent();
+        assertThat(snapshot.get().status())
+                .isIn(JobStatus.REQUESTED, JobStatus.RUNNING);
+
+        // worker 해제 후 SUCCEEDED 도달까지 대기
+        workerReleased.countDown();
+        boolean reachedTerminal = waitForTerminal(jobId, 10_000);
+        assertThat(reachedTerminal).as("worker should reach terminal state").isTrue();
+    }
+
+    private boolean waitForTerminal(String jobId, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            Optional<JobStatusSnapshot> snapshot = jobStatusService.find(USER_ID, jobId);
+            if (snapshot.isPresent()) {
+                JobStatus status = snapshot.get().status();
+                if (status == JobStatus.SUCCEEDED || status == JobStatus.FAILED) {
+                    return true;
+                }
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        return false;
+    }
+}

--- a/backend/src/test/java/com/back/coach/domain/job/service/JobRecoveryServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/job/service/JobRecoveryServiceIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.back.coach.domain.job.service;
+
+import com.back.coach.global.code.JobStatus;
+import com.back.coach.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class JobRecoveryServiceIntegrationTest {
+
+    private static final Long USER_ID = 9_999_001L;
+
+    @Autowired
+    private JobRecoveryService jobRecoveryService;
+
+    @Autowired
+    private JobStatusService jobStatusService;
+
+    @Autowired
+    private JobHistoryService jobHistoryService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private long jobCounter;
+
+    @BeforeEach
+    void resetCounter() {
+        jobCounter = System.nanoTime();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        redisTemplate.delete(redisTemplate.keys(JobStatusService.KEY_PREFIX + "*"));
+        redisTemplate.delete(JobHistoryService.key(USER_ID));
+    }
+
+    @Test
+    @DisplayName("RUNNING 잡은 startup recovery에서 FAILED로 마킹된다")
+    void runningJobRecoveredToFailed() {
+        String jobId = nextJobId();
+        jobStatusService.save(USER_ID, jobId, JobStatus.RUNNING, "RUN_ANALYSIS");
+
+        jobRecoveryService.recoverStaleJobsOnStartup();
+
+        Optional<JobStatusSnapshot> after = jobStatusService.find(USER_ID, jobId);
+        assertThat(after).isPresent();
+        assertThat(after.get().status()).isEqualTo(JobStatus.FAILED);
+        assertThat(after.get().currentStep()).isEqualTo(JobRecoveryService.RECOVERY_STEP);
+        assertThat(after.get().error()).isEqualTo(JobRecoveryService.RECOVERY_ERROR);
+    }
+
+    @Test
+    @DisplayName("REQUESTED 잡도 FAILED로 마킹된다")
+    void requestedJobRecoveredToFailed() {
+        String jobId = nextJobId();
+        jobStatusService.save(USER_ID, jobId, JobStatus.REQUESTED, "REQUEST_ACCEPTED");
+
+        jobRecoveryService.recoverStaleJobsOnStartup();
+
+        Optional<JobStatusSnapshot> after = jobStatusService.find(USER_ID, jobId);
+        assertThat(after).isPresent();
+        assertThat(after.get().status()).isEqualTo(JobStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("이미 SUCCEEDED/FAILED 인 잡은 건드리지 않는다")
+    void terminalJobUntouched() {
+        String successJobId = nextJobId();
+        String failedJobId = nextJobId();
+        jobStatusService.saveSuccess(USER_ID, successJobId, "ANALYSIS_DONE", "42");
+        jobStatusService.saveFailure(USER_ID, failedJobId, "RUN_ANALYSIS", "기존 실패");
+
+        jobRecoveryService.recoverStaleJobsOnStartup();
+
+        Optional<JobStatusSnapshot> success = jobStatusService.find(USER_ID, successJobId);
+        Optional<JobStatusSnapshot> failed = jobStatusService.find(USER_ID, failedJobId);
+        assertThat(success).hasValueSatisfying(s -> {
+            assertThat(s.status()).isEqualTo(JobStatus.SUCCEEDED);
+            assertThat(s.resultId()).isEqualTo("42");
+        });
+        assertThat(failed).hasValueSatisfying(s -> {
+            assertThat(s.status()).isEqualTo(JobStatus.FAILED);
+            assertThat(s.error()).isEqualTo("기존 실패");
+        });
+    }
+
+    @Test
+    @DisplayName("recovery된 잡은 history에도 기록된다")
+    void recoveredJobAppendedToHistory() {
+        String jobId = nextJobId();
+        jobStatusService.save(USER_ID, jobId, JobStatus.RUNNING, "RUN_ANALYSIS");
+
+        jobRecoveryService.recoverStaleJobsOnStartup();
+
+        var history = jobHistoryService.findRecent(USER_ID, 10);
+        assertThat(history).extracting(JobHistoryEntry::jobId).contains(jobId);
+        JobHistoryEntry recovered = history.stream()
+                .filter(e -> e.jobId().equals(jobId))
+                .findFirst().orElseThrow();
+        assertThat(recovered.status()).isEqualTo(JobStatus.FAILED);
+        assertThat(recovered.error()).isEqualTo(JobRecoveryService.RECOVERY_ERROR);
+    }
+
+    private String nextJobId() {
+        return "recovery-test-" + (++jobCounter);
+    }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2368,3 +2368,93 @@ a {
   }
 }
 
+
+/* === Analysis Progress (#321) === */
+.analysis-progress {
+  max-width: 640px;
+  margin: 32px auto;
+  padding: 32px;
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 12px;
+}
+.analysis-progress-header { margin-bottom: 24px; }
+.analysis-progress-title { font-size: 1.25rem; font-weight: 600; margin: 0 0 8px; }
+.analysis-progress-subtitle { color: var(--text-muted, #6b7280); margin: 0; }
+.analysis-progress-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.analysis-progress-step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: background 120ms;
+}
+.analysis-progress-step[data-status="done"] { color: #16a34a; }
+.analysis-progress-step[data-status="active"] {
+  background: #eff6ff;
+  font-weight: 600;
+}
+.analysis-progress-step[data-status="active"] .analysis-progress-step-dot {
+  background: #2563eb;
+  color: #fff;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+.analysis-progress-step[data-status="pending"] { color: var(--text-muted, #6b7280); }
+.analysis-progress-step-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-muted, #f3f4f6);
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.analysis-progress-step[data-status="done"] .analysis-progress-step-dot {
+  background: #16a34a;
+  color: #fff;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+.analysis-progress-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  padding: 16px;
+  background: var(--bg-muted, #f9fafb);
+  border-radius: 8px;
+  margin: 0 0 16px;
+}
+.analysis-progress-meta div { margin: 0; }
+.analysis-progress-meta dt {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6b7280);
+  margin: 0 0 4px;
+}
+.analysis-progress-meta dd {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+.analysis-progress-hint {
+  font-size: 0.875rem;
+  color: var(--text-muted, #6b7280);
+  margin: 0;
+  padding: 12px 16px;
+  background: #fffbeb;
+  border-left: 3px solid #f59e0b;
+  border-radius: 4px;
+}

--- a/frontend/src/features/github-connection/analysis-progress-view.tsx
+++ b/frontend/src/features/github-connection/analysis-progress-view.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type AnalysisProgressViewProps = {
+  selectedCount: number;
+  currentStep: string | null;
+  startedAtMs: number;
+};
+
+type StageId = "REQUESTED" | "METADATA" | "ANALYSIS" | "DONE";
+
+const STAGE_ORDER: StageId[] = ["REQUESTED", "METADATA", "ANALYSIS", "DONE"];
+
+const STAGE_LABEL: Record<StageId, string> = {
+  REQUESTED: "잡 시작",
+  METADATA: "저장소 메타데이터 수집",
+  ANALYSIS: "코드 분석 + 종합",
+  DONE: "완료"
+};
+
+// 백엔드 `currentStep` 문자열 → 사용자용 스테이지 매핑
+function mapStep(step: string | null): StageId {
+  if (!step) return "REQUESTED";
+  if (step === "REQUEST_ACCEPTED") return "REQUESTED";
+  if (step === "RUN_ANALYSIS") return "ANALYSIS";
+  if (step === "ANALYSIS_DONE") return "DONE";
+  if (step === "FETCH_METADATA") return "METADATA";
+  return "ANALYSIS";
+}
+
+// 선택 repo 수 기준 대략적 예상 시간 (실측: 2 repos ≈ 9분, 호출당 ~100s 평균)
+// 호출 수 = N triage + N summary + 1 synthesis = 2N + 1
+function estimateMinutes(repoCount: number) {
+  const llmCalls = 2 * repoCount + 1;
+  const avgSeconds = 100;
+  return Math.round((llmCalls * avgSeconds) / 60);
+}
+
+function formatElapsed(ms: number) {
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}분 ${String(sec).padStart(2, "0")}초`;
+}
+
+export function AnalysisProgressView({
+  selectedCount,
+  currentStep,
+  startedAtMs
+}: AnalysisProgressViewProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const elapsedMs = now - startedAtMs;
+  const stage = mapStep(currentStep);
+  const stageIndex = STAGE_ORDER.indexOf(stage);
+  const estimate = useMemo(() => estimateMinutes(selectedCount), [selectedCount]);
+
+  return (
+    <section className="analysis-progress" aria-live="polite">
+      <header className="analysis-progress-header">
+        <h2 className="analysis-progress-title">GitHub 분석 진행 중</h2>
+        <p className="analysis-progress-subtitle">
+          선택한 저장소 {selectedCount}개를 분석하고 있어요. 예상 소요 시간 약 {estimate}분.
+        </p>
+      </header>
+
+      <ol className="analysis-progress-steps" aria-label="분석 단계">
+        {STAGE_ORDER.map((id, index) => {
+          const status =
+            index < stageIndex ? "done" : index === stageIndex ? "active" : "pending";
+          return (
+            <li key={id} className="analysis-progress-step" data-status={status}>
+              <span className="analysis-progress-step-dot" aria-hidden="true">
+                {status === "done" ? "✓" : index + 1}
+              </span>
+              <span className="analysis-progress-step-label">{STAGE_LABEL[id]}</span>
+            </li>
+          );
+        })}
+      </ol>
+
+      <dl className="analysis-progress-meta">
+        <div>
+          <dt>경과 시간</dt>
+          <dd>{formatElapsed(elapsedMs)}</dd>
+        </div>
+        <div>
+          <dt>현재 단계</dt>
+          <dd>{STAGE_LABEL[stage]}</dd>
+        </div>
+      </dl>
+
+      <p className="analysis-progress-hint">
+        이 페이지를 닫아도 분석은 계속 진행됩니다. 결과는{" "}
+        <strong>분석 목록</strong>에서 확인할 수 있어요.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -11,6 +11,7 @@ import {
   submitAnalysisAsync
 } from "@/features/github-connection/api";
 import type { Repository } from "@/features/github-connection/types";
+import { AnalysisProgressView } from "@/features/github-connection/analysis-progress-view";
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 
@@ -20,11 +21,17 @@ type ViewState =
   | { status: "loading-repos" }
   | { status: "auth-required" }
   | { status: "ready"; repos: Repository[] }
-  | { status: "analyzing"; currentStep: string | null }
+  | {
+      status: "analyzing";
+      currentStep: string | null;
+      selectedCount: number;
+      startedAtMs: number;
+    }
   | { status: "error"; message: string };
 
 const POLL_INTERVAL_MS = 2000;
-const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+// e2e 실측: 2 repos ≈ 9분, 5 repos ≈ 20분 추정. 사용자가 페이지 닫아도 백그라운드 진행됨.
+const POLL_TIMEOUT_MS = 20 * 60 * 1000;
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof ApiError) return error.message;
@@ -103,7 +110,9 @@ export function GithubConnectionView() {
 
   async function handleAnalyze() {
     if (!connectionId || selected.size === 0) return;
-    setState({ status: "analyzing", currentStep: null });
+    const startedAtMs = Date.now();
+    const selectedCount = selected.size;
+    setState({ status: "analyzing", currentStep: null, selectedCount, startedAtMs });
     try {
       const ids = Array.from(selected);
       const { jobId } = await submitAnalysisAsync(connectionId, ids, ids);
@@ -123,11 +132,17 @@ export function GithubConnectionView() {
           });
           return;
         }
-        setState({ status: "analyzing", currentStep: snapshot.currentStep });
+        setState({
+          status: "analyzing",
+          currentStep: snapshot.currentStep,
+          selectedCount,
+          startedAtMs
+        });
       }
       setState({
         status: "error",
-        message: "분석이 너무 오래 걸려 대기를 중단했습니다. 잠시 후 결과를 확인해주세요."
+        message:
+          "분석이 예상보다 오래 걸려 대기를 중단했습니다. 잠시 후 분석 목록에서 결과를 확인해주세요."
       });
     } catch (err) {
       if (isUnauthorizedError(err)) {
@@ -161,10 +176,11 @@ export function GithubConnectionView() {
   }
 
   if (state.status === "analyzing") {
-    const stepLabel = state.currentStep ? ` (${state.currentStep})` : "";
     return (
-      <StatePanel
-        message={`GitHub 분석 중입니다. 잠시 기다려주세요...${stepLabel}`}
+      <AnalysisProgressView
+        selectedCount={state.selectedCount}
+        currentStep={state.currentStep}
+        startedAtMs={state.startedAtMs}
       />
     );
   }


### PR DESCRIPTION
## 무엇

Slice 5 (Redis 기반 비동기 잡, [#298](../pull/298) 머지) 운영에서 2026-05-12 dev 세션 실측 중 발견된 두 버그를 fix + 프론트 대기 UX 보강.

이슈: [#321](../issues/321)

## 변경

### 백엔드 — Self-call sync 실행 문제 fix

`GithubAnalysisAsyncOrchestrator`가 같은 클래스의 `runAnalysisAsync()`를 self-call → Spring AOP proxy 우회 → 동기 실행되던 문제.

**분리**:
- `GithubAnalysisAsyncOrchestrator` — submit 전용 (jobId 생성, REQUESTED 저장, worker 위임 후 즉시 return)
- `GithubAnalysisAsyncWorker` — `@Async(analysisTaskExecutor)` 실제 실행 빈
- orchestrator → worker 외부 호출 = Spring proxy 통과 = 진짜 비동기

### 백엔드 — Zombie RUNNING recovery

백엔드 재시작 시 in-memory worker thread 종료 → Redis RUNNING 상태 24h TTL까지 유지되던 문제.

**신규 `JobRecoveryService`**:
- `@EventListener(ApplicationReadyEvent.class)` 훅
- Redis SCAN으로 `job:status:*` 순회 → `RUNNING`/`REQUESTED` 상태인 잡 → `FAILED("백엔드 재시작으로 작업이 중단되었습니다. 다시 시도해주세요.")` 마킹
- `JobHistoryService`에도 동일 entry 추가
- 단일 백엔드 인스턴스 가정. 멀티 인스턴스는 leader election 필요 (현재 범위 밖)
- 비활성화 옵션: `coach.job.recovery.enabled=false`

### 프론트 — 대기 UX 보강

기존 \"GitHub 분석 중입니다. 잠시 기다려주세요... (RUN_ANALYSIS)\" 정적 메시지를 진행 표시 컴포넌트로 교체.

**신규 `AnalysisProgressView`**:
- 4단계 진행 표시 (잡 시작 → 메타데이터 수집 → 분석/종합 → 완료) + 현재 단계 강조 + pulse 애니메이션
- 예상 소요 시간 (선택 repo 수 기반 추정: \"약 N분 소요됩니다\")
- 경과 시간 카운터 (분:초)
- \"이 페이지를 닫아도 분석은 계속 진행됩니다\" 안내
- 폴링 타임아웃 5분 → 20분 (실측: 2 repos ≈ 9분, 5 repos ≈ 20분 추정)

## 검증

- `JobRecoveryServiceIntegrationTest` — 4 케이스 GREEN (RUNNING→FAILED, REQUESTED→FAILED, SUCCEEDED/FAILED untouched, history 기록 검증)
- `GithubAnalysisAsyncOrchestratorIntegrationTest` — submit이 worker 실행 기다리지 않고 500ms 이내 return 검증 (1 케이스, real Spring context)
- 기존 fast test 333개 회귀 GREEN
- frontend `tsc --noEmit` 통과

## 메모

- 본 PR은 fix만. 별도 PR 후보:
  - System role 분리 5개 PromptBuilder 적용 (per-LLM -64% 잠재, `docs/32_prompt_tuning_log.md`)
  - `parallelAnalysisExecutor` 활용 (repo 단위 병렬화) — Slice 5 본 PR 미반영분
- `CoachMessageService` 동시 수정분(prompt 보강)은 본 PR에 포함되지 않음 (별도 작업)

## 관련

- #298 (merged) — Slice 5 본 PR
- #321 (open, 본 PR이 close 예정)
- 2026-05-12 dev 세션 e2e 실측에서 두 버그 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)