### PR TITLE
feat(llm): 분석 파이프라인 LLM 호출에 system role 분리 적용

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
@@ -20,6 +20,7 @@ import com.back.coach.domain.user.entity.UserSkill;
 import com.back.coach.domain.user.repository.UserProfileRepository;
 import com.back.coach.domain.user.repository.UserSkillRepository;
 import com.back.coach.external.llm.LlmClient;
+import com.back.coach.external.llm.PromptDirectives;
 import com.back.coach.global.code.SkillSourceType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -105,7 +106,8 @@ public class DiagnosisCommandService {
                 inputs.githubAnalysisPayload().finalTechProfile()
         ));
         DiagnosisResponseParser.DiagnosisResult diagnosisResult =
-                diagnosisResponseParser.parse(llmClient.complete(prompt));
+                diagnosisResponseParser.parse(
+                        llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt));
         DiagnosisPayload diagnosisPayload = new DiagnosisPayload(
                 diagnosisResult.missingSkills(),
                 diagnosisResult.strengths(),

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -17,6 +17,7 @@ import com.back.coach.domain.github.service.synthesis.SynthesisPromptBuilder;
 import com.back.coach.domain.github.service.synthesis.SynthesisResponseParser;
 import com.back.coach.domain.github.service.triage.ChampionTriageService;
 import com.back.coach.external.llm.LlmClient;
+import com.back.coach.external.llm.PromptDirectives;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -134,7 +135,7 @@ public class GithubAnalysisService {
                     core.primaryLanguage(), resolved);
             summaryPromptBytes += summaryPrompt.getBytes().length;
             long summaryStartMs = System.currentTimeMillis();
-            String summaryResponse = llmClient.complete(summaryPrompt);
+            String summaryResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, summaryPrompt);
             summaryElapsedMs += System.currentTimeMillis() - summaryStartMs;
             repoSummaries.add(summaryResponseParser.parse(summaryResponse));
             long repoElapsedMs = System.currentTimeMillis() - repoStartMs;
@@ -146,7 +147,7 @@ public class GithubAnalysisService {
         String synthesisPrompt = synthesisPromptBuilder.build(inputs.signals(), repoSummaries);
         int synthesisPromptBytes = synthesisPrompt.getBytes().length;
         log.debug("Synthesis prompt built: bytes={}", synthesisPromptBytes);
-        String synthesisResponse = llmClient.complete(synthesisPrompt);
+        String synthesisResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, synthesisPrompt);
         SynthesisResponseParser.SynthesisResult synthesis = synthesisResponseParser.parse(synthesisResponse);
         long synthesisElapsedMs = System.currentTimeMillis() - synthesisStartMs;
         log.debug("Synthesis completed: elapsedMs={}", synthesisElapsedMs);

--- a/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageService.java
@@ -1,6 +1,7 @@
 package com.back.coach.domain.github.service.triage;
 
 import com.back.coach.external.llm.LlmClient;
