### PR TITLE
fix(deploy): 로드맵 생성 504 타임아웃 경계 조정

### DIFF
--- a/docker/.env.deploy.example
+++ b/docker/.env.deploy.example
@@ -53,6 +53,8 @@ GITHUB_CONNECTION_CLIENT_SECRET=your-production-connection-oauth-client-secret
 AI_GATEWAY_API_KEY=your-ai-gateway-api-key
 AI_GATEWAY_BASE_URL=https://aigw.alpha.grepp.co
 AI_GATEWAY_MODEL=glm-4.5-flash
+AI_GATEWAY_TIMEOUT_CONNECT=5s
+AI_GATEWAY_TIMEOUT_READ=300s
 
 # Frontend build-time public config.
 # These values are baked into the frontend image during docker build.

--- a/docker/.env.deploy.example
+++ b/docker/.env.deploy.example
@@ -56,6 +56,11 @@ AI_GATEWAY_MODEL=glm-4.5-flash
 AI_GATEWAY_TIMEOUT_CONNECT=5s
 AI_GATEWAY_TIMEOUT_READ=300s
 
+# Nginx API proxy timeouts. Keep read/send longer than AI_GATEWAY_TIMEOUT_READ.
+API_PROXY_CONNECT_TIMEOUT=10s
+API_PROXY_SEND_TIMEOUT=330s
+API_PROXY_READ_TIMEOUT=330s
+
 # Frontend build-time public config.
 # These values are baked into the frontend image during docker build.
 NEXT_PUBLIC_API_BASE_URL=http://localhost

--- a/docker/docker-compose.deploy.yml
+++ b/docker/docker-compose.deploy.yml
@@ -18,6 +18,8 @@ x-backend-env: &backend-env
   AI_GATEWAY_API_KEY: ${AI_GATEWAY_API_KEY:-}
   AI_GATEWAY_BASE_URL: ${AI_GATEWAY_BASE_URL:-https://aigw.alpha.grepp.co}
   AI_GATEWAY_MODEL: ${AI_GATEWAY_MODEL:-glm-4.7}
+  AI_GATEWAY_TIMEOUT_CONNECT: ${AI_GATEWAY_TIMEOUT_CONNECT:-5s}
+  AI_GATEWAY_TIMEOUT_READ: ${AI_GATEWAY_TIMEOUT_READ:-300s}
 
 x-backend-depends-on: &backend-depends-on
   postgres:

--- a/scripts/deploy/switch-active-color.sh
+++ b/scripts/deploy/switch-active-color.sh
@@ -44,6 +44,16 @@ read_env_value() {
   printf '%s\n' "$value"
 }
 
+validate_nginx_timeout() {
+  local key="$1"
+  local value="$2"
+
+  if ! [[ "$value" =~ ^[0-9]+(ms|s|m|h)?$ ]]; then
+    echo "${key} must be an nginx time value such as 10s, 330s, or 5m. value=${value}" >&2
+    exit 1
+  fi
+}
+
 app_domain="$(read_env_value APP_DOMAIN "")"
 server_name="_"
 if [ -n "$app_domain" ]; then
@@ -66,6 +76,14 @@ if [ -n "$tls_cert_path" ] && [ -n "$tls_key_path" ] && [ -f "$tls_cert_path" ] 
   tls_enabled=true
 fi
 
+api_proxy_connect_timeout="$(read_env_value API_PROXY_CONNECT_TIMEOUT "10s")"
+api_proxy_send_timeout="$(read_env_value API_PROXY_SEND_TIMEOUT "330s")"
+api_proxy_read_timeout="$(read_env_value API_PROXY_READ_TIMEOUT "330s")"
+
+validate_nginx_timeout API_PROXY_CONNECT_TIMEOUT "$api_proxy_connect_timeout"
+validate_nginx_timeout API_PROXY_SEND_TIMEOUT "$api_proxy_send_timeout"
+validate_nginx_timeout API_PROXY_READ_TIMEOUT "$api_proxy_read_timeout"
+
 cat > "$nginx_config" <<NGINX
 server {
     listen 80 default_server;
@@ -82,10 +100,16 @@ server {
     proxy_set_header X-Forwarded-Port \$server_port;
 
     location = /api {
+        proxy_connect_timeout ${api_proxy_connect_timeout};
+        proxy_send_timeout ${api_proxy_send_timeout};
+        proxy_read_timeout ${api_proxy_read_timeout};
         proxy_pass http://127.0.0.1:${backend_port};
     }
 
     location /api/ {
+        proxy_connect_timeout ${api_proxy_connect_timeout};
+        proxy_send_timeout ${api_proxy_send_timeout};
+        proxy_read_timeout ${api_proxy_read_timeout};
         proxy_pass http://127.0.0.1:${backend_port};
     }
 
@@ -128,10 +152,16 @@ server {
     proxy_set_header X-Forwarded-Port \$server_port;
 
     location = /api {
+        proxy_connect_timeout ${api_proxy_connect_timeout};
+        proxy_send_timeout ${api_proxy_send_timeout};
+        proxy_read_timeout ${api_proxy_read_timeout};
         proxy_pass http://127.0.0.1:${backend_port};
     }
 
     location /api/ {
+        proxy_connect_timeout ${api_proxy_connect_timeout};
+        proxy_send_timeout ${api_proxy_send_timeout};
+        proxy_read_timeout ${api_proxy_read_timeout};
         proxy_pass http://127.0.0.1:${backend_port};
     }
 


### PR DESCRIPTION
﻿## Summary

- 로드맵 생성 중 LLM 동기 대기가 길어질 때 Nginx/backend timeout 경계가 먼저 끊기는 문제를 완화합니다.
- backend AI Gateway read timeout은 300s로, Nginx API proxy read/send timeout은 330s로 맞췄습니다.
- Terraform, DNSZI, Certbot, OAuth App은 변경하지 않았습니다.

## Changes

- deploy compose backend env에 `AI_GATEWAY_TIMEOUT_CONNECT`, `AI_GATEWAY_TIMEOUT_READ` 기본값 추가
- Nginx active color switch script의 `/api`, `/api/` location에 proxy timeout 추가
- `.env.deploy.example`에 운영 timeout 예시 추가

## Test

- `bash -lc "bash -n /mnt/c/Users/qkrqh/IdeaProjects/INT6-Roadmap-Team06/scripts/deploy/switch-active-color.sh"`
- `docker compose --env-file docker/.env.deploy.example -f docker/docker-compose.deploy.yml config`
- `git diff --check HEAD~2..HEAD`

Closes #331
