### PR TITLE
feat(coach): CoachMessageService 프롬프트에 system role 분리 적용 (#324 후속)

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -24,6 +24,32 @@ public class CoachMessageService {
 
     private static final int PROPOSAL_TTL_HOURS = 24;
 
+    // Coach 역할 + 출력 형식 규칙을 system role로 분리.
+    // GLM-4.5 reasoning 모델에서 system role 분리는 chain-of-thought 길이를 크게 줄임 (docs/32 § 3).
+    // 데이터 컨텍스트(profile/plan/activeSignals/사용자 메시지)는 ContextManagerService가 user role 텍스트로 조립.
+    private static final String SYSTEM_PROMPT = """
+            당신은 학습 코치입니다. 사용자의 질문에 짧고 실용적인 답변을 한국어로 제공합니다.
+
+            ## 응답 형식 (반드시 JSON만 출력)
+            {
+              "route": "SIMPLE_GUIDE | REPLAN_SUGGEST | DISMISS",
+              "responseText": "<사용자에게 보여줄 메시지>",
+              "replanReason": "<REPLAN_SUGGEST일 때만, 재계획 필요 이유>",
+              "detectedIntent": "<감지된 의도 (선택)>"
+            }
+
+            규칙:
+            - activeSignals가 없거나 단순 질문이면 route=SIMPLE_GUIDE
+            - activeSignals가 있고 재계획이 필요하다고 판단되면 route=REPLAN_SUGGEST
+            - 신호가 있어도 처리 불필요하면 route=DISMISS
+            - replanReason은 REPLAN_SUGGEST일 때만 작성, 나머지는 null
+
+            출력 제약:
+            - JSON 외 텍스트(설명, 추론, 코드펜스 ```) 절대 출력 금지
+            - markdown으로 JSON을 감싸지 마세요
+            - 모든 필드명은 위 스키마와 정확히 일치해야 함
+            """;
+
     private final ChatSessionRepository chatSessionRepository;
     private final CoachConversationRepository coachConversationRepository;
     private final ReplanProposalRepository replanProposalRepository;
@@ -77,7 +103,7 @@ public class CoachMessageService {
         coachConversationRepository.save(CoachConversation.user(sessionId, userId, userMessage));
 
         AssembledContext context = contextManagerService.assembleAuto(session, userMessage);
-        String llmRaw = llmClient.complete(buildPrompt(context, userMessage));
+        String llmRaw = llmClient.complete(SYSTEM_PROMPT, context.systemPrompt());
         CoachResponseParser.ParsedCoachResponse parsed = responseParser.parse(llmRaw);
 
         CoachConversation coachMessage = CoachConversation.coach(
@@ -97,22 +123,4 @@ public class CoachMessageService {
         return new MessageResult(coachMessage, proposal);
     }
 
-    private String buildPrompt(AssembledContext context, String userMessage) {
-        return context.systemPrompt() + """
-
-                ## 응답 형식 (반드시 JSON만 출력)
-                {
-                  "route": "SIMPLE_GUIDE | REPLAN_SUGGEST | DISMISS",
-                  "responseText": "<사용자에게 보여줄 메시지>",
-                  "replanReason": "<REPLAN_SUGGEST일 때만, 재계획 필요 이유>",
-                  "detectedIntent": "<감지된 의도 (선택)>"
-                }
-
-                규칙:
-                - activeSignals가 없거나 단순 질문이면 route=SIMPLE_GUIDE
-                - activeSignals가 있고 재계획이 필요하다고 판단되면 route=REPLAN_SUGGEST
-                - 신호가 있어도 처리 불필요하면 route=DISMISS
-                - replanReason은 REPLAN_SUGGEST일 때만 작성, 나머지는 null
-                """;
-    }
 }

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -95,7 +95,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("USER 메시지 전송 시 USER/COACH 두 행이 저장되고 COACH는 SIMPLE_GUIDE 라우트")
     void sendMessageStoresUserAndCoachRows() {
-        given(llmClient.complete(anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
         );
 
@@ -144,7 +144,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("LLM 실패 시 USER 메시지는 저장되지만 COACH 행은 생성되지 않음")
     void llmFailureLeavesOnlyUserMessage() {
-        given(llmClient.complete(anyString())).willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
+        given(llmClient.complete(anyString(), anyString())).willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
 
         assertThatThrownBy(() -> coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?"))
                 .isInstanceOf(ServiceException.class)
@@ -158,7 +158,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("getMessages: 저장된 USER/COACH 메시지를 시간순으로 조회")
     void getMessagesReturnsStoredMessagesInTimeOrder() {
-        given(llmClient.complete(anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\",\"detectedIntent\":\"CHECK_TODAY_PLAN\"}"
         );
         coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
@@ -176,7 +176,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("getMessages: 닫힌 세션도 히스토리 조회 가능")
     void getMessagesAllowsClosedSession() {
-        given(llmClient.complete(anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
         );
         coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");


### PR DESCRIPTION
## 무엇

[#324](../pull/324)에서 5개 분석 파이프라인 LLM 호출에 system role 분리를 적용했음. 본 PR은 동일 패턴을 **CoachMessageService (Coach 채팅 응답)**에도 적용.

## 변경

`CoachMessageService.sendMessage()`:
- **Before**: `llmClient.complete(buildPrompt(context, userMessage))` — `context.systemPrompt()` (assembled context, 데이터 + 사용자 메시지)에 출력 형식 규칙을 concat해서 단일 user role로 전송
- **After**: `llmClient.complete(SYSTEM_PROMPT, context.systemPrompt())` — Coach 역할 + JSON 출력 규칙은 system role, 데이터/사용자 메시지는 user role

`SYSTEM_PROMPT` 상수 신설 — 기존 `buildPrompt()`의 출력 형식 규칙 + Coach 역할 정의 + "JSON 외 출력 금지" 명시.

`buildPrompt()` private 메서드 제거 (이제 불필요).

`AssembledContext`와 `ContextManagerService`는 그대로 — 데이터 조립 책임은 변경 없음. `context.systemPrompt()` 필드는 (이름과 달리) 실제로는 user role text로 사용됨. 이름 정리는 별도 리팩토링 후보.

## 왜

[docs/32_prompt_tuning_log.md](../tree/main/docs/32_prompt_tuning_log.md) § 3 A/B/C 측정 결과:
- per LLM call 평균 -64% latency
- 응답 크기 -64% (reasoning_content 축소)
- 분산 폭 12–16s로 안정

Coach 채팅은 분석 파이프라인보다 빈도 높고(매 메시지마다 1 LLM call), 사용자 대기 시간에 직접적 영향. UX 개선 효과 큼.

## 위험 + 완화

- **Coach 답변 quality 영향 미측정** — 분석 파이프라인 PR #324와 동일 위험. 머지 후 실제 Coach 메시지 1–2건 보내서 응답 품질 시각 검증 권장 (route 분류 정확성, responseText 자연스러움)
- **`AssembledContext.systemPrompt` 필드 이름의 의미가 모호해짐** — 실제로는 user role 텍스트지만 필드명은 `systemPrompt`. 이번 PR은 최소 침습으로 그대로 두고, 별도 PR에서 `assembledContext()` / `userContext()` 같은 이름으로 정리 가능

## 검증

- `CoachMessageServiceIntegrationTest` 통합 테스트 mock setup을 `complete(anyString(), anyString())`로 갱신
- 4개 케이스 GREEN
- 전체 fast tests 회귀 GREEN

## 관련

- #324 — 5개 분석 파이프라인 system role 분리 (base)
- docs/32_prompt_tuning_log.md (untracked) — A/B/C 측정 근거
- 후속 backlog: `AssembledContext` 필드명 정리, golden eval fixture
