### PR TITLE
fix(ai): 사용자 노출 AI 출력 한국어 고정

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -9,6 +9,7 @@ import com.back.coach.domain.coach.repository.ReplanProposalRepository;
 import com.back.coach.domain.context.service.AssembledContext;
 import com.back.coach.domain.context.service.ContextManagerService;
 import com.back.coach.external.llm.LlmClient;
+import com.back.coach.external.llm.PromptDirectives;
 import com.back.coach.global.code.CoachRoute;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
@@ -48,6 +49,8 @@ public class CoachMessageService {
             - JSON 외 텍스트(설명, 추론, 코드펜스 ```) 절대 출력 금지
             - markdown으로 JSON을 감싸지 마세요
             - 모든 필드명은 위 스키마와 정확히 일치해야 함
+            - responseText, replanReason, detectedIntent는 한국어로 작성
+            - 기술명, 제품명, 프레임워크명, enum 값은 원문 유지
             """;
 
     private final ChatSessionRepository chatSessionRepository;
@@ -103,7 +106,10 @@ public class CoachMessageService {
         coachConversationRepository.save(CoachConversation.user(sessionId, userId, userMessage));
 
         AssembledContext context = contextManagerService.assembleAuto(session, userMessage);
-        String llmRaw = llmClient.complete(SYSTEM_PROMPT, context.systemPrompt());
+        String llmRaw = llmClient.complete(
+                PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY + "\n\n" + SYSTEM_PROMPT,
+                context.systemPrompt()
+        );
         CoachResponseParser.ParsedCoachResponse parsed = responseParser.parse(llmRaw);
 
         CoachConversation coachMessage = CoachConversation.coach(

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandService.java
@@ -107,7 +107,7 @@ public class DiagnosisCommandService {
         ));
         DiagnosisResponseParser.DiagnosisResult diagnosisResult =
                 diagnosisResponseParser.parse(
-                        llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt));
+                        llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, prompt));
         DiagnosisPayload diagnosisPayload = new DiagnosisPayload(
                 diagnosisResult.missingSkills(),
                 diagnosisResult.strengths(),

--- a/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilder.java
@@ -30,6 +30,10 @@ public class DiagnosisPromptBuilder {
         prompt.append("You are an AI developer growth diagnosis engine.\n");
         prompt.append("Compare the user's profile and GitHub final tech profile against the target job role requirements.\n");
         prompt.append("Return only one JSON object with summary, missingSkills, strengths, recommendations.\n\n");
+        prompt.append("## Language Rules\n");
+        prompt.append("Write user-visible natural-language values in Korean: summary, missingSkills[].reason, strengths[], recommendations[].\n");
+        prompt.append("Keep technical proper nouns such as Java, Spring Boot, Redis, Docker, and GitHub Actions in their original form.\n");
+        prompt.append("Keep JSON field names and enum values such as HIGH, MEDIUM, LOW unchanged.\n\n");
 
         prompt.append("## Target Role\n");
         prompt.append("roleCode: ").append(input.jobRole().getRoleCode()).append("\n");
@@ -70,17 +74,17 @@ public class DiagnosisPromptBuilder {
         prompt.append("Return exactly this JSON shape; use these field names only:\n");
         prompt.append("""
                 {
-                  "summary": "short diagnosis summary",
+                  "summary": "백엔드 개발자 목표 대비 Redis와 운영 경험 보완이 필요합니다.",
                   "missingSkills": [
                     {
-                      "skillName": "skill name",
+                      "skillName": "Redis",
                       "severity": "HIGH",
-                      "reason": "why this skill is missing based on user input, GitHub final profile, or job requirements",
+                      "reason": "GitHub 분석과 사용자 입력에서 캐시 설계 경험이 충분히 확인되지 않았습니다.",
                       "priorityOrder": 1
                     }
                   ],
-                  "strengths": ["skill or strength supported by user input or GitHub confirmed skills"],
-                  "recommendations": ["concrete next learning priority"]
+                  "strengths": ["Spring Boot 기반 API 구현 경험이 확인됩니다."],
+                  "recommendations": ["Redis 캐시와 TTL 기반 설계를 우선 학습하세요."]
                 }
                 """);
         prompt.append("Do not add any fields other than summary, missingSkills, strengths, recommendations.\n");
@@ -91,6 +95,7 @@ public class DiagnosisPromptBuilder {
         prompt.append("missingSkills[].reason must be a non-empty explanation tied to the input evidence.\n");
         prompt.append("strengths should include skills supported by user input or GitHub confirmed skills.\n");
         prompt.append("recommendations should be concrete next learning priorities.\n");
+        prompt.append("summary, missingSkills[].reason, strengths[], and recommendations[] must be written in Korean.\n");
         prompt.append("Do not wrap JSON in Markdown code fences.\n");
         String result = prompt.toString();
         log.debug("Prompt built: builder=DiagnosisPromptBuilder, version={}, bytes={}", VERSION, result.getBytes().length);

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -135,7 +135,7 @@ public class GithubAnalysisService {
                     core.primaryLanguage(), resolved);
             summaryPromptBytes += summaryPrompt.getBytes().length;
             long summaryStartMs = System.currentTimeMillis();
-            String summaryResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, summaryPrompt);
+            String summaryResponse = llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, summaryPrompt);
             summaryElapsedMs += System.currentTimeMillis() - summaryStartMs;
             repoSummaries.add(summaryResponseParser.parse(summaryResponse));
             long repoElapsedMs = System.currentTimeMillis() - repoStartMs;
@@ -147,7 +147,7 @@ public class GithubAnalysisService {
         String synthesisPrompt = synthesisPromptBuilder.build(inputs.signals(), repoSummaries);
         int synthesisPromptBytes = synthesisPrompt.getBytes().length;
         log.debug("Synthesis prompt built: bytes={}", synthesisPromptBytes);
-        String synthesisResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, synthesisPrompt);
+        String synthesisResponse = llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, synthesisPrompt);
         SynthesisResponseParser.SynthesisResult synthesis = synthesisResponseParser.parse(synthesisResponse);
         long synthesisElapsedMs = System.currentTimeMillis() - synthesisStartMs;
         log.debug("Synthesis completed: elapsedMs={}", synthesisElapsedMs);

--- a/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilder.java
@@ -39,6 +39,10 @@ public class RepoSummaryPromptBuilder {
         sb.append("Output a single JSON object {repoId, repoName, summary, highlights[{text, status}]}.\n");
         sb.append("Each highlight must have: text (string) and status (ADOPTED|EVOLVED|REVERSED).\n");
         sb.append("Use REVERSED if a subsequent activity shows the feature was reverted or abandoned.\n\n");
+        sb.append("Language rules:\n");
+        sb.append("- Write summary and highlights[].text in Korean.\n");
+        sb.append("- Keep technical proper nouns such as Java, Spring Boot, Redis, Docker, and GitHub Actions in their original form.\n");
+        sb.append("- Keep repoId, repoName, and status values unchanged.\n\n");
 
         int dropped = 0;
         Champion.Kind currentSection = null;

--- a/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilder.java
@@ -80,6 +80,8 @@ public class SynthesisPromptBuilder {
         sb.append("For evidences[].type, use ONLY one of: ").append(EVIDENCE_VALUES).append(".\n");
         sb.append("If evidence type is uncertain, use REPO_METADATA. Do NOT leave it blank and do NOT invent new values.\n");
         sb.append("Do NOT rename fields. Do NOT add extra fields.\n");
+        sb.append("Write user-visible natural-language values in Korean: techTags[].tagReason, depthEstimates[].reason, evidences[].summary, finalTechProfile.focusAreas.\n");
+        sb.append("Keep skillName, repoName, source, enum values, and technical proper nouns in their original form.\n");
         return sb.toString();
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapCommandService.java
@@ -101,7 +101,7 @@ public class RoadmapCommandService {
         ));
         RoadmapResponseParser.RoadmapResult roadmapResult =
                 roadmapResponseParser.parse(
-                        llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt));
+                        llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, prompt));
 
         // 3. DB 저장 (새 트랜잭션)
         RoadmapDetailResponse response = transactionTemplate.execute(status -> {

--- a/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
+++ b/backend/src/main/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilder.java
@@ -48,16 +48,19 @@ public class RoadmapPromptBuilder {
                 Rules:
                 - Return JSON only.
                 - Do not wrap JSON in Markdown code fences.
+                - Write user-visible natural-language values in Korean: summary, weeks[].topic, weeks[].reason, tasks[].title, materials[].title.
+                - Keep technical proper nouns such as Java, Spring Boot, Redis, Docker, and GitHub Actions in their original form.
+                - Keep JSON field names and enum values unchanged.
                 - The JSON must match this shape:
                   {
-                    "summary": "short roadmap summary",
+                    "summary": "백엔드 취업 준비를 위한 8주 학습 로드맵 요약",
                     "weeks": [
                       {
                         "weekNumber": 1,
-                        "topic": "topic",
-                        "reason": "why this week matters",
-                        "tasks": [{"type": "READ_DOCS", "title": "task title"}],
-                        "materials": [{"type": "DOCS", "title": "material title", "url": "https://example.com"}],
+                        "topic": "Redis 캐시 기초",
+                        "reason": "백엔드 서비스의 성능 개선 역량을 보완하기 위해 필요합니다.",
+                        "tasks": [{"type": "READ_DOCS", "title": "Redis 공식 문서 핵심 개념 읽기"}],
+                        "materials": [{"type": "DOCS", "title": "Redis Documentation", "url": "https://example.com"}],
                         "estimatedHours": 8.0
                       }
                     ]

--- a/backend/src/main/java/com/back/coach/external/llm/PromptDirectives.java
+++ b/backend/src/main/java/com/back/coach/external/llm/PromptDirectives.java
@@ -12,7 +12,7 @@ public final class PromptDirectives {
     private PromptDirectives() {}
 
     /**
-     * 5개 PromptBuilder가 공통으로 사용하는 system role 지시문.
+     * 내부/범용 JSON 출력에 사용하는 system role 지시문.
      * 출력 quality에 영향이 있을 수 있으니 변경 시 docs/32 § 3 A/B/C 재측정 필요.
      */
     public static final String NO_REASONING_JSON_ONLY = """
@@ -20,6 +20,22 @@ public final class PromptDirectives {
             Output ONLY the JSON object requested by the user. No preamble, no reasoning, no explanation, no commentary.
             Do not wrap JSON in markdown code fences (no ```json blocks).
             Follow every field name and value constraint specified in the user message exactly.
+            If a field is missing data, use null or an empty array; do not invent values.
+            """;
+
+    /**
+     * 사용자 화면에 노출되는 자연어 값을 포함한 JSON 출력에 사용하는 system role 지시문.
+     *
+     * <p>JSON field name, enum, 기술 고유명사는 API/도메인 계약대로 유지하고,
+     * summary/reason/title 같은 사용자-facing 설명 문장만 한국어로 고정한다.
+     */
+    public static final String USER_VISIBLE_KOREAN_JSON_ONLY = """
+            You are a JSON-only output assistant for Korean users.
+            Output ONLY the JSON object requested by the user. No preamble, no reasoning, no explanation, no commentary.
+            Do not wrap JSON in markdown code fences (no ```json blocks).
+            Follow every field name and enum/value constraint specified in the user message exactly.
+            Write all user-visible natural-language values in Korean.
+            Keep technical proper nouns, framework names, product names, URLs, and API enum values in their original form.
             If a field is missing data, use null or an empty array; do not invent values.
             """;
 }

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.List;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @IntegrationTest
 class CoachMessageServiceIntegrationTest {
@@ -104,6 +106,11 @@ class CoachMessageServiceIntegrationTest {
         assertThat(coachMessage.getRole()).isEqualTo(CoachMessageRole.COACH);
         assertThat(coachMessage.getRoute()).isEqualTo(CoachRoute.SIMPLE_GUIDE);
         assertThat(coachMessage.getMessageText()).contains("Redis");
+
+        ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(systemCaptor.capture(), anyString());
+        assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
+        assertThat(systemCaptor.getValue()).contains("responseText, replanReason, detectedIntent는 한국어로 작성");
 
         List<CoachConversation> rows = coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         assertThat(rows).hasSize(2);

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisCommandServiceTest.java
@@ -160,6 +160,8 @@ class DiagnosisCommandServiceTest {
         ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
         verify(llmClient).complete(systemCaptor.capture(), userCaptor.capture());
         assertThat(systemCaptor.getValue()).contains("JSON-only");
+        assertThat(systemCaptor.getValue()).contains("Korean users");
+        assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
         assertThat(userCaptor.getValue()).contains("Spring Boot", "Redis", "BACKEND_DEVELOPER");
     }
 

--- a/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/diagnosis/service/DiagnosisPromptBuilderTest.java
@@ -45,6 +45,9 @@ class DiagnosisPromptBuilderTest {
         assertThat(prompt).contains("Do not use alias field names like skill, name, description, priority, rationale");
         assertThat(prompt).contains("missingSkills[].reason must be a non-empty explanation");
         assertThat(prompt).contains("LOW, MEDIUM, HIGH");
+        assertThat(prompt).contains("Write user-visible natural-language values in Korean");
+        assertThat(prompt).contains("summary, missingSkills[].reason, strengths[], and recommendations[] must be written in Korean");
+        assertThat(prompt).contains("Redis 캐시와 TTL 기반 설계를 우선 학습하세요.");
         assertThat(prompt).contains("Do not wrap JSON in Markdown code fences.");
     }
 

--- a/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/summary/RepoSummaryPromptBuilderTest.java
@@ -31,6 +31,8 @@ class RepoSummaryPromptBuilderTest {
         // RepoSummary JSON 응답 형식과 highlight status enum을 LLM에 알려주는 instruction이 있어야 함
         assertThat(prompt).contains("highlights[{text, status}]");
         assertThat(prompt).contains("ADOPTED").contains("EVOLVED").contains("REVERSED");
+        assertThat(prompt).contains("Write summary and highlights[].text in Korean");
+        assertThat(prompt).contains("Keep technical proper nouns");
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/synthesis/SynthesisPromptBuilderTest.java
@@ -47,6 +47,8 @@ class SynthesisPromptBuilderTest {
         // 출력 형식 / enum 값 안내
         assertThat(prompt).contains("INTRO").contains("APPLIED").contains("PRACTICAL").contains("DEEP");
         assertThat(prompt).contains("README").contains("CODE").contains("CONFIG").contains("REPO_METADATA").contains("COMMIT");
+        assertThat(prompt).contains("Write user-visible natural-language values in Korean");
+        assertThat(prompt).contains("techTags[].tagReason", "depthEstimates[].reason", "evidences[].summary", "finalTechProfile.focusAreas");
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapCommandServiceTest.java
@@ -157,7 +157,10 @@ class RoadmapCommandServiceTest {
         ArgumentCaptor<String> userCaptor = ArgumentCaptor.forClass(String.class);
         verify(llmClient).complete(systemCaptor.capture(), userCaptor.capture());
         assertThat(systemCaptor.getValue()).contains("JSON-only");
+        assertThat(systemCaptor.getValue()).contains("Korean users");
+        assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
         assertThat(userCaptor.getValue()).contains("BACKEND_DEVELOPER", "Redis", "weeklyStudyHours: 8");
+        assertThat(userCaptor.getValue()).contains("weeks[].topic", "tasks[].title", "materials[].title");
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilderTest.java
+++ b/backend/src/test/java/com/back/coach/domain/roadmap/service/RoadmapPromptBuilderTest.java
@@ -1,0 +1,87 @@
+package com.back.coach.domain.roadmap.service;
+
+import com.back.coach.domain.diagnosis.dto.DiagnosisPayload;
+import com.back.coach.domain.diagnosis.entity.CapabilityDiagnosis;
+import com.back.coach.domain.jobrole.entity.JobRole;
+import com.back.coach.domain.user.entity.UserProfile;
+import com.back.coach.global.code.CurrentLevel;
+import com.back.coach.global.code.DiagnosisSeverity;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class RoadmapPromptBuilderTest {
+
+    private final RoadmapPromptBuilder builder = new RoadmapPromptBuilder(8);
+
+    @Test
+    void build_includesKoreanUserVisibleOutputRulesAndStrictJsonShape() {
+        String prompt = builder.build(new RoadmapPromptBuilder.Input(
+                jobRole(),
+                profile(),
+                diagnosis(),
+                diagnosisPayload(),
+                8,
+                LocalDate.of(2099, 12, 31)
+        ));
+
+        assertThat(prompt).contains("Write user-visible natural-language values in Korean");
+        assertThat(prompt).contains("summary, weeks[].topic, weeks[].reason, tasks[].title, materials[].title");
+        assertThat(prompt).contains("Keep JSON field names and enum values unchanged");
+        assertThat(prompt).contains("Redis 캐시 기초");
+        assertThat(prompt).contains("READ_DOCS", "DOCS", "weekNumber");
+    }
+
+    private JobRole jobRole() {
+        JobRole jobRole = mock(JobRole.class);
+        given(jobRole.getRoleCode()).willReturn("BACKEND_DEVELOPER");
+        return jobRole;
+    }
+
+    private UserProfile profile() {
+        return UserProfile.create(
+                1L,
+                10L,
+                CurrentLevel.JUNIOR,
+                8,
+                LocalDate.of(2099, 12, 31),
+                "[]",
+                null,
+                null
+        );
+    }
+
+    private CapabilityDiagnosis diagnosis() {
+        CapabilityDiagnosis diagnosis = CapabilityDiagnosis.create(
+                1L,
+                10L,
+                20L,
+                30L,
+                1,
+                CurrentLevel.JUNIOR,
+                "Redis 보완 필요",
+                "{}"
+        );
+        ReflectionTestUtils.setField(diagnosis, "id", 100L);
+        return diagnosis;
+    }
+
+    private DiagnosisPayload diagnosisPayload() {
+        return new DiagnosisPayload(
+                List.of(new DiagnosisPayload.MissingSkill(
+                        "Redis",
+                        DiagnosisSeverity.HIGH,
+                        "캐시 설계 경험이 부족함",
+                        1
+                )),
+                List.of("Spring Boot"),
+                List.of("Redis 캐시와 TTL 기반 설계를 먼저 학습")
+        );
+    }
+}


### PR DESCRIPTION
﻿## Summary

- 사용자에게 보이는 AI 자연어 출력은 한국어로 고정했습니다.
- JSON field name, enum 값, 기술 고유명사는 기존 계약대로 유지합니다.
- GitHub triage 같은 내부 판단용 LLM 출력은 기존 directive를 유지합니다.

## Changes

- user-visible Korean JSON directive 추가
- GitHub summary/synthesis, diagnosis, roadmap, coach 호출에 적용
- prompt builder/service 테스트 보강

## Test

- `./gradlew.bat test --tests "*RepoSummaryPromptBuilderTest" --tests "*SynthesisPromptBuilderTest" --tests "*DiagnosisPromptBuilderTest" --tests "*RoadmapPromptBuilderTest" --tests "*DiagnosisCommandServiceTest" --tests "*RoadmapCommandServiceTest" --tests "*CoachMessageServiceIntegrationTest"`
- `./gradlew.bat test`

Closes #329
