### PR TITLE
fix(github): listUserRepos 페이지네이션 + organization_member affiliation (#290)

### DIFF
--- a/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
+++ b/backend/src/main/java/com/back/coach/external/github/RestGithubApiClient.java
@@ -11,9 +11,13 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -78,11 +82,31 @@ public class RestGithubApiClient implements GithubApiClient {
 
     @Override
     public List<GithubRepoDto> listUserRepos(String accessToken) {
+        // affiliation에 organization_member 포함: collaborator로 명시 추가되지 않은 org repo도 노출.
+        // per_page=100 + Link header rel="next"로 페이지 순회. 사용자별 ~1000 repo까지 안전 처리.
         URI uri = UriComponentsBuilder.fromUriString("/user/repos")
-                .queryParam("affiliation", "owner,collaborator")
+                .queryParam("affiliation", "owner,collaborator,organization_member")
                 .queryParam("per_page", 100)
                 .build().toUri();
-        return getList(uri, accessToken, new ParameterizedTypeReference<>() {});
+        List<GithubRepoDto> all = new ArrayList<>();
+        for (int page = 0; page < MAX_REPO_PAGES && uri != null; page++) {
+            ResponseEntity<List<GithubRepoDto>> response = getListWithHeaders(
+                    uri, accessToken, new ParameterizedTypeReference<>() {});
+            List<GithubRepoDto> body = response.getBody();
+            if (body != null) all.addAll(body);
+            uri = nextPageUri(response.getHeaders().getFirst(HttpHeaders.LINK));
+        }
+        return all;
+    }
+
+    private static final int MAX_REPO_PAGES = 10;
+    private static final Pattern NEXT_LINK_PATTERN =
+            Pattern.compile("<([^>]+)>\\s*;\\s*rel=\"next\"");
+
+    private static URI nextPageUri(String linkHeader) {
+        if (linkHeader == null || linkHeader.isBlank()) return null;
+        Matcher m = NEXT_LINK_PATTERN.matcher(linkHeader);
+        return m.find() ? URI.create(m.group(1)) : null;
     }
 
     @Override
@@ -193,6 +217,30 @@ public class RestGithubApiClient implements GithubApiClient {
             throw e;
         } catch (RuntimeException e) {
             log.warn("GitHub API call failed path={} error={}", path, e.getMessage());
+            throw new ServiceException(classify(e), e.getMessage());
+        }
+    }
+
+    private <T> ResponseEntity<List<T>> getListWithHeaders(
+            URI uri, String accessToken, ParameterizedTypeReference<List<T>> type) {
+        try {
+            return apiClient.get()
+                    .uri(uri)
+                    .headers(h -> h.setBearerAuth(accessToken))
+                    .retrieve()
+                    .onStatus(s -> s.value() == HttpStatus.TOO_MANY_REQUESTS.value(),
+                            (req, res) -> { throw new ServiceException(ErrorCode.GITHUB_RATE_LIMITED); })
+                    .onStatus(s -> s.value() == NOT_FOUND,
+                            (req, res) -> { throw new ServiceException(ErrorCode.RESOURCE_NOT_FOUND); })
+                    .onStatus(s -> s.isError(), (req, res) -> {
+                        log.warn("GitHub API list error: status={} uri={}", res.getStatusCode(), uri);
+                        throw new ServiceException(ErrorCode.GITHUB_API_ERROR);
+                    })
+                    .toEntity(type);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            log.warn("GitHub API list call failed uri={} error={}", uri, e.getMessage());
             throw new ServiceException(classify(e), e.getMessage());
         }
     }

--- a/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/github/RestGithubApiClientTest.java
@@ -145,7 +145,7 @@ class RestGithubApiClientTest {
     // ── listUserRepos ──
 
     @Test
-    @DisplayName("listUserRepos — 저장소 목록 파싱")
+    @DisplayName("listUserRepos — 저장소 목록 파싱 + affiliation에 organization_member 포함")
     void listUserRepos_parsesRepoList() {
         wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
                 .willReturn(aResponse()
@@ -162,6 +162,64 @@ class RestGithubApiClientTest {
         assertThat(repos).hasSize(2);
         assertThat(repos.get(0).fullName()).isEqualTo("user/repo-a");
         assertThat(repos.get(1).language()).isEqualTo("Python");
+        wireMock.verify(getRequestedFor(urlPathEqualTo("/user/repos"))
+                .withQueryParam("affiliation", equalTo("owner,collaborator,organization_member"))
+                .withQueryParam("per_page", equalTo("100")));
+    }
+
+    @Test
+    @DisplayName("listUserRepos — Link 헤더 rel=\"next\" 따라 모든 페이지 fetch")
+    void listUserRepos_followsLinkHeaderPagination() {
+        String base = "http://127.0.0.1:" + wireMock.port();
+        // page 1: 2 repos + Link to page 2
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .withQueryParam("affiliation", equalTo("owner,collaborator,organization_member"))
+                .withQueryParam("per_page", equalTo("100"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withHeader("Link",
+                                "<" + base + "/user/repos?page=2&per_page=100>; rel=\"next\", "
+                                + "<" + base + "/user/repos?page=2&per_page=100>; rel=\"last\"")
+                        .withBody("""
+                                [
+                                  {"node_id":"N1","full_name":"user/repo-a","html_url":"https://github.com/user/repo-a","language":"Java","default_branch":"main","fork":false},
+                                  {"node_id":"N2","full_name":"user/repo-b","html_url":"https://github.com/user/repo-b","language":"Python","default_branch":"main","fork":false}
+                                ]
+                                """)));
+        // page 2: 1 repo + no Link rel="next" (마지막 페이지)
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .withQueryParam("page", equalTo("2"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [
+                                  {"node_id":"N3","full_name":"org/repo-c","html_url":"https://github.com/org/repo-c","language":"Go","default_branch":"main","fork":false}
+                                ]
+                                """)));
+
+        List<GithubRepoDto> repos = client.listUserRepos("ghp_token");
+
+        assertThat(repos).hasSize(3);
+        assertThat(repos).extracting(GithubRepoDto::fullName)
+                .containsExactly("user/repo-a", "user/repo-b", "org/repo-c");
+    }
+
+    @Test
+    @DisplayName("listUserRepos — Link 헤더 없으면 1 페이지로 종료")
+    void listUserRepos_noLinkHeader_stopsAtSinglePage() {
+        wireMock.stubFor(get(urlPathEqualTo("/user/repos"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [
+                                  {"node_id":"N1","full_name":"user/repo-a","html_url":"https://github.com/user/repo-a","language":"Java","default_branch":"main","fork":false}
+                                ]
+                                """)));
+
+        List<GithubRepoDto> repos = client.listUserRepos("ghp_token");
+
+        assertThat(repos).hasSize(1);
+        wireMock.verify(1, getRequestedFor(urlPathEqualTo("/user/repos")));
     }
 
     // ── getReadme ──


### PR DESCRIPTION
Closes #290

## 무엇

`RestGithubApiClient.listUserRepos`에 두 가지 변경:

1. **페이지네이션** — `Link` 헤더 `rel=\"next\"` 따라 다음 페이지 fetch. 안전 cap 10페이지(=1000 repos)로 runaway 방지.
2. **`organization_member` affiliation 추가** — `owner,collaborator,organization_member`. org 소속 repo가 명시적 collaborator로 등록되지 않아도 보이도록.

## 왜

- 사용자 보유/기여 repo 합산이 100을 초과하면 `per_page=100` 단일 호출이 silent drop.
- org 멤버십 기반 권한이 있는 repo가 `owner,collaborator` affiliation에는 안 잡혀 누락.

## 변경

| 파일 | 변경 |
|------|------|
| `RestGithubApiClient.java` | `listUserRepos`에 Link 헤더 페이지 루프 + 새 헬퍼 `getListWithHeaders` (기존 `getList`는 그대로) + `nextPageUri` 정규식 파서 |
| `RestGithubApiClientTest.java` | (a) 기존 + affiliation/per_page query 검증, (b) Link 따라 page 2까지 fetch, (c) Link 없으면 1 페이지 종료 |

## 검증

- `./gradlew test --tests RestGithubApiClientTest` GREEN (3 신규 시나리오 포함)
- `./gradlew compileJava` GREEN
- 기존 `getList` API 시그니처 유지 — listCommits/listPullRequests/listIssues 영향 없음

## 비범위

- `syncRepos`의 fork/archived 추가 필터링 (issue 명시)
- 프론트 `ownerType` 분기 (issue 명시)
- 분석 대상 선택 UX (Slice 9 이후 별도)