### PR TITLE
feat(coach): 로드맵 기반 실행형 학습 가이드 강화

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -34,7 +34,7 @@ public class CoachMessageService {
     // GLM-4.5 reasoning 모델에서 system role 분리는 chain-of-thought 길이를 크게 줄임 (docs/32 § 3).
     // 데이터 컨텍스트(profile/plan/activeSignals/사용자 메시지)는 ContextManagerService가 user role 텍스트로 조립.
     private static final String SYSTEM_PROMPT = """
-            당신은 학습 코치입니다. 사용자의 학습 로드맵·프로필 맥락에 맞춰
+            당신은 학습 코치입니다. 사용자의 학습 로드맵과 프로필 맥락에 맞춰
             실행 가능한(actionable) 답변을 한국어로 제공합니다.
 
             ## 동작 범위
@@ -46,12 +46,13 @@ public class CoachMessageService {
             ## 답변 길이/깊이 — 의도별 분기
             detectedIntent를 먼저 정하고 거기에 맞춰 responseText 분량을 결정하세요.
             - CONFIRMATION / STATUS_CHECK / SMALL_TALK: 1~2문장.
-            - LEARNING_GUIDE / CONCEPT_EXPLAIN / TASK_BREAKDOWN: 4~6 단계의
-              step-by-step. 각 단계는 "무엇을 / 왜 / 어떻게 (1줄 실행 미션)" 순.
-              roadmap.weeks[].topic/tasks/materials와 관련 있으면 반드시 그 항목을 우선 근거로 사용.
+            - LEARNING_GUIDE / CONCEPT_EXPLAIN / TASK_BREAKDOWN: 4~6줄의 번호 목록.
+              각 줄은 "무엇을 / 왜 / 어떻게 (1줄 실행 미션)" 순서로 짧게 작성.
+              roadmap.weeks[].topic/tasks/materials와 관련 있으면 반드시 그 항목의 title을 그대로 인용.
+              roadmap.weeks[]에 없는 주차, topic, task, material, 책 제목, URL은 새로 만들지 말 것.
               중간에 짧은 insight(왜 이 순서가 중요한지 또는 초보자가 놓치기 쉬운 함정) 1개를 포함.
-              마지막 줄은 "우선순위: 1) ... 2) ... 3) ..."처럼 다음 행동 2~3개를 제안.
-              총 한국어 300~600자. 사용자의 현재 주차/로드맵 topic을 1번은 인용.
+              마지막 줄은 "우선순위: 1) ... 2) ..."처럼 다음 행동 2개만 제안.
+              총 한국어 300~500자. 사용자의 현재 주차/로드맵 topic을 1번은 인용.
             - REPLAN_TRIGGER: 결정 근거 1~2문장 + REPLAN_SUGGEST.
             - OUT_OF_SCOPE (코드 실행, 진도 mutation, 외부 시스템 호출 등): 못 한다고
               솔직히 1문장으로 답하고 가능한 대안을 1줄 제시.
@@ -62,6 +63,7 @@ public class CoachMessageService {
               실습 미션(예: "Optional.ofNullable로 NPE 방어하는 메서드 1개 작성")을 포함.
             - 로드맵에 tasks/materials가 있으면 문서 읽기, 예제 구현, 영상/강의, 작은 프로젝트 중
               저장된 항목을 먼저 연결해 제안. 로드맵 근거 없이 새 URL을 만들지 말 것.
+            - 저장된 materials가 없으면 자료 이름이나 URL을 추정하지 말고, "저장된 자료 없음"이라고 짧게 표현.
             - 학습 자료를 추천할 때는 카테고리(공식 docs / 한국어 인강 / 책 / 예제 repo)를
               구분해 1~2개씩만 제시. URL은 사용자가 명시한 출처가 아니면 만들지 말 것.
             - 코드를 보여줄 때는 4~10줄 스니펫으로 최소화. 긴 코드는 핵심 라인만.

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachMessageService.java
@@ -48,8 +48,10 @@ public class CoachMessageService {
             - CONFIRMATION / STATUS_CHECK / SMALL_TALK: 1~2문장.
             - LEARNING_GUIDE / CONCEPT_EXPLAIN / TASK_BREAKDOWN: 4~6 단계의
               step-by-step. 각 단계는 "무엇을 / 왜 / 어떻게 (1줄 실행 미션)" 순.
-              마지막 줄에 "다음에 물어볼 만한 질문" 1개를 제안.
-              총 한국어 250~500자. 사용자의 현재 주차/로드맵 topic을 1번은 인용.
+              roadmap.weeks[].topic/tasks/materials와 관련 있으면 반드시 그 항목을 우선 근거로 사용.
+              중간에 짧은 insight(왜 이 순서가 중요한지 또는 초보자가 놓치기 쉬운 함정) 1개를 포함.
+              마지막 줄은 "우선순위: 1) ... 2) ... 3) ..."처럼 다음 행동 2~3개를 제안.
+              총 한국어 300~600자. 사용자의 현재 주차/로드맵 topic을 1번은 인용.
             - REPLAN_TRIGGER: 결정 근거 1~2문장 + REPLAN_SUGGEST.
             - OUT_OF_SCOPE (코드 실행, 진도 mutation, 외부 시스템 호출 등): 못 한다고
               솔직히 1문장으로 답하고 가능한 대안을 1줄 제시.
@@ -58,6 +60,8 @@ public class CoachMessageService {
             - 사용자가 이미 안다고 말한 내용(예: "자바 기본은 안다")은 다시 설명하지 말 것.
             - "공식 문서를 보세요" 같은 일반론으로 끝내지 말고, 한 단계라도 구체적인
               실습 미션(예: "Optional.ofNullable로 NPE 방어하는 메서드 1개 작성")을 포함.
+            - 로드맵에 tasks/materials가 있으면 문서 읽기, 예제 구현, 영상/강의, 작은 프로젝트 중
+              저장된 항목을 먼저 연결해 제안. 로드맵 근거 없이 새 URL을 만들지 말 것.
             - 학습 자료를 추천할 때는 카테고리(공식 docs / 한국어 인강 / 책 / 예제 repo)를
               구분해 1~2개씩만 제시. URL은 사용자가 명시한 출처가 아니면 만들지 말 것.
             - 코드를 보여줄 때는 4~10줄 스니펫으로 최소화. 긴 코드는 핵심 라인만.

--- a/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
+++ b/backend/src/main/java/com/back/coach/domain/coach/service/CoachSessionService.java
@@ -9,6 +9,8 @@ import com.back.coach.global.code.ChatSessionStatus;
 import com.back.coach.global.code.ContextType;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -31,17 +33,20 @@ public class CoachSessionService {
     private final UserContextSnapshotRepository contextSnapshotRepository;
     private final ContextSnapshotPublisher contextSnapshotPublisher;
     private final TransactionTemplate transactionTemplate;
+    private final ObjectMapper objectMapper;
 
     public CoachSessionService(
             ChatSessionRepository chatSessionRepository,
             UserContextSnapshotRepository contextSnapshotRepository,
             ContextSnapshotPublisher contextSnapshotPublisher,
-            TransactionTemplate transactionTemplate
+            TransactionTemplate transactionTemplate,
+            ObjectMapper objectMapper
     ) {
         this.chatSessionRepository = chatSessionRepository;
         this.contextSnapshotRepository = contextSnapshotRepository;
         this.contextSnapshotPublisher = contextSnapshotPublisher;
         this.transactionTemplate = transactionTemplate;
+        this.objectMapper = objectMapper;
     }
 
     // 트랜잭션 밖에서 self-heal publish 먼저 실행 후, 짧은 auto-tx로 세션 생성.
@@ -77,7 +82,7 @@ public class CoachSessionService {
     }
 
     /**
-     * Placeholder snapshot이 이미 존재할 때만 publisher 호출 (self-heal).
+     * Placeholder snapshot 또는 legacy PLAN snapshot이 이미 존재할 때만 publisher 호출 (self-heal).
      * snapshot이 아예 없는 경우는 v1 입력 미완 = 사용자에게 SNAPSHOT_NOT_FOUND를 그대로 노출.
      * outer tx 밖에서 동기 실행되므로 새 active snapshot이 즉시 가시화된다.
      * payload가 풍부하면 skip → churn 0.
@@ -92,10 +97,11 @@ public class CoachSessionService {
                 });
 
         contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN)
-                .filter(this::isPlaceholder)
+                .filter(this::needsPlanSelfHeal)
                 .ifPresent(stale -> {
-                    log.info("PLAN snapshot self-heal: publishing for userId={} (current bytes={})",
-                            userId, stale.getPayload() == null ? 0 : stale.getPayload().length());
+                    log.info("PLAN snapshot self-heal: publishing for userId={} (current bytes={}, hasWeeks={})",
+                            userId, stale.getPayload() == null ? 0 : stale.getPayload().length(),
+                            hasRoadmapWeeks(stale));
                     contextSnapshotPublisher.publishPlan(userId);
                 });
     }
@@ -103,6 +109,19 @@ public class CoachSessionService {
     private boolean isPlaceholder(UserContextSnapshot snapshot) {
         String payload = snapshot.getPayload();
         return payload == null || payload.length() < PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD;
+    }
+
+    private boolean needsPlanSelfHeal(UserContextSnapshot snapshot) {
+        return isPlaceholder(snapshot) || !hasRoadmapWeeks(snapshot);
+    }
+
+    private boolean hasRoadmapWeeks(UserContextSnapshot snapshot) {
+        try {
+            JsonNode root = objectMapper.readTree(snapshot.getPayload());
+            return root.path("roadmap").path("weeks").isArray();
+        } catch (Exception ignored) {
+            return false;
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotPublisher.java
+++ b/backend/src/main/java/com/back/coach/domain/context/service/ContextSnapshotPublisher.java
@@ -7,13 +7,16 @@ import com.back.coach.domain.github.repository.GithubAnalysisRepository;
 import com.back.coach.domain.jobrole.entity.JobRole;
 import com.back.coach.domain.jobrole.repository.JobRoleRepository;
 import com.back.coach.domain.roadmap.entity.LearningRoadmap;
+import com.back.coach.domain.roadmap.entity.RoadmapWeek;
 import com.back.coach.domain.roadmap.repository.LearningRoadmapRepository;
+import com.back.coach.domain.roadmap.repository.RoadmapWeekRepository;
 import com.back.coach.domain.user.entity.UserProfile;
 import com.back.coach.domain.user.entity.UserSkill;
 import com.back.coach.domain.user.repository.UserProfileRepository;
 import com.back.coach.domain.user.repository.UserSkillRepository;
 import com.back.coach.global.code.ContextType;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -45,6 +48,7 @@ public class ContextSnapshotPublisher {
     private final GithubAnalysisRepository githubAnalysisRepository;
     private final CapabilityDiagnosisRepository capabilityDiagnosisRepository;
     private final LearningRoadmapRepository learningRoadmapRepository;
+    private final RoadmapWeekRepository roadmapWeekRepository;
     private final ObjectMapper objectMapper;
 
     public ContextSnapshotPublisher(
@@ -55,6 +59,7 @@ public class ContextSnapshotPublisher {
             GithubAnalysisRepository githubAnalysisRepository,
             CapabilityDiagnosisRepository capabilityDiagnosisRepository,
             LearningRoadmapRepository learningRoadmapRepository,
+            RoadmapWeekRepository roadmapWeekRepository,
             ObjectMapper objectMapper
     ) {
         this.storageService = storageService;
@@ -64,6 +69,7 @@ public class ContextSnapshotPublisher {
         this.githubAnalysisRepository = githubAnalysisRepository;
         this.capabilityDiagnosisRepository = capabilityDiagnosisRepository;
         this.learningRoadmapRepository = learningRoadmapRepository;
+        this.roadmapWeekRepository = roadmapWeekRepository;
         this.objectMapper = objectMapper;
     }
 
@@ -195,12 +201,39 @@ public class ContextSnapshotPublisher {
         root.put("progressAsOf", now.toString());
 
         ObjectNode rmNode = root.putObject("roadmap");
+        ArrayNode weeksNode = rmNode.putArray("weeks");
         if (roadmap.isPresent()) {
             LearningRoadmap r = roadmap.get();
             rmNode.put("totalWeeks", r.getTotalWeeks());
             rmNode.put("summary", r.getSummary());
+            for (RoadmapWeek week : roadmapWeekRepository.findByRoadmapIdOrderByWeekNumberAsc(r.getId())) {
+                ObjectNode weekNode = weeksNode.addObject();
+                weekNode.put("weekNumber", week.getWeekNumber());
+                weekNode.put("topic", week.getTopic());
+                weekNode.put("reason", week.getReasonText());
+                if (week.getEstimatedHours() != null) {
+                    weekNode.put("estimatedHours", week.getEstimatedHours());
+                }
+                weekNode.set("tasks", readArrayOrEmpty(week.getTasksJson()));
+                weekNode.set("materials", readArrayOrEmpty(week.getMaterialsJson()));
+            }
         }
 
         return objectMapper.writeValueAsString(root);
+    }
+
+    private ArrayNode readArrayOrEmpty(String json) {
+        if (json == null || json.isBlank()) {
+            return objectMapper.createArrayNode();
+        }
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            if (node.isArray()) {
+                return (ArrayNode) node;
+            }
+        } catch (Exception ignored) {
+            // malformed v1 payload should not block snapshot publication
+        }
+        return objectMapper.createArrayNode();
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -109,9 +109,15 @@ class CoachMessageServiceIntegrationTest {
         assertThat(coachMessage.getMessageText()).contains("Redis");
 
         ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
-        verify(llmClient).complete(systemCaptor.capture(), anyString(), anyInt());
+        ArgumentCaptor<Integer> maxTokensCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(llmClient).complete(systemCaptor.capture(), anyString(), maxTokensCaptor.capture());
         assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
         assertThat(systemCaptor.getValue()).contains("responseText, replanReason, detectedIntent는 한국어로 작성");
+        assertThat(systemCaptor.getValue()).contains("roadmap.weeks[].topic/tasks/materials");
+        assertThat(systemCaptor.getValue()).contains("insight");
+        assertThat(systemCaptor.getValue()).contains("우선순위");
+        assertThat(systemCaptor.getValue()).contains("새 URL을 만들지 말 것");
+        assertThat(maxTokensCaptor.getValue()).isEqualTo(3000);
 
         List<CoachConversation> rows = coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         assertThat(rows).hasSize(2);

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachMessageServiceIntegrationTest.java
@@ -114,9 +114,12 @@ class CoachMessageServiceIntegrationTest {
         assertThat(systemCaptor.getValue()).contains("Write all user-visible natural-language values in Korean");
         assertThat(systemCaptor.getValue()).contains("responseText, replanReason, detectedIntent는 한국어로 작성");
         assertThat(systemCaptor.getValue()).contains("roadmap.weeks[].topic/tasks/materials");
+        assertThat(systemCaptor.getValue()).contains("title을 그대로 인용");
+        assertThat(systemCaptor.getValue()).contains("없는 주차, topic, task, material, 책 제목, URL은 새로 만들지 말 것");
         assertThat(systemCaptor.getValue()).contains("insight");
         assertThat(systemCaptor.getValue()).contains("우선순위");
         assertThat(systemCaptor.getValue()).contains("새 URL을 만들지 말 것");
+        assertThat(systemCaptor.getValue()).doesNotContain("·");
         assertThat(maxTokensCaptor.getValue()).isEqualTo(3000);
 
         List<CoachConversation> rows = coachConversationRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);

--- a/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/coach/service/CoachSessionServiceIntegrationTest.java
@@ -229,6 +229,24 @@ class CoachSessionServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("self-heal: legacy PLAN snapshot에 roadmap.weeks가 없으면 새 세션은 보강된 PLAN version에 pin된다")
+    void selfHealRefreshesLegacyPlanSnapshotWithoutRoadmapWeeks() {
+        seedSnapshot(ContextType.PROFILE, 1);
+        seedSnapshot(ContextType.PLAN, 1, legacyRichPlanPayloadWithoutWeeks());
+
+        ChatSession session = coachSessionService.startSession(userId);
+
+        assertThat(session.getProfileVersion()).isEqualTo(1);
+        assertThat(session.getRoadmapVersion()).isGreaterThan(1);
+        assertThat(contextSnapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PLAN))
+                .hasValueSatisfying(snapshot -> {
+                    assertThat(snapshot.getVersion()).isEqualTo(session.getRoadmapVersion());
+                    assertThat(snapshot.getPayload()).contains("\"roadmap\"");
+                    assertThat(snapshot.getPayload()).contains("\"weeks\"");
+                });
+    }
+
+    @Test
     @DisplayName("self-heal: 두 snapshot 모두 풍부하면 publisher가 호출되지 않고 기존 version에 pin")
     void noSelfHealWhenSnapshotsAlreadyRich() {
         seedSnapshot(ContextType.PROFILE, 7);
@@ -289,10 +307,16 @@ class CoachSessionServiceIntegrationTest {
 
     private static String paddedPayload(ContextType type) {
         // 500 bytes 이상이면 publisher self-heal이 트리거되지 않는다 (PLACEHOLDER_PAYLOAD_BYTES_THRESHOLD).
+        if (type == ContextType.PLAN) {
+            return planContextPayload("padded");
+        }
         return "{\"contextType\":\"" + type.name() + "\",\"_padding\":\"" + "x".repeat(600) + "\"}";
     }
 
     private static String contextPayload(ContextType type, String marker) {
+        if (type == ContextType.PLAN) {
+            return planContextPayload(marker);
+        }
         return """
                 {
                   "contextType": "%s",
@@ -305,5 +329,48 @@ class CoachSessionServiceIntegrationTest {
                   }
                 }
                 """.formatted(type.code(), marker, marker, "x".repeat(600));
+    }
+
+    private static String planContextPayload(String marker) {
+        return """
+                {
+                  "contextType": "PLAN",
+                  "sourceRefs": {
+                    "marker": "%s"
+                  },
+                  "roadmap": {
+                    "summary": "%s",
+                    "weeks": [
+                      {
+                        "weekNumber": 1,
+                        "topic": "%s Java 기초",
+                        "tasks": [
+                          {
+                            "title": "%s 예제 구현",
+                            "type": "example"
+                          }
+                        ],
+                        "materials": []
+                      }
+                    ]
+                  },
+                  "_padding": "%s"
+                }
+                """.formatted(marker, marker, marker, marker, "x".repeat(600));
+    }
+
+    private static String legacyRichPlanPayloadWithoutWeeks() {
+        return """
+                {
+                  "contextType": "PLAN",
+                  "sourceRefs": {
+                    "marker": "legacy"
+                  },
+                  "roadmap": {
+                    "summary": "legacy plan without weeks"
+                  },
+                  "_padding": "%s"
+                }
+                """.formatted("x".repeat(600));
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextManagerServiceIntegrationTest.java
@@ -94,6 +94,24 @@ class ContextManagerServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Tier 1: 고정 PLAN snapshot의 주차 topic/tasks/materials가 프롬프트에 포함된다")
+    void tier1IncludesPinnedPlanWeekTasksAndMaterials() {
+        seedSnapshot(ContextType.PROFILE, 1, "{\"job\":\"BACKEND\"}");
+        seedSnapshot(ContextType.PLAN, 1, planPayloadWithWeekDetails("plan-pinned"));
+        ChatSession session = startSession(1, 1);
+
+        AssembledContext ctx = contextManagerService.assemble(
+                session, CoachTemplate.COACH_LIGHTWEIGHT, "Java 기초를 배우려면 어떻게 해야 해?"
+        );
+
+        assertThat(ctx.systemPrompt()).contains("plan-pinned");
+        assertThat(ctx.systemPrompt()).contains("Java 기초 문법");
+        assertThat(ctx.systemPrompt()).contains("Optional 예제 구현");
+        assertThat(ctx.systemPrompt()).contains("Oracle Java Tutorial");
+        assertThat(ctx.systemPrompt()).contains("https://docs.oracle.com/javase/tutorial/");
+    }
+
+    @Test
     @DisplayName("Tier 3: Tier 1 + 활성 신호 섹션 포함")
     void tier3IncludesActiveSignals() {
         seedSnapshot(ContextType.PROFILE, 2, "{}");
@@ -314,5 +332,39 @@ class ContextManagerServiceIntegrationTest {
                   }
                 }
                 """.formatted(type.code(), marker, marker);
+    }
+
+    private static String planPayloadWithWeekDetails(String marker) {
+        return """
+                {
+                  "contextType": "PLAN",
+                  "sourceRefs": {
+                    "marker": "%s"
+                  },
+                  "roadmap": {
+                    "summary": "Java 기초와 Spring 입문",
+                    "weeks": [
+                      {
+                        "weekNumber": 1,
+                        "topic": "Java 기초 문법",
+                        "reason": "Spring 학습 전 문법 기반 확보",
+                        "tasks": [
+                          {
+                            "title": "Optional 예제 구현",
+                            "type": "example"
+                          }
+                        ],
+                        "materials": [
+                          {
+                            "title": "Oracle Java Tutorial",
+                            "type": "docs",
+                            "url": "https://docs.oracle.com/javase/tutorial/"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+                """.formatted(marker);
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotPublisherIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/context/service/ContextSnapshotPublisherIntegrationTest.java
@@ -7,11 +7,14 @@ import com.back.coach.domain.user.repository.UserRepository;
 import com.back.coach.global.code.AuthProvider;
 import com.back.coach.global.code.ContextType;
 import com.back.coach.support.IntegrationTest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Optional;
@@ -33,6 +36,12 @@ class ContextSnapshotPublisherIntegrationTest {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     private Long userId;
 
     @BeforeEach
@@ -47,6 +56,13 @@ class ContextSnapshotPublisherIntegrationTest {
 
     @AfterEach
     void cleanUp() {
+        jdbc.update("DELETE FROM roadmap_weeks WHERE roadmap_id IN (SELECT id FROM learning_roadmaps WHERE user_id = ?)", userId);
+        jdbc.update("DELETE FROM learning_roadmaps WHERE user_id = ?", userId);
+        jdbc.update("DELETE FROM capability_diagnoses WHERE user_id = ?", userId);
+        jdbc.update("DELETE FROM github_analyses WHERE user_id = ?", userId);
+        jdbc.update("DELETE FROM github_connections WHERE user_id = ?", userId);
+        jdbc.update("DELETE FROM user_profiles WHERE user_id = ?", userId);
+        jdbc.update("DELETE FROM job_roles WHERE role_code LIKE 'TEST_SNAPSHOT_%'");
         snapshotRepository.deleteAll(snapshotRepository.findAll().stream()
                 .filter(s -> s.getUserId().equals(userId))
                 .toList());
@@ -63,6 +79,35 @@ class ContextSnapshotPublisherIntegrationTest {
         assertThat(active).isPresent();
         assertThat(active.get().getVersion()).isEqualTo(1);
         assertThat(active.get().getValidTo()).isNull();
+    }
+
+    @Test
+    @DisplayName("publishPlan: PLAN snapshot에 로드맵 주차별 tasks/materials를 포함한다")
+    void publishPlanIncludesRoadmapWeeksTasksAndMaterials() throws Exception {
+        Long roadmapId = seedRoadmapWithWeeks();
+
+        publisher.publishPlan(userId);
+
+        UserContextSnapshot active = snapshotRepository
+                .findActiveByUserIdAndContextType(userId, ContextType.PLAN)
+                .orElseThrow();
+        JsonNode root = objectMapper.readTree(active.getPayload());
+
+        assertThat(root.path("sourceRefs").path("roadmapId").asText()).isEqualTo(String.valueOf(roadmapId));
+        assertThat(root.path("sourceRefs").path("roadmapVersion").asInt()).isEqualTo(3);
+        assertThat(root.path("sourceRefs").path("diagnosisVersion").asInt()).isEqualTo(2);
+        assertThat(root.path("roadmap").path("summary").asText()).isEqualTo("Java 기초와 Spring 입문 로드맵");
+        assertThat(root.path("roadmap").path("totalWeeks").asInt()).isEqualTo(4);
+
+        JsonNode weeks = root.path("roadmap").path("weeks");
+        assertThat(weeks.size()).isEqualTo(2);
+        assertThat(weeks.get(0).path("weekNumber").asInt()).isEqualTo(1);
+        assertThat(weeks.get(0).path("topic").asText()).isEqualTo("Java 기초 문법");
+        assertThat(weeks.get(0).path("reason").asText()).contains("기초 문법");
+        assertThat(weeks.get(0).path("estimatedHours").decimalValue()).isEqualByComparingTo("5.5");
+        assertThat(weeks.get(0).path("tasks").get(0).path("title").asText()).isEqualTo("Optional 예제 구현");
+        assertThat(weeks.get(0).path("materials").get(0).path("url").asText()).isEqualTo("https://docs.oracle.com/javase/tutorial/");
+        assertThat(weeks.get(1).path("tasks").size()).isZero();
     }
 
     @Test
@@ -105,5 +150,65 @@ class ContextSnapshotPublisherIntegrationTest {
                 snapshotRepository.findActiveByUserIdAndContextType(userId, ContextType.PROFILE);
         assertThat(active).isPresent();
         assertThat(active.get().getVersion()).isEqualTo(2);
+    }
+
+    private Long seedRoadmapWithWeeks() {
+        String suffix = String.valueOf(System.nanoTime());
+        Long jobRoleId = jdbc.queryForObject("""
+                INSERT INTO job_roles (role_code, role_name, description)
+                VALUES (?, ?, ?)
+                RETURNING id
+                """, Long.class, "TEST_SNAPSHOT_" + suffix, "테스트 백엔드 " + suffix, "test");
+
+        Long profileId = jdbc.queryForObject("""
+                INSERT INTO user_profiles (user_id, job_role_id, current_level, weekly_study_hours, interest_areas_json)
+                VALUES (?, ?, 'BASIC', 8, ?::jsonb)
+                RETURNING id
+                """, Long.class, userId, jobRoleId, "[\"Java\", \"Spring\"]");
+
+        Long connectionId = jdbc.queryForObject("""
+                INSERT INTO github_connections (user_id, github_user_id, github_login, access_type)
+                VALUES (?, ?, ?, 'OAUTH')
+                RETURNING id
+                """, Long.class, userId, "snapshot-" + suffix, "snapshot-" + suffix);
+
+        Long analysisId = jdbc.queryForObject("""
+                INSERT INTO github_analyses (user_id, github_connection_id, version, summary, analysis_payload)
+                VALUES (?, ?, 1, 'GitHub 분석 요약', ?::jsonb)
+                RETURNING id
+                """, Long.class, userId, connectionId, "{}");
+
+        Long diagnosisId = jdbc.queryForObject("""
+                INSERT INTO capability_diagnoses (
+                  user_id, profile_id, github_analysis_id, job_role_id, version, current_level, summary, diagnosis_payload
+                )
+                VALUES (?, ?, ?, ?, 2, 'BASIC', 'Java 기초 보강 필요', ?::jsonb)
+                RETURNING id
+                """, Long.class, userId, profileId, analysisId, jobRoleId, "{}");
+
+        Long roadmapId = jdbc.queryForObject("""
+                INSERT INTO learning_roadmaps (user_id, diagnosis_id, version, total_weeks, summary, roadmap_payload)
+                VALUES (?, ?, 3, 4, 'Java 기초와 Spring 입문 로드맵', ?::jsonb)
+                RETURNING id
+                """, Long.class, userId, diagnosisId, "{}");
+
+        jdbc.update("""
+                INSERT INTO roadmap_weeks (
+                  roadmap_id, week_number, topic, reason_text, tasks_json, materials_json, estimated_hours
+                )
+                VALUES (?, 1, 'Java 기초 문법', '기초 문법을 먼저 잡아야 Spring 예제를 이해할 수 있음',
+                        ?::jsonb, ?::jsonb, 5.5)
+                """, roadmapId,
+                "[{\"title\":\"Optional 예제 구현\",\"type\":\"example\",\"description\":\"NPE 방어 메서드 작성\"}]",
+                "[{\"title\":\"Oracle Java Tutorial\",\"type\":\"docs\",\"url\":\"https://docs.oracle.com/javase/tutorial/\"}]");
+        jdbc.update("""
+                INSERT INTO roadmap_weeks (
+                  roadmap_id, week_number, topic, reason_text, tasks_json, materials_json, estimated_hours
+                )
+                VALUES (?, 2, 'Spring Controller 실습', 'HTTP 요청 흐름을 작은 API로 확인',
+                        ?::jsonb, ?::jsonb, 4.0)
+                """, roadmapId, "{}", "[]");
+
+        return roadmapId;
     }
 }

--- a/docs/16_v2_context_snapshot_contract.md
+++ b/docs/16_v2_context_snapshot_contract.md
@@ -115,7 +115,28 @@ Pattern Detector 저장 원본과 `CONVERSATION.activeSignals` 요약 관계는 
   "roadmap": {
     "title": "백엔드 Redis 역량 보강 로드맵",
     "totalWeeks": 12,
-    "summary": "Redis 캐시 설계부터 프로젝트 적용까지 진행"
+    "summary": "Redis 캐시 설계부터 프로젝트 적용까지 진행",
+    "weeks": [
+      {
+        "weekNumber": 1,
+        "topic": "Redis 기초",
+        "reason": "캐시 패턴 학습 전 자료구조와 TTL 개념을 먼저 확인",
+        "estimatedHours": 4.5,
+        "tasks": [
+          {
+            "title": "TTL 캐시 예제 구현",
+            "type": "example"
+          }
+        ],
+        "materials": [
+          {
+            "title": "Redis 공식 문서",
+            "type": "docs",
+            "url": "https://redis.io/docs/latest/"
+          }
+        ]
+      }
+    ]
   },
   "currentWeek": {
     "roadmapWeekId": "21",
@@ -145,6 +166,8 @@ Pattern Detector 저장 원본과 `CONVERSATION.activeSignals` 요약 관계는 
 규칙
 - 로드맵 원본은 `learning_roadmaps + roadmap_weeks + progress_logs`다.
 - `roadmap_payload`는 보조 결과로만 사용하고, `roadmap_weeks`와 불일치하면 `roadmap_weeks`를 우선한다.
+- Coach가 실행형 학습 가이드를 만들 때 쓰는 주차별 학습 항목은 `roadmap.weeks[]`에 둔다.
+- `roadmap.weeks[].tasks`, `roadmap.weeks[].materials`는 `roadmap_weeks.tasks_json`, `materials_json`의 구조를 유지하며, 파싱할 수 없으면 빈 배열로 둘 수 있다.
 - 진도 상태는 `progress_logs` 최신 row 기준으로 계산한다.
 - `progressAsOf`는 진도 snapshot을 조립한 기준 시각이다.
 - 로드맵이 없으면 `roadmap`, `currentWeek`는 `null`, `weeks`는 빈 배열로 둘 수 있다.

--- a/docs/17_v2_context_tier_assembly.md
+++ b/docs/17_v2_context_tier_assembly.md
@@ -36,6 +36,7 @@
 기본 데이터
 - `PROFILE` snapshot의 `profile`, `skills`, `diagnosisSummary.topMissingSkills`
 - `PLAN` snapshot의 `currentWeek`, 최근 progress 상태
+- 학습 가이드 질문이면 `PLAN.roadmap.weeks[]`의 현재/관련 주차 `topic`, `tasks`, `materials`
 
 무효화 기준
 - 프로필 저장
@@ -51,7 +52,7 @@
 
 기본 데이터
 - Tier 1 전체
-- `PLAN` snapshot의 `roadmap`, `weeks`, `progressSummary`
+- `PLAN` snapshot의 `roadmap`, `roadmap.weeks[]`, `weeks`, `progressSummary`
 - `PROFILE` snapshot의 `diagnosisSummary`
 
 무효화 기준


### PR DESCRIPTION
## Summary
Coach가 저장된 로드맵의 주차별 과제/자료를 근거로 실행형 학습 가이드를 제공하도록 개선합니다.

## Changes
- PLAN snapshot에 `roadmap.weeks[]`의 topic/tasks/materials를 포함
- legacy PLAN snapshot이 새 세션 시작 시 보강된 snapshot으로 self-heal되도록 처리
- Coach prompt에 로드맵 근거 우선 사용, 짧은 insight, 우선순위 기반 다음 행동 지시 추가
- AI Gateway에서 400을 유발할 수 있는 prompt 호환 문자 제거 및 저장되지 않은 주차/자료 생성 금지 강화
- Context/Coach 관련 검증 테스트와 snapshot 계약 문서 보강

## Test
- `backend/gradlew.bat compileTestJava --rerun-tasks`
- `backend/gradlew.bat test`
- `backend/gradlew.bat integrationTest --tests com.back.coach.domain.context.service.ContextSnapshotPublisherIntegrationTest --tests com.back.coach.domain.coach.service.CoachSessionServiceIntegrationTest --tests com.back.coach.domain.context.service.ContextManagerServiceIntegrationTest --tests com.back.coach.domain.coach.service.CoachMessageServiceIntegrationTest`
- `backend/gradlew.bat integrationTest --tests com.back.coach.domain.coach.service.CoachMessageServiceIntegrationTest`
- `git diff --check`
- 로컬 AI Gateway 실제 호출 1회: `Java 기초를 배우려면 어떻게 해야 해?` 질문에서 저장된 `Java 기초 문법`, `Optional 예제 구현`, `컬렉션 반복문 리팩터링`, `Oracle Java Tutorial`을 근거로 JSON 응답 확인

Closes #340