+import com.back.coach.external.llm.PromptDirectives;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.back.coach.domain.github.service.Champion;
@@ -35,7 +36,7 @@ public class ChampionTriageService {
     public TriageResult triage(String repoName, String repoUrl, RepoMetadata metadata) {
         String prompt = promptBuilder.build(repoName, repoUrl, metadata);
         try {
-            String llmResponse = llmClient.complete(prompt);
+            String llmResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt);
             List<Champion> champions = responseParser.parse(llmResponse);
             return new TriageResult(champions, false);
         } catch (ServiceException e) {

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
@@ -19,6 +19,7 @@ import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
 import com.back.coach.domain.user.entity.UserProfile;
 import com.back.coach.domain.user.repository.UserProfileRepository;
 import com.back.coach.external.llm.LlmClient;
+import com.back.coach.external.llm.PromptDirectives;
 import com.back.coach.global.code.ProgressStatus;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -99,7 +100,8 @@ public class RoadmapCommandService {
                 request.weeklyStudyHours(), request.targetDate()
         ));
         RoadmapResponseParser.RoadmapResult roadmapResult =
-                roadmapResponseParser.parse(llmClient.complete(prompt));
+                roadmapResponseParser.parse(
+                        llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt));
 
         // 3. DB 저장 (새 트랜잭션)
         RoadmapDetailResponse response = transactionTemplate.execute(status -> {

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -46,9 +46,33 @@ public class AiGatewayLlmClient implements LlmClient {
         if (prompt == null || prompt.isBlank()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "prompt is empty");
         }
+        return callApi(java.util.List.of(new Message("user", prompt)), prompt.getBytes().length);
+    }
+
+    @Override
+    public String complete(String systemPrompt, String userPrompt) {
+        if (userPrompt == null || userPrompt.isBlank()) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "user prompt is empty");
+        }
+        java.util.List<Message> messages;
+        int promptBytes;
+        if (systemPrompt == null || systemPrompt.isBlank()) {
+            messages = java.util.List.of(new Message("user", userPrompt));
+            promptBytes = userPrompt.getBytes().length;
+        } else {
+            messages = java.util.List.of(
+                    new Message("system", systemPrompt),
+                    new Message("user", userPrompt)
+            );
+            promptBytes = systemPrompt.getBytes().length + userPrompt.getBytes().length;
+        }
+        return callApi(messages, promptBytes);
+    }
+
+    private String callApi(java.util.List<Message> messages, int promptBytes) {
         long startNs = System.nanoTime();
-        int promptBytes = prompt.getBytes().length;
-        log.debug("LLM request starting: model={}, promptBytes={}", properties.model(), promptBytes);
+        log.debug("LLM request starting: model={}, promptBytes={}, messages={}",
+                properties.model(), promptBytes, messages.size());
         try {
             ChatCompletionResponse response = restClient.post()
                     .uri("/v1/chat/completions")
@@ -57,7 +81,7 @@ public class AiGatewayLlmClient implements LlmClient {
                     .headers(headers -> setAuthorization(headers, properties.apiKey()))
                     .body(new ChatCompletionRequest(
                             properties.model(),
-                            java.util.List.of(new Message("user", prompt)),
+                            messages,
                             16384,
                             false
                     ))

--- a/backend/src/main/java/com/back/coach/external/llm/LlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/LlmClient.java
@@ -13,10 +13,29 @@ package com.back.coach.external.llm;
 public interface LlmClient {
 
     /**
-     * 단일 프롬프트로 동기 completion 호출.
+     * user role 단일 메시지로 동기 completion 호출. (legacy)
      *
      * @throws com.back.coach.global.exception.ServiceException
      *         LLM 호출 실패 시 (timeout, rate limit, schema 위반 등)
      */
     String complete(String prompt);
+
+    /**
+     * system role + user role을 분리해서 동기 completion 호출.
+     *
+     * <p>GLM-4.5 시리즈 reasoning 모델에서 system role 분리는 chain-of-thought 길이를 크게 줄여
+     * 평균 -64% latency 효과 관찰됨 (2026-05-12 A/B/C 측정, docs/32 § 3).
+     *
+     * <p>기본 구현은 system+user를 결합해 단일 user 메시지로 보냄. 실제 message-list 분리를
+     * 지원하는 클라이언트는 이 메서드를 override.
+     *
+     * @throws com.back.coach.global.exception.ServiceException
+     *         LLM 호출 실패 시 (timeout, rate limit, schema 위반 등)
+     */
+    default String complete(String systemPrompt, String userPrompt) {
+        if (systemPrompt == null || systemPrompt.isBlank()) {
+            return complete(userPrompt);
+        }
+        return complete(systemPrompt + "\n\n" + userPrompt);
+    }
 }

--- a/backend/src/main/java/com/back/coach/external/llm/PromptDirectives.java
+++ b/backend/src/main/java/com/back/coach/external/llm/PromptDirectives.java
@@ -1,0 +1,25 @@
+package com.back.coach.external.llm;
+
+/**
+ * LLM 호출 시 system role에 공통적으로 들어가는 directive.
+ *
+ * <p>GLM-4.5 시리즈 reasoning 모델은 응답 직전에 `reasoning_content` (chain-of-thought)를
+ * 길게 생성한다. system role에 명시적으로 "no reasoning, output only JSON"을 두면
+ * reasoning 길이가 ~1/3로 줄어 평균 latency -64% 효과 (2026-05-12 A/B/C 측정, docs/32 § 3).
+ */
+public final class PromptDirectives {
+
+    private PromptDirectives() {}
+
+    /**
+     * 5개 PromptBuilder가 공통으로 사용하는 system role 지시문.
+     * 출력 quality에 영향이 있을 수 있으니 변경 시 docs/32 § 3 A/B/C 재측정 필요.
+     */
+    public static final String NO_REASONING_JSON_ONLY = """
+            You are a JSON-only output assistant.
+            Output ONLY the JSON object requested by the user. No preamble, no reasoning, no explanation, no commentary.
+            Do not wrap JSON in markdown code fences (no ```json blocks).
+            Follow every field name and value constraint specified in the user message exactly.
+            If a field is missing data, use null or an empty array; do not invent values.
+            """;
+}

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
@@ -117,7 +117,7 @@ class DiagnosisCommandServiceTest {
     void createDiagnosis_whenInputsAreValid_savesVersionedDiagnosisPayload() throws Exception {
         primeValidInputs();
         given(resultVersionService.nextCapabilityDiagnosisVersion(USER_ID)).willReturn(4);
-        given(llmClient.complete(anyString())).willReturn(validLlmResponse());
+        given(llmClient.complete(anyString(), anyString())).willReturn(validLlmResponse());
         given(capabilityDiagnosisRepository.save(any(CapabilityDiagnosis.class)))
                 .willAnswer(invocation -> withIdAndCreatedAt(invocation.getArgument(0), 30L));
 
@@ -156,9 +156,11 @@ class DiagnosisCommandServiceTest {
         assertThat(storedPayload.strengths()).containsExactly("Spring Boot");
         assertThat(storedPayload.recommendations()).containsExactly("Redis 캐시와 TTL 기반 설계를 먼저 학습");
 
-        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(llmClient).complete(promptCaptor.capture());
-        assertThat(promptCaptor.getValue()).contains("Spring Boot", "Redis", "BACKEND_DEVELOPER");
+        ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(systemCaptor.capture(), userCaptor.capture());
+        assertThat(systemCaptor.getValue()).contains("JSON-only");
+        assertThat(userCaptor.getValue()).contains("Spring Boot", "Redis", "BACKEND_DEVELOPER");
     }
 
     @Test
@@ -220,7 +222,7 @@ class DiagnosisCommandServiceTest {
     @Test
     void createDiagnosis_whenLlmResponseIsInvalid_throwsLlmInvalidResponseAndDoesNotSave() {
         primeValidInputs();
-        given(llmClient.complete(anyString())).willReturn("{}");
+        given(llmClient.complete(anyString(), anyString())).willReturn("{}");
 
         assertThatThrownBy(() -> diagnosisCommandService.createDiagnosis(
                 USER_ID,

--- a/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/flow/V1ResultFlowIntegrationTest.java
@@ -109,7 +109,7 @@ class V1ResultFlowIntegrationTest {
     @Test
     @DisplayName("v1 결과 흐름이 DB 원본 기준으로 진단, 로드맵, 진도, 대시보드까지 이어진다")
     void v1ResultFlow_persistsVersionedResultsAndDashboardSnapshot() {
-        given(llmClient.complete(anyString())).willReturn(diagnosisResponse(), roadmapResponse());
+        given(llmClient.complete(anyString(), anyString())).willReturn(diagnosisResponse(), roadmapResponse());
 
         User user = userRepository.save(User.signupFromOAuth(
                 AuthProvider.GITHUB,
@@ -239,7 +239,7 @@ class V1ResultFlowIntegrationTest {
         assertThat(otherDashboard.githubAnalysis()).isNull();
         assertThat(otherDashboard.diagnosis()).isNull();
         assertThat(otherDashboard.roadmap()).isNull();
-        verify(llmClient, times(2)).complete(anyString());
+        verify(llmClient, times(2)).complete(anyString(), anyString());
     }
 
     private ProfileSaveResult saveProfile(Long userId) {

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -147,7 +147,7 @@ class GithubAnalysisServiceTest {
         given(analysisRepo.findMaxVersionByUserId(USER_ID)).willReturn(null);
         given(analysisRepo.save(any(GithubAnalysis.class))).willAnswer(inv -> withId(inv.getArgument(0), 9L));
         // triage 호출(첫 호출) → timeout, summary 호출(두 번째) → 정상, synthesis 호출(세 번째) → 정상
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT))
                 .willReturn(repoSummaryJson)
                 .willReturn(synthesisJson);
@@ -164,7 +164,7 @@ class GithubAnalysisServiceTest {
     void run_stage2LlmError_propagates() {
         primeRepos();
         given(analysisRepo.findMaxVersionByUserId(USER_ID)).willReturn(null);
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willReturn(triageJson)
                 .willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
 
@@ -202,7 +202,7 @@ class GithubAnalysisServiceTest {
     }
 
     private void primeLlm() {
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willReturn(triageJson)
                 .willReturn(repoSummaryJson)
                 .willReturn(synthesisJson);

--- a/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageServiceTest.java
@@ -36,7 +36,7 @@ class ChampionTriageServiceTest {
     @Test
     @DisplayName("정상 LLM 응답 → champion 그대로 반환, fallback=false")
     void triage_validResponse_returnsChampions() {
-        given(llmClient.complete(anyString())).willReturn("""
+        given(llmClient.complete(anyString(), anyString())).willReturn("""
                 {"champions":[
                   {"kind":"COMMIT","ref":"abc","reason":"OAuth"},
                   {"kind":"PR","ref":"42","reason":"라우팅"}
@@ -53,7 +53,7 @@ class ChampionTriageServiceTest {
     @Test
     @DisplayName("LLM 호출이 LLM_TIMEOUT throw → 최신 6개 commit으로 fallback, fallback=true")
     void triage_timeout_fallsBackToLatest6Commits() {
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
 
         ChampionTriageService.TriageResult result = service.triage("r", "u", metadataWithCommits(10));
@@ -69,7 +69,7 @@ class ChampionTriageServiceTest {
     @Test
     @DisplayName("스키마 위반 응답 → fallback")
     void triage_schemaViolation_fallsBack() {
-        given(llmClient.complete(anyString())).willReturn("""
+        given(llmClient.complete(anyString(), anyString())).willReturn("""
                 {"champions":[]}
                 """);
 
@@ -82,7 +82,7 @@ class ChampionTriageServiceTest {
     @Test
     @DisplayName("commit이 6개 미만이면 있는 만큼만 fallback")
     void triage_fallback_withFewerThanSixCommits() {
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willThrow(new ServiceException(ErrorCode.LLM_RATE_LIMITED));
 
         ChampionTriageService.TriageResult result = service.triage("r", "u", metadataWithCommits(3));
@@ -94,7 +94,7 @@ class ChampionTriageServiceTest {
     @Test
     @DisplayName("commit이 0개이고 LLM도 실패하면 LLM_TRIAGE_FAILED throw")
     void triage_noCommitsAndLlmFails_throws() {
-        given(llmClient.complete(anyString()))
+        given(llmClient.complete(anyString(), anyString()))
                 .willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
 
         RepoMetadata empty = new RepoMetadata(null, Map.of(), List.of(), List.of(), List.of(), List.of());

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -120,7 +120,7 @@ class RoadmapCommandServiceTest {
         primeValidInputs();
         given(githubAnalysisRepository.existsByIdAndUserId(GITHUB_ANALYSIS_ID, USER_ID)).willReturn(true);
         given(resultVersionService.nextLearningRoadmapVersion(USER_ID)).willReturn(2);
-        given(llmClient.complete(anyString())).willReturn(validLlmResponse());
+        given(llmClient.complete(anyString(), anyString())).willReturn(validLlmResponse());
         given(learningRoadmapRepository.save(any(LearningRoadmap.class)))
                 .willAnswer(invocation -> withIdAndCreatedAt(invocation.getArgument(0), 40L));
         given(roadmapWeekRepository.saveAll(any()))
@@ -153,9 +153,11 @@ class RoadmapCommandServiceTest {
         assertThat(storedPayload.weeks()).hasSize(2);
         assertThat(storedPayload.weeks().get(0).topic()).isEqualTo("Redis 기초");
 
-        ArgumentCaptor<String> promptCaptor = ArgumentCaptor.forClass(String.class);
-        verify(llmClient).complete(promptCaptor.capture());
-        assertThat(promptCaptor.getValue()).contains("BACKEND_DEVELOPER", "Redis", "weeklyStudyHours: 8");
+        ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(systemCaptor.capture(), userCaptor.capture());
+        assertThat(systemCaptor.getValue()).contains("JSON-only");
+        assertThat(userCaptor.getValue()).contains("BACKEND_DEVELOPER", "Redis", "weeklyStudyHours: 8");
     }
 
     @Test
@@ -193,7 +195,7 @@ class RoadmapCommandServiceTest {
     @Test
     void createRoadmap_whenLlmResponseIsInvalid_throwsLlmInvalidResponseAndDoesNotSave() {
         primeValidInputs();
-        given(llmClient.complete(anyString())).willReturn("{}");
+        given(llmClient.complete(anyString(), anyString())).willReturn("{}");
 
         assertThatThrownBy(() -> roadmapCommandService.createRoadmap(
                 USER_ID,


### PR DESCRIPTION
## 무엇

GLM-4.5 reasoning 모델 latency 단축. `LlmClient.complete(systemPrompt, userPrompt)` 메서드 신설 + `AiGatewayLlmClient`에서 실제 OpenAI 호환 `messages: [system, user]` 배열로 분리 전송. 5개 caller (triage, summary, synthesis, diagnosis, roadmap)에 `PromptDirectives.NO_REASONING_JSON_ONLY` 적용.

CoachMessageService(채팅 prompt)는 다른 prompt 구조라 본 PR 범위 밖.

## 왜 — 측정 근거

2026-05-12 dev 세션 A/B/C 측정 (\`docs/32_prompt_tuning_log.md\` § 3):

| 변형 | 평균 latency | 응답 dl 평균 |
|------|-------------|--------------|
| A. Baseline (user role만) | 40.5s | 13.2KB |
| B. User-level instruct (\"No reasoning\" prefix) | 36.7s | 14.6KB |
| C. **System role 분리** | **14.3s** | **4.8KB** |

System role 분리만으로 **per-LLM call 평균 -64%, 응답 크기 -64%, 분산 매우 작음**.

e2e 적용 시 추정:
- 현재 2 repos 분석 e2e ~527s
- → ~190s (대략 -64% 적용)
- 5 repos: ~20분 → ~7분

## 변경

### 신규
- `external/llm/PromptDirectives.java` — 공통 system role 지시문 (`NO_REASONING_JSON_ONLY`)
- `LlmClient.complete(String systemPrompt, String userPrompt)` — default 메서드 (legacy `complete(String)` 호환 유지)

### 변경
- `AiGatewayLlmClient` — `callApi(List<Message>)` 내부 메서드로 통합. complete(String)/complete(String,String) 모두 같은 경로
- 5 callers — `llmClient.complete(prompt)` → `llmClient.complete(NO_REASONING_JSON_ONLY, prompt)`
  - `DiagnosisCommandService`
  - `GithubAnalysisService` (summary + synthesis)
  - `ChampionTriageService` (triage)
  - `RoadmapCommandService` (roadmap)

### 테스트
- 단위 테스트 5개 — mock setup을 `complete(anyString(), anyString())` 으로 갱신
- ArgumentCaptor 패턴은 system + user 각각 캡쳐로 변경
- `V1ResultFlowIntegrationTest` 회귀 확인 통과

## 위험 + 완화

- **출력 quality 영향 미측정** — 응답 크기 -64%는 latency 이득이지만, reasoning_content 축소가 quality loss인지 효율화인지 구분 안 됨. 머지 후 실제 분석 1건 돌려서 결과 quality (repoSummaries, finalTechProfile 정확성)를 시각 검증 권장
- **per-builder eval fixture 미적용** — `docs/32` § 6 backlog #2 (golden eval, 5h) 후속 작업으로 분리
- **CoachMessageService 미적용** — Slice 8 chat은 별도 prompt 템플릿 구조라 본 PR 비범위. 동일 패턴 적용 시 별도 PR

## 검증

- 컴파일: BUILD SUCCESSFUL
- Fast tests 전체 GREEN (단위 테스트 5개 + 통합 V1ResultFlow 1개 회귀 확인)

## 관련

- #254 LLM 응답 지연 원인 규명
- \`docs/27_llm_latency_investigation_2026-05-11.md\` (untracked, 실측 데이터)
- \`docs/32_prompt_tuning_log.md\` (untracked, § 3 A/B/C 측정 근거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)