### PR TITLE
feat(prompt): 5개 PromptBuilder에 VERSION 상수 + 빌드 로그 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
@@ -6,6 +6,8 @@ import com.back.coach.domain.jobrole.entity.SkillRequirement;
 import com.back.coach.domain.user.entity.UserProfile;
 import com.back.coach.domain.user.entity.UserSkill;
 import com.back.coach.global.code.DiagnosisSeverity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -14,6 +16,10 @@ import java.util.stream.Collectors;
 
 @Component
 public class DiagnosisPromptBuilder {
+
+    public static final String VERSION = "diagnosis-v1.0";
+
+    private static final Logger log = LoggerFactory.getLogger(DiagnosisPromptBuilder.class);
 
     private static final String SEVERITY_VALUES = Arrays.stream(DiagnosisSeverity.values())
             .map(Enum::name)
@@ -86,7 +92,9 @@ public class DiagnosisPromptBuilder {
         prompt.append("strengths should include skills supported by user input or GitHub confirmed skills.\n");
         prompt.append("recommendations should be concrete next learning priorities.\n");
         prompt.append("Do not wrap JSON in Markdown code fences.\n");
-        return prompt.toString();
+        String result = prompt.toString();
+        log.debug("Prompt built: builder=DiagnosisPromptBuilder, version={}, bytes={}", VERSION, result.getBytes().length);
+        return result;
     }
 
     private String nullToEmpty(String value) {

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
@@ -14,6 +14,8 @@ import java.util.Map;
 @Component
 public class RepoSummaryPromptBuilder {
 
+    public static final String VERSION = "repo-summary-v1.0";
+
     private static final Logger log = LoggerFactory.getLogger(RepoSummaryPromptBuilder.class);
 
     public static final int MAX_ITEM_BYTES = 8 * 1024;
@@ -61,7 +63,10 @@ public class RepoSummaryPromptBuilder {
         if (dropped > 0) {
             log.warn("RepoSummary prompt cap reached, dropped {} lower-priority champions", dropped);
         }
-        return sb.toString();
+        String result = sb.toString();
+        log.debug("RepoSummary prompt built: builder=RepoSummaryPromptBuilder, version={}, repo={}, bytes={}",
+                VERSION, repoName, result.getBytes().length);
+        return result;
     }
 
     private String renderItem(ResolvedChampion c) {

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 @Component
 public class SynthesisPromptBuilder {
 
+    public static final String VERSION = "synthesis-v1.0";
+
     private static final Logger log = LoggerFactory.getLogger(SynthesisPromptBuilder.class);
 
     public static final int MAX_PROMPT_BYTES = 16 * 1024;
@@ -29,11 +31,18 @@ public class SynthesisPromptBuilder {
 
     public String build(GithubAnalysisPayload.StaticSignals signals, List<GithubAnalysisPayload.RepoSummary> summaries) {
         String full = render(signals, summaries, /* compress */ false);
-        if (full.getBytes().length <= MAX_PROMPT_BYTES) return full;
+        if (full.getBytes().length <= MAX_PROMPT_BYTES) {
+            log.debug("Synthesis prompt built: builder=SynthesisPromptBuilder, version={}, bytes={}, compressed=false",
+                    VERSION, full.getBytes().length);
+            return full;
+        }
 
         log.warn("Synthesis prompt cap reached, compressing highlights to first {} per summary",
                 COMPRESSED_HIGHLIGHTS_PER_SUMMARY);
-        return render(signals, summaries, true);
+        String compressed = render(signals, summaries, true);
+        log.debug("Synthesis prompt built: builder=SynthesisPromptBuilder, version={}, bytes={}, compressed=true",
+                VERSION, compressed.getBytes().length);
+        return compressed;
     }
 
     private String render(GithubAnalysisPayload.StaticSignals signals, List<GithubAnalysisPayload.RepoSummary> summaries, boolean compress) {

--- a/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriagePromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriagePromptBuilder.java
@@ -13,6 +13,8 @@ import java.util.List;
 @Component
 public class ChampionTriagePromptBuilder {
 
+    public static final String VERSION = "triage-v1.0";
+
     private static final Logger log = LoggerFactory.getLogger(ChampionTriagePromptBuilder.class);
 
     public static final int MAX_PROMPT_BYTES = 20 * 1024;
@@ -35,8 +37,8 @@ public class ChampionTriagePromptBuilder {
         int commits = metadata.commits() == null ? 0 : metadata.commits().size();
         int prs = metadata.pullRequests() == null ? 0 : metadata.pullRequests().size();
         int issues = metadata.issues() == null ? 0 : metadata.issues().size();
-        log.debug("Triage prompt built: repo={}, promptBytes={}, candidates(C/P/I)={}/{}/{}, preview={}...",
-                repoName, promptBytes, commits, prs, issues,
+        log.debug("Triage prompt built: builder=ChampionTriagePromptBuilder, version={}, repo={}, promptBytes={}, candidates(C/P/I)={}/{}/{}, preview={}...",
+                VERSION, repoName, promptBytes, commits, prs, issues,
                 body.length() > 200 ? body.substring(0, 200).replace("\n", " ") : body);
         return body;
     }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -8,11 +8,17 @@ import com.back.coach.domain.user.entity.UserProfile;
 import java.time.LocalDate;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class RoadmapPromptBuilder {
+
+    public static final String VERSION = "roadmap-v1.0";
+
+    private static final Logger log = LoggerFactory.getLogger(RoadmapPromptBuilder.class);
 
     private final int maxWeeks;
 
@@ -21,6 +27,13 @@ public class RoadmapPromptBuilder {
     }
 
     public String build(Input input) {
+        String prompt = renderPrompt(input);
+        log.debug("Roadmap prompt built: builder=RoadmapPromptBuilder, version={}, bytes={}",
+                VERSION, prompt.getBytes().length);
+        return prompt;
+    }
+
+    private String renderPrompt(Input input) {
         Integer weeklyStudyHours = input.weeklyStudyHours() == null
                 ? input.profile().getWeeklyStudyHours()
                 : input.weeklyStudyHours();


### PR DESCRIPTION
## 무엇

5개 PromptBuilder(`ChampionTriagePromptBuilder`, `RepoSummaryPromptBuilder`, `SynthesisPromptBuilder`, `DiagnosisPromptBuilder`, `RoadmapPromptBuilder`)에 `public static final String VERSION` 상수 추가 + `build()` 호출 시 `log.debug(builder, version, bytes)` 출력.

## 왜

지금까지 프롬프트는 Java 코드에 하드코딩, 버전 추적은 git commit hash로만 가능 — 어떤 분석/진단/로드맵 결과가 어떤 prompt 버전에서 나왔는지 사후 추적 불가. 시연/제출용 자료로 \"프롬프트 설계·튜닝 과정\" 기록도 부재.

이 PR은 그 중 최소 단계 (단계 1: VERSION 상수)만 적용:
- 변경 즉시 모든 LLM 호출 로그에 builder name + version 노출
- 향후 응답 row의 metadata에 promptVersion 저장(단계 2)으로 확장 가능
- v1.0이 기준점, 변경 시 minor/major bump

후속 단계(응답 row 메타, golden eval fixture, system role 분리 등)는 별도 PR로 분리.

## 변경 파일

| 파일 | 변경 |
|------|------|
| `DiagnosisPromptBuilder.java` | `VERSION=\"diagnosis-v1.0\"` + logger + build 끝 debug 로그 |
| `ChampionTriagePromptBuilder.java` | `VERSION=\"triage-v1.0\"` + 기존 debug 로그에 version 포함 |
| `RepoSummaryPromptBuilder.java` | `VERSION=\"repo-summary-v1.0\"` + build 끝 debug 로그 |
| `SynthesisPromptBuilder.java` | `VERSION=\"synthesis-v1.0\"` + 두 path(compressed/not) 각각 debug 로그 |
| `RoadmapPromptBuilder.java` | `VERSION=\"roadmap-v1.0\"` + logger + `build` 메서드 분리(`renderPrompt` 내부) + debug 로그 |

## 검증

- 컴파일: `./gradlew compileTestJava` GREEN
- 기존 PromptBuilder 단위 테스트 (`com.back.coach.domain.{diagnosis,github,roadmap}.*PromptBuilder*`) — 회귀 없음, BUILD SUCCESSFUL

## Backlog (이 PR 범위 밖)

1. **응답 row에 prompt_version 저장** — `analysis_payload._meta` 등 JSONB 메타 필드 (1.5h). 본 PR의 VERSION 상수가 prereq
2. **각 PromptBuilder 변경 후 golden eval** — `backend/src/test/resources/prompt-eval/` (5h)
3. ~~**System role 분리 5개 PromptBuilder에 적용**~~ — **#324에서 진행 완료** (별도 PR)
4. **응답 `usage` 필드 활용한 토큰 비용 정확 측정**
5. **Provider 격리 / non-reasoning 모델 가용성 확인** (Grepp 운영팀 외부 의존)

## 관련

- #324 system role 분리 PR — 본 PR 머지 후 응답 row 메타 작성 시 `VERSION` + 모델 + system role 사용 여부 함께 저장하면 좋음
- `docs/32_prompt_tuning_log.md` (untracked) — 본 PR의 1단계 결정과 후속 단계 backlog 정리