### PR TITLE
test(github-analysis): E2E WireMock catch-all stub으로 매칭 실패 즉시 감지 (#294)

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/GithubAnalysisE2eTest.java
@@ -74,6 +74,16 @@ class GithubAnalysisE2eTest extends ApiTestBase {
         String unique = UUID.randomUUID().toString().substring(0, 8);
         user = userRepository.save(User.signupFromOAuth(AuthProvider.GITHUB, "gh-" + unique, "e2e-" + unique + "@test.com"));
         authHeader = JwtAuthHelper.bearerToken(jwtTokenProvider, user.getId());
+
+        // WireMock stubs from previous test bleed into the next via static singleton.
+        // Reset + register a low-priority catch-all so an unmatched prompt fails loudly.
+        wireMock.resetAll();
+        wireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/v1/chat/completions")
+                .atPriority(10)
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\":\"E2E: no stubLlm() matched the prompt — update GithubAnalysisE2eTest stubs\"}")));
     }
 
     @Test
@@ -213,6 +223,7 @@ class GithubAnalysisE2eTest extends ApiTestBase {
 
     private void stubLlm(String promptContains, String content) {
         wireMock.stubFor(com.github.tomakehurst.wiremock.client.WireMock.post("/v1/chat/completions")
+                .atPriority(5)
                 .withRequestBody(matchingJsonPath("$.messages[0].content",
                         new com.github.tomakehurst.wiremock.matching.RegexPattern("(?s).*" + promptContains + ".*")))
                 .willReturn(aResponse()


### PR DESCRIPTION
Closes #294 

## Summary
- `stubLlm` 미매칭 시 WireMock이 404를 반환해도 분석이 빈 채로 끝나 원인 추적이 어려웠던 문제 해결
- 우선순위 10의 catch-all `/v1/chat/completions` stub 추가 → 매칭 실패 시 500 + 명시 메시지로 즉시 실패
- 기존 `stubLlm` 호출에 `.atPriority(5)` 명시로 catch-all과의 우선순위 관계 명확화
- `@BeforeEach`에 `wireMock.resetAll()` 추가 → 테스트 간 stub 누수 방지

## Test plan
- [ ] `./gradlew integrationTest --tests "*GithubAnalysisE2eTest*"` 통과 확인
- [ ] stubLlm 매칭 실패 시나리오에서 500 + 명시 메시지로 즉시 실패하는지 확인
