### PR TITLE
fix(coach): replan URL에 sessionId 경로 포함하도록 수정

### DIFF
--- a/frontend/src/features/coach/api.ts
+++ b/frontend/src/features/coach/api.ts
@@ -55,12 +55,13 @@ export function sendMessage(
 }
 
 export function confirmReplan(
+  sessionId: string,
   proposalId: string,
   confirmed: boolean,
   signal?: AbortSignal
 ) {
   return apiClient.post<ReplanResult>(
-    "/api/coach/replan",
+    `/api/coach/sessions/${sessionId}/replan`,
     {
       proposalId: Number(proposalId),
       confirmed

--- a/frontend/src/features/coach/coach-chat-view.tsx
+++ b/frontend/src/features/coach/coach-chat-view.tsx
@@ -239,7 +239,7 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
   const handleConfirmReplan = useCallback(
     async (proposal: ReplanProposal, confirmed: boolean) => {
       try {
-        const result = await confirmReplan(proposal.proposalId, confirmed);
+        const result = await confirmReplan(sessionId, proposal.proposalId, confirmed);
         toast.success(result.message ?? (confirmed ? "재계획이 적용되었습니다." : "제안을 보류했어요."));
         if (confirmed && !result.dismissed) {
           await handleNewSession();
@@ -253,7 +253,7 @@ export function CoachChatView({ sessionId }: ChatViewProps) {
         toast.error(info.title, { description: info.detail });
       }
     },
-    [handleNewSession]
+    [handleNewSession, sessionId]
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION

##  변경 요약
/api/coach/replan → /api/coach/sessions/{sessionId}/replan 백엔드 컨트롤러 경로와 불일치해 500이 발생하던 버그 수정.
confirmReplan()에 sessionId 파라미터 추가, 호출부 및 useCallback deps 갱신. 

