### PR TITLE
fix(coach): Coach 세션 스냅샷 기준 명확화

### DIFF
--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import com.back.coach.domain.coach.entity.ChatSession;
 import com.back.coach.domain.coach.repository.ChatSessionRepository;
 import com.back.coach.domain.context.entity.UserContextSnapshot;
 import com.back.coach.domain.context.repository.UserContextSnapshotRepository;
+import com.back.coach.domain.context.service.ContextSnapshotStorageService;
 import com.back.coach.domain.user.entity.User;
 import com.back.coach.domain.user.repository.UserRepository;
 import com.back.coach.global.code.AuthProvider;
@@ -35,6 +36,9 @@ class CoachSessionServiceIntegrationTest {
 
     @Autowired
     private UserContextSnapshotRepository contextSnapshotRepository;
+
+    @Autowired
+    private ContextSnapshotStorageService contextSnapshotStorageService;
 
     @Autowired
     private UserRepository userRepository;
@@ -74,6 +78,24 @@ class CoachSessionServiceIntegrationTest {
         assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
         assertThat(session.getStartedAt()).isNotNull();
         assertThat(session.getEndedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("startSession은 현재 active PROFILE/PLAN snapshot version을 세션에 고정한다")
+    void startSessionPinsCurrentActiveSnapshotVersions() {
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PROFILE, contextPayload(ContextType.PROFILE, "profile-old"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PROFILE, contextPayload(ContextType.PROFILE, "profile-current"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PLAN, contextPayload(ContextType.PLAN, "plan-old"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PLAN, contextPayload(ContextType.PLAN, "plan-current"));
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        assertThat(session.getProfileVersion()).isEqualTo(2);
+        assertThat(session.getRoadmapVersion()).isEqualTo(2);
+        assertThat(contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.getVersion()).isEqualTo(2));
+        assertThat(contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.getVersion()).isEqualTo(2));
     }
 
     @Test
@@ -268,5 +290,20 @@ class CoachSessionServiceIntegrationTest {
     private static String paddedPayload(ContextType type) {
         // 500 bytes 이상이면 publisher self-heal이 트리거되지 않는다 (PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD).
         return "{\"contextType\":\"" + type.name() + "\",\"_padding\":\"" + "x".repeat(600) + "\"}";
+    }
+
+    private static String contextPayload(ContextType type, String marker) {
+        return """
+                {
+                  "contextType": "%s",
+                  "sourceRefs": {
+                    "marker": "%s"
+                  },
+                  "payload": {
+                    "marker": "%s",
+                    "padding": "%s"
+                  }
+                }
+                """.formatted(type.code(), marker, marker, "x".repeat(600));
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
@@ -35,6 +35,9 @@ class ContextManagerServiceIntegrationTest {
     private ContextManagerService contextManagerService;
 
     @Autowired
+    private ContextSnapshotStorageService contextSnapshotStorageService;
+
+    @Autowired
     private ChatSessionRepository chatSessionRepository;
 
     @Autowired
@@ -242,18 +245,24 @@ class ContextManagerServiceIntegrationTest {
     @Test
     @DisplayName("세션 고정 version 기준으로 조립 — active와 다른 version도 정확히 로드")
     void assemblesByPinnedVersionNotActive() {
-        // version 1, 2가 모두 존재. active는 v2지만 세션은 v1으로 고정.
-        seedSnapshot(ContextType.PROFILE, 1, "{\"v\":\"old\"}");
-        seedSnapshot(ContextType.PROFILE, 2, "{\"v\":\"new\"}");
-        seedSnapshot(ContextType.PLAN, 1, "{\"weeks\":4}");
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PROFILE, contextPayload(ContextType.PROFILE, "profile-old"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PROFILE, contextPayload(ContextType.PROFILE, "profile-current"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PLAN, contextPayload(ContextType.PLAN, "plan-old"));
+        contextSnapshotStorageService.createSnapshot(userId, ContextType.PLAN, contextPayload(ContextType.PLAN, "plan-current"));
         ChatSession session = startSession(1, 1);
 
         AssembledContext ctx = contextManagerService.assemble(
                 session, CoachTemplate.COACH_LIGHTWEIGHT, "hello"
         );
 
-        assertThat(ctx.systemPrompt()).contains("\"old\"");
-        assertThat(ctx.systemPrompt()).doesNotContain("\"new\"");
+        assertThat(contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.getVersion()).isEqualTo(2));
+        assertThat(contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN))
+                .hasValueSatisfying(snapshot -> assertThat(snapshot.getVersion()).isEqualTo(2));
+        assertThat(ctx.systemPrompt()).contains("profile-old");
+        assertThat(ctx.systemPrompt()).contains("plan-old");
+        assertThat(ctx.systemPrompt()).doesNotContain("profile-current");
+        assertThat(ctx.systemPrompt()).doesNotContain("plan-current");
     }
 
     @Test
@@ -291,5 +300,19 @@ class ContextManagerServiceIntegrationTest {
 
     private ChatSession startSession(int profileVersion, int planVersion) {
         return chatSessionRepository.save(ChatSession.start(userId, profileVersion, planVersion));
+    }
+
+    private static String contextPayload(ContextType type, String marker) {
+        return """
+                {
+                  "contextType": "%s",
+                  "sourceRefs": {
+                    "marker": "%s"
+                  },
+                  "payload": {
+                    "marker": "%s"
+                  }
+                }
+                """.formatted(type.code(), marker, marker);
     }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3648,6 +3648,13 @@ a {
   font-weight: 700;
 }
 
+.coach-sidebar-note {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .coach-sidebar-new {
   border: 1px solid var(--line);
   background: transparent;
@@ -3718,15 +3725,22 @@ a {
   color: var(--muted);
 }
 
-.coach-sidebar-version {
+.coach-sidebar-snapshot {
   color: var(--muted);
   font-size: 11px;
+  line-height: 1.35;
+  margin-top: 4px;
+  overflow-wrap: anywhere;
+}
+
+.coach-sidebar-snapshot span {
+  display: block;
 }
 
 .coach-sidebar-date {
   color: var(--muted);
   font-size: 11px;
-  margin-top: 2px;
+  white-space: nowrap;
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/features/coach/coach-chat-view.tsx
+++ b/frontend/src/features/coach/coach-chat-view.tsx
@@ -262,7 +262,7 @@ export function CoachChatView({ sessionId, mode = "page", onClose }: ChatViewPro
         toast.error(info.title, { description: info.detail });
       }
     },
-    [handleNewSession]
+    [handleNewSession, sessionId]
   );
 
   const handleKeyDown = useCallback(

--- a/frontend/src/features/coach/coach-sessions-sidebar.tsx
+++ b/frontend/src/features/coach/coach-sessions-sidebar.tsx
@@ -44,7 +44,10 @@ export function CoachSessionsSidebar({ activeSessionId }: SidebarProps) {
   return (
     <aside className="coach-sidebar" aria-label="Coach 세션 목록">
       <header className="coach-sidebar-header">
-        <h3>세션</h3>
+        <div>
+          <h3>세션</h3>
+          <p className="coach-sidebar-note">세션 생성 시점의 스냅샷 기준</p>
+        </div>
         <button
           type="button"
           className="coach-sidebar-new"
@@ -90,12 +93,16 @@ export function CoachSessionsSidebar({ activeSessionId }: SidebarProps) {
                     <span className="coach-sidebar-label">
                       {isClosed ? "종료됨" : "활성"}
                     </span>
-                    <span className="coach-sidebar-version">
-                      v{session.profileVersion}/{session.roadmapVersion}
+                    <span className="coach-sidebar-date">
+                      {formatStartedAt(session.startedAt)}
                     </span>
                   </div>
-                  <div className="coach-sidebar-date">
-                    {formatStartedAt(session.startedAt)}
+                  <div
+                    className="coach-sidebar-snapshot"
+                    aria-label={`프로필 스냅샷 v${session.profileVersion}, 로드맵 스냅샷 v${session.roadmapVersion}`}
+                  >
+                    <span>프로필 스냅샷 v{session.profileVersion}</span>
+                    <span>로드맵 스냅샷 v{session.roadmapVersion}</span>
                   </div>
                 </Link>
               </li>

--- a/frontend/src/features/coach/coach-widget.tsx
+++ b/frontend/src/features/coach/coach-widget.tsx
@@ -14,6 +14,15 @@ import { isUnauthorizedError } from "@/lib/auth";
 
 const STORAGE_KEY = "coach-widget-open";
 
+function getInitialOpen() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 type SessionState =
   | { status: "idle" }
   | { status: "loading" }
@@ -22,19 +31,11 @@ type SessionState =
   | { status: "error"; message: string };
 
 export function CoachWidget() {
-  const [open, setOpen] = useState(false);
-  const [session, setSession] = useState<SessionState>({ status: "idle" });
+  const [open, setOpen] = useState(getInitialOpen);
+  const [session, setSession] = useState<SessionState>(() =>
+    getInitialOpen() ? { status: "loading" } : { status: "idle" }
+  );
   const pathname = usePathname();
-
-  // localStorage 복원
-  useEffect(() => {
-    try {
-      const stored = window.localStorage.getItem(STORAGE_KEY);
-      if (stored === "1") setOpen(true);
-    } catch {
-      // ignore
-    }
-  }, []);
 
   // /coach 경로에서는 위젯 숨김 (full-page 코치와 중복 방지)
   const onCoachPage = pathname?.startsWith("/coach") ?? false;
@@ -48,7 +49,6 @@ export function CoachWidget() {
 
     let cancelled = false;
     const controller = new AbortController();
-    setSession({ status: "loading" });
 
     (async () => {
       try {
@@ -91,6 +91,7 @@ export function CoachWidget() {
 
   const persistOpen = useCallback((next: boolean) => {
     setOpen(next);
+    setSession(next ? { status: "loading" } : { status: "idle" });
     try {
       window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
     } catch {

--- a/frontend/src/features/diagnosis/diagnosis-create-view.tsx
+++ b/frontend/src/features/diagnosis/diagnosis-create-view.tsx
@@ -62,7 +62,7 @@ export function DiagnosisCreateView({ githubAnalysisId }: Props) {
         }
         setState({ status: "error", message: getErrorMessage(err) });
       });
-  }, []);
+  }, [githubAnalysisId]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/src/features/github-connection/github-analysis-job-context.tsx
+++ b/frontend/src/features/github-connection/github-analysis-job-context.tsx
@@ -40,6 +40,26 @@ interface GithubAnalysisJobContextValue {
 const STORAGE_KEY = "github_analysis_job";
 const POLL_INTERVAL_MS = 3000;
 
+function saveToStorage(job: ActiveJob | null) {
+  if (typeof window === "undefined") return;
+  if (job) {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(job));
+  } else {
+    sessionStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+function loadFromStorage(): ActiveJob | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as ActiveJob;
+  } catch {
+    return null;
+  }
+}
+
 // ── Context ───────────────────────────────────────────────────────────
 
 const GithubAnalysisJobContext = createContext<GithubAnalysisJobContextValue | null>(null);
@@ -47,34 +67,21 @@ const GithubAnalysisJobContext = createContext<GithubAnalysisJobContextValue | n
 // ── Provider ─────────────────────────────────────────────────────────
 
 export function GithubAnalysisJobProvider({ children }: { children: React.ReactNode }) {
-  const [activeJob, setActiveJob] = useState<ActiveJob | null>(null);
+  const [activeJob, setActiveJob] = useState<ActiveJob | null>(() => loadFromStorage());
   const [jobStatus, setJobStatus] = useState<AnalysisJobStatusResponse | null>(null);
   const [cacheInvalidateKey, setCacheInvalidateKey] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // ── sessionStorage 직렬화/복원 ──
-
-  function saveToStorage(job: ActiveJob | null) {
-    if (job) {
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(job));
-    } else {
-      sessionStorage.removeItem(STORAGE_KEY);
-    }
-  }
-
-  function loadFromStorage(): ActiveJob | null {
-    try {
-      const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (!raw) return null;
-      return JSON.parse(raw) as ActiveJob;
-    } catch {
-      return null;
-    }
-  }
-
   // ── 폴링 ──
+
+  const stopPoll = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
 
   const poll = useCallback(async (job: ActiveJob) => {
     try {
@@ -93,42 +100,26 @@ export function GithubAnalysisJobProvider({ children }: { children: React.ReactN
     } catch {
       // 개별 폴링 실패는 무시 (네트워크 일시적 오류)
     }
-  }, []);
+  }, [stopPoll]);
 
-  function startPoll(job: ActiveJob) {
+  const startPoll = useCallback((job: ActiveJob) => {
     stopPoll();
     pollRef.current = setInterval(() => poll(job), POLL_INTERVAL_MS);
-    // 즉시 1회 폴링
-    void poll(job);
-  }
-
-  function stopPoll() {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-  }
+    window.setTimeout(() => void poll(job), 0);
+  }, [poll, stopPoll]);
 
   // 폴링 설정: activeJob 변경 시
   useEffect(() => {
     if (!activeJob) return;
     startPoll(activeJob);
     return stopPoll;
-  }, [activeJob, poll]);
-
-  // ── 새로고침 복구 ──
-
-  useEffect(() => {
-    const stored = loadFromStorage();
-    if (!stored) return;
-    setActiveJob(stored);
-  }, []);
+  }, [activeJob, startPoll, stopPoll]);
 
   // ── cleanup ──
 
   useEffect(() => {
     return stopPoll;
-  }, []);
+  }, [stopPoll]);
 
   // ── 공개 API ──
 
@@ -163,7 +154,7 @@ export function GithubAnalysisJobProvider({ children }: { children: React.ReactN
     setJobStatus(null);
     setSubmitError(null);
     saveToStorage(null);
-  }, []);
+  }, [stopPoll]);
 
   return (
     <GithubAnalysisJobContext.Provider

--- a/frontend/src/features/roadmap/roadmap-create-view.tsx
+++ b/frontend/src/features/roadmap/roadmap-create-view.tsx
@@ -25,12 +25,12 @@ function getErrorMessage(error: unknown): string {
 
 const FALLBACK_MAX_WEEKS = 8;
 
-function getTomorrowDateValue() {
-  return new Date(Date.now() + 86400000).toISOString().split("T")[0];
+function getTomorrowDateValue(baseTimeMs: number = Date.now()) {
+  return new Date(baseTimeMs + 86400000).toISOString().split("T")[0];
 }
 
-function getMaxDateValue(maxWeeks: number) {
-  return new Date(Date.now() + maxWeeks * 7 * 86400000)
+function getMaxDateValue(maxWeeks: number, baseTimeMs: number = Date.now()) {
+  return new Date(baseTimeMs + maxWeeks * 7 * 86400000)
     .toISOString()
     .split("T")[0];
 }
@@ -47,13 +47,14 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
   const [weeklyStudyHours, setWeeklyStudyHours] = useState("");
   const [targetDate, setTargetDate] = useState("");
   const [maxWeeks, setMaxWeeks] = useState<number>(FALLBACK_MAX_WEEKS);
+  const [baseTimeMs] = useState(() => Date.now());
   const loaded = useRef(false);
   const targetDateInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (loaded.current) return;
     loaded.current = true;
-    targetDateInputRef.current?.setAttribute("min", getTomorrowDateValue());
+    targetDateInputRef.current?.setAttribute("min", getTomorrowDateValue(baseTimeMs));
 
     getRoadmapConstraints()
       .then((constraints) => setMaxWeeks(constraints.maxWeeks))
@@ -105,7 +106,7 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
           }
         });
     }
-  }, [initialDiagnosisId]);
+  }, [baseTimeMs, initialDiagnosisId]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -187,7 +188,7 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
     ? Math.max(
         1,
         Math.ceil(
-          (new Date(targetDate).getTime() - Date.now()) / (7 * 86400000)
+          (new Date(targetDate).getTime() - baseTimeMs) / (7 * 86400000)
         )
       )
     : null;
@@ -315,7 +316,7 @@ export function RoadmapCreateView({ initialDiagnosisId }: Props) {
             <input
               type="date"
               ref={targetDateInputRef}
-              max={getMaxDateValue(maxWeeks)}
+              max={getMaxDateValue(maxWeeks, baseTimeMs)}
               value={targetDate}
               onChange={(e) => setTargetDate(e.target.value)}
               disabled={isSubmitting}


### PR DESCRIPTION
## Summary
- Coach 세션 목록의 `v12/4` 축약 표시를 스냅샷 의미가 드러나도록 개선했습니다.
- 세션 생성 시점의 Context Snapshot version을 기준으로 Coach 맥락이 고정된다는 점을 테스트로 보강했습니다.
- 실제 원격 `dev` 최신 기준에서 frontend CI가 React lint 오류를 내던 항목을 함께 정리했습니다.

## Changes
- 세션 목록에 `프로필 스냅샷 vN`, `로드맵 스냅샷 vN`을 표시합니다.
- 세션 목록 보조 문구에 생성 시점 스냅샷 기준임을 명시했습니다.
- `CoachSessionService`의 active snapshot version pinning과 `ContextManagerService`의 pinned version 우선 로딩 검증을 보강했습니다.
- effect 안의 동기 setState, render 중 `Date.now()` 등 React lint 오류를 제거했습니다.

## Test
- `npm run lint`
- `npm run build`
- `git diff --check`
- `./gradlew.bat compileTestJava --rerun-tasks`
- 로컬 Docker Desktop 미실행으로 Testcontainers 기반 `integrationTest`는 실행하지 못했습니다.

Closes #337