### PR TITLE
feat(coach): per-call max_tokens(=3000) + 의도별 응답 깊이 프롬프트

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -25,21 +25,52 @@ public class CoachMessageService {
 
     private static final int PROPOSAL_TTL_HOURS = 24;
 
+    // Coach 채팅 응답 토큰 cap. 분석/진단/로드맵(DEFAULT_MAX_TOKENS=16384)보다 짧게 죄어
+    // reasoning loop가 cap까지 채우는 분산 폭주를 차단한다. (docs/32 § 9, 2026-05-13)
+    // 한국어 step-by-step 400~600자 + JSON wrapping에 충분한 여유.
+    private static final int COACH_MAX_TOKENS = 3000;
+
     // Coach 역할 + 출력 형식 규칙을 system role로 분리.
     // GLM-4.5 reasoning 모델에서 system role 분리는 chain-of-thought 길이를 크게 줄임 (docs/32 § 3).
     // 데이터 컨텍스트(profile/plan/activeSignals/사용자 메시지)는 ContextManagerService가 user role 텍스트로 조립.
     private static final String SYSTEM_PROMPT = """
-            당신은 학습 코치입니다. 사용자의 질문에 짧고 실용적인 답변을 한국어로 제공합니다.
+            당신은 학습 코치입니다. 사용자의 학습 로드맵·프로필 맥락에 맞춰
+            실행 가능한(actionable) 답변을 한국어로 제공합니다.
+
+            ## 동작 범위
+            당신이 실제로 시스템에 변경을 가할 수 있는 유일한 방법은 route=REPLAN_SUGGEST로
+            재계획을 제안하는 것입니다. 그 외의 모든 요청은 세션 내의 텍스트 질답으로 이루어지며,
+            실제 시스템 상태(진도, 알림, 외부 시스템)는 변경되지 않습니다.
+            "업데이트했습니다", "알림을 보냈습니다"처럼 일어나지 않은 동작을 단정하지 마세요.
+
+            ## 답변 길이/깊이 — 의도별 분기
+            detectedIntent를 먼저 정하고 거기에 맞춰 responseText 분량을 결정하세요.
+            - CONFIRMATION / STATUS_CHECK / SMALL_TALK: 1~2문장.
+            - LEARNING_GUIDE / CONCEPT_EXPLAIN / TASK_BREAKDOWN: 4~6 단계의
+              step-by-step. 각 단계는 "무엇을 / 왜 / 어떻게 (1줄 실행 미션)" 순.
+              마지막 줄에 "다음에 물어볼 만한 질문" 1개를 제안.
+              총 한국어 250~500자. 사용자의 현재 주차/로드맵 topic을 1번은 인용.
+            - REPLAN_TRIGGER: 결정 근거 1~2문장 + REPLAN_SUGGEST.
+            - OUT_OF_SCOPE (코드 실행, 진도 mutation, 외부 시스템 호출 등): 못 한다고
+              솔직히 1문장으로 답하고 가능한 대안을 1줄 제시.
+
+            ## 답변 품질 가이드
+            - 사용자가 이미 안다고 말한 내용(예: "자바 기본은 안다")은 다시 설명하지 말 것.
+            - "공식 문서를 보세요" 같은 일반론으로 끝내지 말고, 한 단계라도 구체적인
+              실습 미션(예: "Optional.ofNullable로 NPE 방어하는 메서드 1개 작성")을 포함.
+            - 학습 자료를 추천할 때는 카테고리(공식 docs / 한국어 인강 / 책 / 예제 repo)를
+              구분해 1~2개씩만 제시. URL은 사용자가 명시한 출처가 아니면 만들지 말 것.
+            - 코드를 보여줄 때는 4~10줄 스니펫으로 최소화. 긴 코드는 핵심 라인만.
 
             ## 응답 형식 (반드시 JSON만 출력)
             {
               "route": "SIMPLE_GUIDE | REPLAN_SUGGEST | DISMISS",
               "responseText": "<사용자에게 보여줄 메시지>",
               "replanReason": "<REPLAN_SUGGEST일 때만, 재계획 필요 이유>",
-              "detectedIntent": "<감지된 의도 (선택)>"
+              "detectedIntent": "<감지된 의도. 위 분기 라벨 중 하나 권장>"
             }
 
-            규칙:
+            라우팅 규칙:
             - activeSignals가 없거나 단순 질문이면 route=SIMPLE_GUIDE
             - activeSignals가 있고 재계획이 필요하다고 판단되면 route=REPLAN_SUGGEST
             - 신호가 있어도 처리 불필요하면 route=DISMISS
@@ -47,7 +78,7 @@ public class CoachMessageService {
 
             출력 제약:
             - JSON 외 텍스트(설명, 추론, 코드펜스 ```) 절대 출력 금지
-            - markdown으로 JSON을 감싸지 마세요
+            - markdown으로 JSON을 감싸지 마세요 (단, responseText 본문 안의 markdown은 허용)
             - 모든 필드명은 위 스키마와 정확히 일치해야 함
             - responseText, replanReason, detectedIntent는 한국어로 작성
             - 기술명, 제품명, 프레임워크명, enum 값은 원문 유지
@@ -108,7 +139,8 @@ public class CoachMessageService {
         AssembledContext context = contextManagerService.assembleAuto(session, userMessage);
         String llmRaw = llmClient.complete(
                 PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY + "\n\n" + SYSTEM_PROMPT,
-                context.systemPrompt()
+                context.systemPrompt(),
+                COACH_MAX_TOKENS
         );
         CoachResponseParser.ParsedCoachResponse parsed = responseParser.parse(llmRaw);
 

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -46,13 +46,21 @@ public class AiGatewayLlmClient implements LlmClient {
         if (prompt == null || prompt.isBlank()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "prompt is empty");
         }
-        return callApi(java.util.List.of(new Message("user", prompt)), prompt.getBytes().length);
+        return callApi(java.util.List.of(new Message("user", prompt)), prompt.getBytes().length, DEFAULT_MAX_TOKENS);
     }
 
     @Override
     public String complete(String systemPrompt, String userPrompt) {
+        return complete(systemPrompt, userPrompt, DEFAULT_MAX_TOKENS);
+    }
+
+    @Override
+    public String complete(String systemPrompt, String userPrompt, int maxTokens) {
         if (userPrompt == null || userPrompt.isBlank()) {
             throw new ServiceException(ErrorCode.INVALID_INPUT, "user prompt is empty");
+        }
+        if (maxTokens <= 0) {
+            throw new ServiceException(ErrorCode.INVALID_INPUT, "maxTokens must be positive");
         }
         java.util.List<Message> messages;
         int promptBytes;
@@ -66,13 +74,13 @@ public class AiGatewayLlmClient implements LlmClient {
             );
             promptBytes = systemPrompt.getBytes().length + userPrompt.getBytes().length;
         }
-        return callApi(messages, promptBytes);
+        return callApi(messages, promptBytes, maxTokens);
     }
 
-    private String callApi(java.util.List<Message> messages, int promptBytes) {
+    private String callApi(java.util.List<Message> messages, int promptBytes, int maxTokens) {
         long startNs = System.nanoTime();
-        log.debug("LLM request starting: model={}, promptBytes={}, messages={}",
-                properties.model(), promptBytes, messages.size());
+        log.debug("LLM request starting: model={}, promptBytes={}, messages={}, maxTokens={}",
+                properties.model(), promptBytes, messages.size(), maxTokens);
         try {
             ChatCompletionResponse response = restClient.post()
                     .uri("/v1/chat/completions")
@@ -82,7 +90,7 @@ public class AiGatewayLlmClient implements LlmClient {
                     .body(new ChatCompletionRequest(
                             properties.model(),
                             messages,
-                            16384,
+                            maxTokens,
                             false
                     ))
                     .retrieve()

--- a/backend/src/main/java/com/back/coach/external/llm/LlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/LlmClient.java
@@ -13,6 +13,12 @@ package com.back.coach.external.llm;
 public interface LlmClient {
 
     /**
+     * 호출 site별 cap을 명시하지 않을 때 적용되는 기본값.
+     * 5개 PromptBuilder(분석/진단/로드맵) 호출 경로는 이 값을 사용.
+     */
+    int DEFAULT_MAX_TOKENS = 16384;
+
+    /**
      * user role 단일 메시지로 동기 completion 호출. (legacy)
      *
      * @throws com.back.coach.global.exception.ServiceException
@@ -37,5 +43,18 @@ public interface LlmClient {
             return complete(userPrompt);
         }
         return complete(systemPrompt + "\n\n" + userPrompt);
+    }
+
+    /**
+     * system role + user role 분리 + 호출 site별 `max_tokens` 명시.
+     *
+     * <p>Coach 채팅처럼 reasoning loop 상한을 죄어 latency 분산을 줄이고 싶은 경로에서 사용.
+     * 분석/진단/로드맵 등 출력 크기가 큰 경로는 2-arg 오버로드로 기본 cap을 그대로 쓰면 됨.
+     *
+     * <p>기본 구현은 maxTokens를 무시하고 2-arg 호출로 위임 — 실제 HTTP 파라미터로 전달하려면
+     * 구현체에서 override 해야 함.
+     */
+    default String complete(String systemPrompt, String userPrompt, int maxTokens) {
+        return complete(systemPrompt, userPrompt);
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -97,7 +98,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("USER 메시지 전송 시 USER/COACH 두 행이 저장되고 COACH는 SIMPLE_GUIDE 라우트")
     void sendMessageStoresUserAndCoachRows() {
-        given(llmClient.complete(anyString(), anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
         );
 
@@ -108,7 +109,7 @@ class CoachMessageServiceIntegrationTest {
         assertThat(coachMessage.getMessageText()).contains("Redis");
 
         ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
-        verify(llmClient).complete(systemCaptor.capture(), anyString());
+        verify(llmClient).complete(systemCaptor.capture(), anyString(), anyInt());
         assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
         assertThat(systemCaptor.getValue()).contains("responseText, replanReason, detectedIntent는 한국어로 작성");
 
@@ -151,7 +152,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("LLM 실패 시 USER 메시지는 저장되지만 COACH 행은 생성되지 않음")
     void llmFailureLeavesOnlyUserMessage() {
-        given(llmClient.complete(anyString(), anyString())).willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willThrow(new ServiceException(ErrorCode.LLM_TIMEOUT));
 
         assertThatThrownBy(() -> coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?"))
                 .isInstanceOf(ServiceException.class)
@@ -165,7 +166,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("getMessages: 저장된 USER/COACH 메시지를 시간순으로 조회")
     void getMessagesReturnsStoredMessagesInTimeOrder() {
-        given(llmClient.complete(anyString(), anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\",\"detectedIntent\":\"CHECK_TODAY_PLAN\"}"
         );
         coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");
@@ -183,7 +184,7 @@ class CoachMessageServiceIntegrationTest {
     @Test
     @DisplayName("getMessages: 닫힌 세션도 히스토리 조회 가능")
     void getMessagesAllowsClosedSession() {
-        given(llmClient.complete(anyString(), anyString())).willReturn(
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(
                 "{\"route\":\"SIMPLE_GUIDE\",\"responseText\":\"이번 주는 Redis 캐시부터 학습하세요.\"}"
         );
         coachMessageService.sendMessage(userId, sessionId, "오늘 뭐 공부할까?");


### PR DESCRIPTION
## Summary

- `LlmClient`에 `complete(system, user, maxTokens)` 오버로드 + `DEFAULT_MAX_TOKENS=16384` 상수 추가. 1-arg / 2-arg 경로는 default 그대로 → 분석/진단/로드맵 호출 무영향.
- `AiGatewayLlmClient`가 maxTokens를 실제 HTTP payload로 전달. `callApi` 시그니처 확장.
- Coach 채팅만 `COACH_MAX_TOKENS=3000` 적용 — reasoning loop가 16384까지 채우는 worst-case 차단.
- `SYSTEM_PROMPT` 재작성: 의도별 길이 분기(CONFIRMATION/LEARNING_GUIDE/REPLAN_TRIGGER/OUT_OF_SCOPE) + 답변 품질 가이드("공식 문서 보세요" 일반론 금지, 최소 1개 실습 미션, URL 환각 금지, 코드 4–10줄) + `detectedIntent` 라벨 활성화.

## Why

수동 시연에서 학습 질문("Java 기초 어떻게 배워?")에 1–2문장 일반론으로 끝나 ChatGPT 대비 수박 겉핥기. 원인은 기존 시스템 프롬프트의 "짧고 실용적인" 지시가 모든 의도에 균일 적용되던 것. streaming(#220) 미도입이라 길이로 latency가 직결되니 *의도별* 분기로 깊이를 늘리되 cap으로 reasoning loop 분산은 죈다.

자세한 배경/측정 추정/제한 사항은 `docs/32_prompt_tuning_log.md` § 9 (별도 커밋 예정, untracked).

## Test plan

- [x] `CoachMessageServiceIntegrationTest` 7 케이스 GREEN (stub을 3-arg `anyInt()`로 갱신)
- [x] `AiGatewayLlmClientTest` GREEN (1-arg 경로는 `max_tokens=16384` 그대로)
- [ ] 시연 전 수동 fixture 3건 비교 (학습 가이드 / 단순 확인 / replan 트리거) — fixture 자동화는 § 9 backlog
- [ ] 응답 잘림 모니터링: 한국어 500자 + reasoning 섞임 케이스에서 3000 토큰 잘림 발생 시 4000–5000으로 상향