### PR TITLE
fix(portfolio): 포트폴리오 초안 LLM 구조화 안정화

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
@@ -44,7 +44,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @Service
 public class PortfolioDraftService {
@@ -52,38 +51,47 @@ public class PortfolioDraftService {
     private static final int RECENT_GITHUB_ANALYSIS_LIMIT = 5;
     private static final int RECENT_CONVERSATION_LIMIT = 20;
     private static final int PORTFOLIO_DRAFT_MAX_TOKENS = 6000;
-    private static final Set<String> REQUIRED_VARIANT_KEYS = Set.of("DONE", "DONE_IN_PROGRESS", "ALL");
+    private static final List<SectionSpec> SECTION_SPECS = List.of(
+            new SectionSpec("overview", "개요"),
+            new SectionSpec("problemGoal", "문제/목표"),
+            new SectionSpec("studyAndImplementation", "진행한 학습과 구현"),
+            new SectionSpec("techStack", "사용 기술"),
+            new SectionSpec("lessons", "배운 점"),
+            new SectionSpec("nextImprovements", "다음 개선"),
+            new SectionSpec("memoCandidates", "학습 메모 후보"),
+            new SectionSpec("recommendationCandidates", "추천/예정 후보"),
+            new SectionSpec("sourceSummary", "사용 근거")
+    );
 
     private static final String SYSTEM_PROMPT = """
-            당신은 개발자 포트폴리오 기술서 초안 작성 도우미입니다.
-            반드시 한국어 JSON만 출력합니다.
+            You create Korean portfolio draft sections from the provided source JSON.
+            Output exactly one JSON object. Do not output markdown, prose, code fences, or explanations.
 
-            원칙:
-            - 완료 사실은 officialStudyRecords.done에 있는 항목만 사용합니다.
-            - 진행 중 사실은 officialStudyRecords.inProgress에 있는 항목만 사용합니다.
-            - planned, coachRecommendations는 예정, 다음 개선, 확장 계획으로만 작성합니다.
-            - coachConversationCandidates.userMemos는 학습 메모 후보로만 표시하고 완료 사실로 확정하지 않습니다.
-            - 입력에 없는 URL, 책, 강의, 프로젝트명, 수치 성과를 새로 만들지 않습니다.
-            - GitHub 근거는 github.repoSummaries, github.evidences, github.skills에 있는 내용만 사용합니다.
+            Evidence rules:
+            - DONE may use only officialStudyRecords.done.
+            - DONE_IN_PROGRESS may use only officialStudyRecords.done and officialStudyRecords.inProgress.
+            - ALL may use done, inProgress, planned, and coachRecommendations, but planned and coachRecommendations must be written only as future plans.
+            - coachConversationCandidates.userMemos are memo candidates only, never completed facts.
+            - Use github.repoSummaries, github.evidences, and github.skills only as GitHub evidence.
+            - Do not invent URLs, books, courses, repository names, metrics, or project names.
 
-            응답 schema:
+            Required JSON schema:
             {
               "title": "프로젝트 기술서 초안 제목",
-              "variants": [
-                {"key": "DONE", "label": "완료 기반", "content": "markdown"},
-                {"key": "DONE_IN_PROGRESS", "label": "완료 + 진행 중", "content": "markdown"},
-                {"key": "ALL", "label": "전체 계획 포함", "content": "markdown"}
-              ]
+              "sectionsByVariant": {
+                "DONE": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] },
+                "DONE_IN_PROGRESS": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] },
+                "ALL": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] }
+              }
             }
 
-            출력 길이:
-            - variants는 정확히 3개만 출력합니다.
-            - 각 content는 700~1000자 안에서 작성합니다.
-            - 세 content 전체를 합쳐 3500자를 넘기지 않습니다.
-            - JSON 밖 설명, markdown fence, 중첩된 draftPayload/data wrapper를 출력하지 않습니다.
-
-            각 content에는 개요, 문제/목표, 진행한 학습과 구현, 사용 기술, 배운 점,
-            다음 개선, 학습 메모 후보, 추천/예정 후보, 사용 근거 섹션을 포함합니다.
+            Hard output constraints:
+            - Top-level fields must be exactly title and sectionsByVariant.
+            - Do not output fields named variants, content, draftPayload, data, markdown, or responseText.
+            - sectionsByVariant must contain exactly DONE, DONE_IN_PROGRESS, and ALL.
+            - Every section field value must be an array of Korean strings. Never use objects or nested arrays.
+            - Each array must contain 1 to 4 short strings. Each string must be 120 Korean characters or fewer.
+            - Do not include markdown headings such as ##. The server will render markdown later.
             """;
 
     private final PortfolioDraftRepository portfolioDraftRepository;
@@ -395,12 +403,11 @@ public class PortfolioDraftService {
 
     private String buildUserPrompt(ObjectNode sourcePayload) {
         return """
-                아래 source JSON만 근거로 프로젝트 기술서 초안 3개 버전을 작성하세요.
-                DONE 버전은 done만 사용하세요.
-                DONE_IN_PROGRESS 버전은 done과 inProgress만 사용하세요.
-                ALL 버전은 done, inProgress, planned, coachRecommendations를 사용하되 planned와 coachRecommendations는 예정으로만 쓰세요.
+                Create the required sectionsByVariant JSON from this source JSON only.
+                The server renders markdown later, so return section arrays only.
+                Repeat: do not return variants[].content and do not write markdown.
 
-                source:
+                Source JSON:
                 %s
                 """.formatted(sourcePayload.toPrettyString());
     }
@@ -417,26 +424,55 @@ public class PortfolioDraftService {
             title = "포트폴리오 기술서 초안";
         }
 
-        JsonNode variantsNode = root.path("variants");
-        if (!variantsNode.isArray()) {
+        JsonNode sectionsByVariant = root.path("sectionsByVariant");
+        if (!sectionsByVariant.isObject()) {
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
         }
         List<PortfolioDraftVariant> variants = new ArrayList<>();
-        Set<String> seenKeys = new LinkedHashSet<>();
-        for (JsonNode node : variantsNode) {
-            String key = text(node, "key");
-            String label = text(node, "label");
-            String content = text(node, "content");
-            if (key == null || label == null || content == null || content.isBlank()) {
+        for (String key : List.of("DONE", "DONE_IN_PROGRESS", "ALL")) {
+            JsonNode sectionNode = sectionsByVariant.path(key);
+            if (!sectionNode.isObject()) {
                 throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
             }
-            variants.add(new PortfolioDraftVariant(key, label, content));
-            seenKeys.add(key);
-        }
-        if (!seenKeys.containsAll(REQUIRED_VARIANT_KEYS)) {
-            throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
+            variants.add(new PortfolioDraftVariant(key, variantLabel(key), renderSections(sectionNode)));
         }
         return new PortfolioDraftGenerationResult(title, new PortfolioDraftPayload("PROJECT_WRITEUP", variants));
+    }
+
+    private String renderSections(JsonNode sectionNode) {
+        StringBuilder sb = new StringBuilder();
+        for (SectionSpec section : SECTION_SPECS) {
+            appendSection(sb, section.title());
+            appendBulletValues(sb, sectionNode.path(section.fieldName()));
+        }
+        return sb.toString().trim();
+    }
+
+    private void appendBulletValues(StringBuilder sb, JsonNode values) {
+        if (!values.isArray() || values.isEmpty()) {
+            appendLine(sb, "- 작성 가능한 근거가 없습니다.");
+            return;
+        }
+        int appended = 0;
+        for (JsonNode value : values) {
+            String text = value.isTextual() ? value.asText() : null;
+            if (text != null && !text.isBlank()) {
+                appendLine(sb, "- " + text);
+                appended++;
+            }
+        }
+        if (appended == 0) {
+            appendLine(sb, "- 작성 가능한 근거가 없습니다.");
+        }
+    }
+
+    private String variantLabel(String key) {
+        return switch (key) {
+            case "DONE" -> "완료 기반";
+            case "DONE_IN_PROGRESS" -> "완료 + 진행 중";
+            case "ALL" -> "전체 계획 포함";
+            default -> key;
+        };
     }
 
     private PortfolioDraftGenerationResult buildFallbackDraft(ObjectNode sourcePayload) {
@@ -677,5 +713,8 @@ public class PortfolioDraftService {
     }
 
     private record PortfolioSource(ObjectNode sourcePayload, ObjectNode sourceRefs) {
+    }
+
+    private record SectionSpec(String fieldName, String title) {
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
@@ -52,19 +52,20 @@ public class PortfolioDraftService {
     private static final int RECENT_CONVERSATION_LIMIT = 20;
     private static final int PORTFOLIO_DRAFT_MAX_TOKENS = 6000;
     private static final List<SectionSpec> SECTION_SPECS = List.of(
-            new SectionSpec("overview", "개요"),
-            new SectionSpec("problemGoal", "문제/목표"),
-            new SectionSpec("studyAndImplementation", "진행한 학습과 구현"),
-            new SectionSpec("techStack", "사용 기술"),
-            new SectionSpec("lessons", "배운 점"),
-            new SectionSpec("nextImprovements", "다음 개선"),
-            new SectionSpec("memoCandidates", "학습 메모 후보"),
-            new SectionSpec("recommendationCandidates", "추천/예정 후보"),
-            new SectionSpec("sourceSummary", "사용 근거")
+            new SectionSpec("overview", "개요", SectionRenderMode.PARAGRAPH),
+            new SectionSpec("problemGoal", "문제/목표", SectionRenderMode.PARAGRAPH),
+            new SectionSpec("studyAndImplementation", "구현 내용", SectionRenderMode.BULLET),
+            new SectionSpec("techStack", "사용 기술", SectionRenderMode.BULLET),
+            new SectionSpec("lessons", "기술적 판단과 배운 점", SectionRenderMode.PARAGRAPH),
+            new SectionSpec("nextImprovements", "다음 개선", SectionRenderMode.BULLET),
+            new SectionSpec("memoCandidates", "학습 메모 후보", SectionRenderMode.BULLET),
+            new SectionSpec("recommendationCandidates", "추천/예정 후보", SectionRenderMode.BULLET),
+            new SectionSpec("sourceSummary", "사용 근거", SectionRenderMode.BULLET)
     );
 
     private static final String SYSTEM_PROMPT = """
-            You create Korean portfolio draft sections from the provided source JSON.
+            You create Korean project write-up draft sections from the provided source JSON.
+            The goal is a portfolio/project description draft, not a study checklist or simple learning summary.
             Output exactly one JSON object. Do not output markdown, prose, code fences, or explanations.
 
             Evidence rules:
@@ -74,6 +75,17 @@ public class PortfolioDraftService {
             - coachConversationCandidates.userMemos are memo candidates only, never completed facts.
             - Use github.repoSummaries, github.evidences, and github.skills only as GitHub evidence.
             - Do not invent URLs, books, courses, repository names, metrics, or project names.
+            - Never convert IN_PROGRESS or TODO/planned records into completed facts.
+            - Do not claim performance improvement, verification completion, production operation, or project completion unless a DONE progress note explicitly supports it.
+
+            Writing rules:
+            - Reconstruct learning records as project experience candidates: problem, implementation context, technical decision, and next improvement.
+            - Do not write bare checklist fragments like "Redis 기본 명령어 학습 완료" unless the source only supports a candidate note.
+            - overview, problemGoal, and lessons must be paragraph strings that explain meaning and context.
+            - studyAndImplementation should describe what was implemented, organized, or prepared and why it matters for a project write-up.
+            - IN_PROGRESS work must use Korean expressions like "진행 중", "확인 중", "설계 중", or "적용 중"; never "완료", "검증했다", or "운영했다".
+            - TODO/planned work must appear only as next improvement or recommendation candidates, using future tense.
+            - If evidence is weak, phrase it as "초안 후보" or "다음 개선 후보"; never present it as completed work.
 
             Required JSON schema:
             {
@@ -90,7 +102,7 @@ public class PortfolioDraftService {
             - Do not output fields named variants, content, draftPayload, data, markdown, or responseText.
             - sectionsByVariant must contain exactly DONE, DONE_IN_PROGRESS, and ALL.
             - Every section field value must be an array of Korean strings. Never use objects or nested arrays.
-            - Each array must contain 1 to 4 short strings. Each string must be 120 Korean characters or fewer.
+            - Each array must contain 1 to 3 strings. Each string must be 260 Korean characters or fewer.
             - Do not include markdown headings such as ##. The server will render markdown later.
             """;
 
@@ -404,6 +416,7 @@ public class PortfolioDraftService {
     private String buildUserPrompt(ObjectNode sourcePayload) {
         return """
                 Create the required sectionsByVariant JSON from this source JSON only.
+                Write for a Korean project write-up draft, not a study checklist.
                 The server renders markdown later, so return section arrays only.
                 Repeat: do not return variants[].content and do not write markdown.
 
@@ -443,9 +456,34 @@ public class PortfolioDraftService {
         StringBuilder sb = new StringBuilder();
         for (SectionSpec section : SECTION_SPECS) {
             appendSection(sb, section.title());
-            appendBulletValues(sb, sectionNode.path(section.fieldName()));
+            if (section.renderMode() == SectionRenderMode.PARAGRAPH) {
+                appendParagraphValues(sb, sectionNode.path(section.fieldName()));
+            } else {
+                appendBulletValues(sb, sectionNode.path(section.fieldName()));
+            }
         }
         return sb.toString().trim();
+    }
+
+    private void appendParagraphValues(StringBuilder sb, JsonNode values) {
+        if (!values.isArray() || values.isEmpty()) {
+            appendLine(sb, "작성 가능한 근거가 없습니다.");
+            return;
+        }
+        int appended = 0;
+        for (JsonNode value : values) {
+            String text = value.isTextual() ? value.asText() : null;
+            if (text != null && !text.isBlank()) {
+                if (appended > 0) {
+                    sb.append('\n');
+                }
+                appendLine(sb, text);
+                appended++;
+            }
+        }
+        if (appended == 0) {
+            appendLine(sb, "작성 가능한 근거가 없습니다.");
+        }
     }
 
     private void appendBulletValues(StringBuilder sb, JsonNode values) {
@@ -511,12 +549,12 @@ public class PortfolioDraftService {
         JsonNode coach = sourcePayload.path("coachConversationCandidates");
 
         appendSection(sb, "개요");
-        appendLine(sb, "저장된 로드맵 진도와 GitHub 분석 근거를 바탕으로 정리한 프로젝트 기술서 초안입니다.");
+        appendLine(sb, "저장된 로드맵 진도와 GitHub 분석 근거를 프로젝트 기술서 초안으로 연결한 문서입니다. 확인된 완료 기록은 구현 경험의 후보로, 진행 중이거나 예정인 기록은 다음 개선 후보로 분리했습니다.");
 
         appendSection(sb, "문제/목표");
-        appendLine(sb, "학습 로드맵에서 확인된 보완 주제를 실제 구현 경험과 정리 가능한 산출물로 연결하는 것이 목표입니다.");
+        appendLine(sb, "로드맵에 흩어진 학습 기록을 구현 맥락, 기술 선택 이유, 다음 개선 계획으로 재구성하는 것이 목표입니다. 근거가 부족한 항목은 완료 사실로 확정하지 않고 초안 후보로만 남깁니다.");
 
-        appendSection(sb, "진행한 학습과 구현");
+        appendSection(sb, "구현 내용");
         if (includeDone) {
             appendWeekList(sb, "완료", official.path("done"));
         }
@@ -526,14 +564,14 @@ public class PortfolioDraftService {
         if (includePlanned) {
             appendWeekList(sb, "예정", official.path("planned"));
         }
-        if (sb.charAt(sb.length() - 1) == '\n' && sb.toString().endsWith("진행한 학습과 구현\n")) {
+        if (sb.charAt(sb.length() - 1) == '\n' && sb.toString().endsWith("구현 내용\n")) {
             appendLine(sb, "- 아직 확정된 학습 진도 근거가 없습니다.");
         }
 
         appendSection(sb, "사용 기술");
         appendTextValues(sb, github.path("skills"), "- ");
 
-        appendSection(sb, "배운 점");
+        appendSection(sb, "기술적 판단과 배운 점");
         appendGithubEvidence(sb, github);
 
         appendSection(sb, "다음 개선");
@@ -715,6 +753,11 @@ public class PortfolioDraftService {
     private record PortfolioSource(ObjectNode sourcePayload, ObjectNode sourceRefs) {
     }
 
-    private record SectionSpec(String fieldName, String title) {
+    private enum SectionRenderMode {
+        PARAGRAPH,
+        BULLET
+    }
+
+    private record SectionSpec(String fieldName, String title, SectionRenderMode renderMode) {
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
@@ -115,14 +115,15 @@ class PortfolioDraftServiceIntegrationTest {
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> maxTokensCaptor = ArgumentCaptor.forClass(Integer.class);
         verify(llmClient).complete(systemCaptor.capture(), userPromptCaptor.capture(), maxTokensCaptor.capture());
-        assertThat(systemCaptor.getValue()).contains("한국어 JSON만 출력");
+        assertThat(systemCaptor.getValue()).contains("JSON-only output assistant for Korean users");
         assertThat(systemCaptor.getValue()).contains("coachConversationCandidates.userMemos");
-        assertThat(systemCaptor.getValue()).contains("입력에 없는 URL, 책, 강의, 프로젝트명, 수치 성과를 새로 만들지 않습니다");
-        assertThat(systemCaptor.getValue()).contains("각 content는 700~1000자");
-        assertThat(systemCaptor.getValue()).contains("draftPayload/data wrapper를 출력하지 않습니다");
+        assertThat(systemCaptor.getValue()).contains("Do not invent URLs");
+        assertThat(systemCaptor.getValue()).contains("sectionsByVariant");
+        assertThat(systemCaptor.getValue()).contains("Do not output fields named variants");
         assertThat(maxTokensCaptor.getValue()).isEqualTo(6000);
 
         String prompt = userPromptCaptor.getValue();
+        assertThat(prompt).contains("sectionsByVariant");
         assertThat(prompt).contains("Redis 공식 문서 정리 완료");
         assertThat(prompt).contains("캐시 예제 진행 중");
         assertThat(prompt).contains("장애 대응 회고 작성");
@@ -131,6 +132,20 @@ class PortfolioDraftServiceIntegrationTest {
         assertThat(prompt).contains("Coach가 추천한 다음 프로젝트 후보");
         assertThat(prompt).contains("최신 Spring API 개선 요약");
         assertThat(prompt).doesNotContain("오래된 Spring API 요약");
+
+        String doneContent = response.draftPayload().variants().get(0).content();
+        String inProgressContent = response.draftPayload().variants().get(1).content();
+        String allContent = response.draftPayload().variants().get(2).content();
+        assertThat(doneContent)
+                .contains("## 개요", "## 진행한 학습과 구현", "Redis 공식 문서 정리 완료")
+                .doesNotContain("캐시 예제 진행 중")
+                .doesNotContain("아직 시작하지 않은 모니터링 개선");
+        assertThat(inProgressContent)
+                .contains("캐시 예제 진행 중")
+                .doesNotContain("아직 시작하지 않은 모니터링 개선");
+        assertThat(allContent)
+                .contains("아직 시작하지 않은 모니터링 개선")
+                .contains("Coach가 추천한 다음 프로젝트 후보");
     }
 
     @Test
@@ -190,6 +205,23 @@ class PortfolioDraftServiceIntegrationTest {
         assertThat(response.draftPayload().variants().get(2).content())
                 .contains("아직 시작하지 않은 모니터링 개선")
                 .contains("Coach가 추천한 다음 프로젝트 후보");
+    }
+
+    @Test
+    @DisplayName("createDraft: LLM section 일부가 비어도 markdown 섹션을 안전하게 조립한다")
+    void createDraftRendersEmptySectionsWithPlaceholder() {
+        Long userId = createUser();
+        seedPortfolioFixture(userId);
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(partialSectionsResponse());
+
+        PortfolioDraftDetailResponse response = portfolioDraftService.createDraft(userId);
+
+        assertThat(response.draftPayload().variants())
+                .extracting(PortfolioDraftVariant::key)
+                .containsExactly("DONE", "DONE_IN_PROGRESS", "ALL");
+        assertThat(response.draftPayload().variants().get(0).content())
+                .contains("## 개요", "- 완료한 Redis 문서 정리를 중심으로 기술합니다.")
+                .contains("## 문제/목표", "- 작성 가능한 근거가 없습니다.");
     }
 
     @Test
@@ -438,23 +470,60 @@ class PortfolioDraftServiceIntegrationTest {
         return """
                 {
                   "title": "백엔드 성장 포트폴리오 초안",
-                  "variants": [
-                    {
-                      "key": "DONE",
-                      "label": "완료 기반",
-                      "content": "## 개요\\n완료한 학습만 기반으로 작성"
+                  "sectionsByVariant": {
+                    "DONE": {
+                      "overview": ["완료한 Redis 공식 문서 정리를 중심으로 작성합니다."],
+                      "problemGoal": ["캐시 설계 기반을 포트폴리오 근거로 정리하는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료"],
+                      "techStack": ["Java", "Spring Boot"],
+                      "lessons": ["최신 Spring API 개선 요약"],
+                      "nextImprovements": ["완료 근거만 포함하므로 예정 작업은 제외합니다."],
+                      "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
+                      "recommendationCandidates": ["완료 기반 버전에서는 추천 후보를 완료 사실로 쓰지 않습니다."],
+                      "sourceSummary": ["progress_logs와 github_analyses를 근거로 사용했습니다."]
                     },
-                    {
-                      "key": "DONE_IN_PROGRESS",
-                      "label": "완료 + 진행 중",
-                      "content": "## 개요\\n진행 중 작업까지 포함"
+                    "DONE_IN_PROGRESS": {
+                      "overview": ["완료한 Redis 정리와 진행 중인 Spring 캐시 적용을 함께 작성합니다."],
+                      "problemGoal": ["문서 정리에서 실제 API 적용으로 확장하는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료", "캐시 예제 진행 중"],
+                      "techStack": ["Java", "Spring Boot"],
+                      "lessons": ["Controller와 Service 계층 구현 근거"],
+                      "nextImprovements": ["진행 중 작업을 마무리한 뒤 회고로 연결합니다."],
+                      "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
+                      "recommendationCandidates": ["진행 중 버전에서는 예정 후보를 완료 사실로 쓰지 않습니다."],
+                      "sourceSummary": ["progress_logs의 DONE과 IN_PROGRESS를 근거로 사용했습니다."]
                     },
-                    {
-                      "key": "ALL",
-                      "label": "전체 계획 포함",
-                      "content": "## 개요\\n예정 후보까지 포함"
+                    "ALL": {
+                      "overview": ["완료, 진행 중, 예정 후보를 전체 계획으로 묶어 작성합니다."],
+                      "problemGoal": ["운영 백엔드 역량을 포트폴리오 산출물로 연결하는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료", "캐시 예제 진행 중"],
+                      "techStack": ["Java", "Spring Boot", "Redis"],
+                      "lessons": ["최신 Spring API 개선 요약"],
+                      "nextImprovements": ["아직 시작하지 않은 모니터링 개선"],
+                      "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
+                      "recommendationCandidates": ["Coach가 추천한 다음 프로젝트 후보"],
+                      "sourceSummary": ["로드맵 진도, GitHub 분석, Coach 후보를 근거로 사용했습니다."]
                     }
-                  ]
+                  }
+                }
+                """;
+    }
+
+    private String partialSectionsResponse() {
+        return """
+                {
+                  "title": "부분 section 포트폴리오 초안",
+                  "sectionsByVariant": {
+                    "DONE": {
+                      "overview": ["완료한 Redis 문서 정리를 중심으로 기술합니다."]
+                    },
+                    "DONE_IN_PROGRESS": {
+                      "overview": ["진행 중인 캐시 예제를 함께 기술합니다."]
+                    },
+                    "ALL": {
+                      "overview": ["예정 후보까지 전체 계획으로 기술합니다."]
+                    }
+                  }
                 }
                 """;
     }

--- a/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
@@ -120,10 +120,17 @@ class PortfolioDraftServiceIntegrationTest {
         assertThat(systemCaptor.getValue()).contains("Do not invent URLs");
         assertThat(systemCaptor.getValue()).contains("sectionsByVariant");
         assertThat(systemCaptor.getValue()).contains("Do not output fields named variants");
+        assertThat(systemCaptor.getValue()).contains("project write-up");
+        assertThat(systemCaptor.getValue()).contains("not a study checklist");
+        assertThat(systemCaptor.getValue()).contains("paragraph strings");
+        assertThat(systemCaptor.getValue()).contains("Never convert IN_PROGRESS or TODO/planned records into completed facts");
+        assertThat(systemCaptor.getValue()).contains("Do not claim performance improvement");
         assertThat(maxTokensCaptor.getValue()).isEqualTo(6000);
 
         String prompt = userPromptCaptor.getValue();
         assertThat(prompt).contains("sectionsByVariant");
+        assertThat(prompt).contains("project write-up draft");
+        assertThat(prompt).contains("not a study checklist");
         assertThat(prompt).contains("Redis 공식 문서 정리 완료");
         assertThat(prompt).contains("캐시 예제 진행 중");
         assertThat(prompt).contains("장애 대응 회고 작성");
@@ -137,7 +144,9 @@ class PortfolioDraftServiceIntegrationTest {
         String inProgressContent = response.draftPayload().variants().get(1).content();
         String allContent = response.draftPayload().variants().get(2).content();
         assertThat(doneContent)
-                .contains("## 개요", "## 진행한 학습과 구현", "Redis 공식 문서 정리 완료")
+                .contains("## 개요\nRedis 공식 문서 정리를 통해", "## 구현 내용", "## 기술적 판단과 배운 점", "Redis 공식 문서 정리 완료")
+                .doesNotContain("## 개요\n-")
+                .doesNotContain("## 진행한 학습과 구현")
                 .doesNotContain("캐시 예제 진행 중")
                 .doesNotContain("아직 시작하지 않은 모니터링 개선");
         assertThat(inProgressContent)
@@ -197,7 +206,10 @@ class PortfolioDraftServiceIntegrationTest {
                 .extracting(PortfolioDraftVariant::key)
                 .containsExactly("DONE", "DONE_IN_PROGRESS", "ALL");
         assertThat(response.draftPayload().variants().get(0).content())
+                .contains("## 구현 내용", "## 기술적 판단과 배운 점")
                 .contains("Redis 공식 문서 정리 완료")
+                .doesNotContain("## 진행한 학습과 구현")
+                .doesNotContain("## 배운 점")
                 .doesNotContain("캐시 예제 진행 중");
         assertThat(response.draftPayload().variants().get(1).content())
                 .contains("캐시 예제 진행 중")
@@ -220,8 +232,10 @@ class PortfolioDraftServiceIntegrationTest {
                 .extracting(PortfolioDraftVariant::key)
                 .containsExactly("DONE", "DONE_IN_PROGRESS", "ALL");
         assertThat(response.draftPayload().variants().get(0).content())
-                .contains("## 개요", "- 완료한 Redis 문서 정리를 중심으로 기술합니다.")
-                .contains("## 문제/목표", "- 작성 가능한 근거가 없습니다.");
+                .contains("## 개요\n완료한 Redis 문서 정리를 중심으로 기술합니다.")
+                .contains("## 문제/목표\n작성 가능한 근거가 없습니다.")
+                .contains("## 구현 내용\n- 작성 가능한 근거가 없습니다.")
+                .doesNotContain("## 개요\n-");
     }
 
     @Test
@@ -472,34 +486,34 @@ class PortfolioDraftServiceIntegrationTest {
                   "title": "백엔드 성장 포트폴리오 초안",
                   "sectionsByVariant": {
                     "DONE": {
-                      "overview": ["완료한 Redis 공식 문서 정리를 중심으로 작성합니다."],
-                      "problemGoal": ["캐시 설계 기반을 포트폴리오 근거로 정리하는 것이 목표입니다."],
-                      "studyAndImplementation": ["Redis 공식 문서 정리 완료"],
+                      "overview": ["Redis 공식 문서 정리를 통해 캐시 적용 전 필요한 명령어와 데이터 만료 기준을 정리하고, 이를 백엔드 API 개선 후보로 연결한 프로젝트 기술서 초안입니다."],
+                      "problemGoal": ["캐시 설계 기반이 부족했던 문제를 공식 문서 기반으로 보완하고, 이후 실제 API 적용 단계에서 판단 기준으로 사용할 수 있게 정리하는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료를 바탕으로 캐시 적용 전 데이터 구조와 명령어 사용 기준을 정리했습니다."],
                       "techStack": ["Java", "Spring Boot"],
-                      "lessons": ["최신 Spring API 개선 요약"],
+                      "lessons": ["최신 Spring API 개선 요약을 GitHub 근거로 확인했으며, 캐시를 적용하기 전에는 저장된 코드 구조와 데이터 흐름을 먼저 설명할 수 있어야 한다는 점을 정리했습니다."],
                       "nextImprovements": ["완료 근거만 포함하므로 예정 작업은 제외합니다."],
                       "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
                       "recommendationCandidates": ["완료 기반 버전에서는 추천 후보를 완료 사실로 쓰지 않습니다."],
                       "sourceSummary": ["progress_logs와 github_analyses를 근거로 사용했습니다."]
                     },
                     "DONE_IN_PROGRESS": {
-                      "overview": ["완료한 Redis 정리와 진행 중인 Spring 캐시 적용을 함께 작성합니다."],
-                      "problemGoal": ["문서 정리에서 실제 API 적용으로 확장하는 것이 목표입니다."],
-                      "studyAndImplementation": ["Redis 공식 문서 정리 완료", "캐시 예제 진행 중"],
+                      "overview": ["완료한 Redis 정리와 캐시 예제 진행 중 기록을 연결해 문서 학습에서 실제 API 적용으로 확장하는 과정을 프로젝트 경험 후보로 작성합니다."],
+                      "problemGoal": ["문서로 정리한 캐시 개념을 Spring Boot API에 적용하며 동작 확인과 구현 기준을 함께 남기는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료 내용을 기준으로 캐시 예제 진행 중인 작업을 API 개선 후보로 연결했습니다."],
                       "techStack": ["Java", "Spring Boot"],
-                      "lessons": ["Controller와 Service 계층 구현 근거"],
+                      "lessons": ["Controller와 Service 계층 구현 근거를 함께 보면 캐시 적용은 단순 명령어 사용보다 요청 흐름과 책임 분리를 먼저 확인해야 한다는 점이 드러납니다."],
                       "nextImprovements": ["진행 중 작업을 마무리한 뒤 회고로 연결합니다."],
                       "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
                       "recommendationCandidates": ["진행 중 버전에서는 예정 후보를 완료 사실로 쓰지 않습니다."],
                       "sourceSummary": ["progress_logs의 DONE과 IN_PROGRESS를 근거로 사용했습니다."]
                     },
                     "ALL": {
-                      "overview": ["완료, 진행 중, 예정 후보를 전체 계획으로 묶어 작성합니다."],
-                      "problemGoal": ["운영 백엔드 역량을 포트폴리오 산출물로 연결하는 것이 목표입니다."],
-                      "studyAndImplementation": ["Redis 공식 문서 정리 완료", "캐시 예제 진행 중"],
+                      "overview": ["완료, 진행 중, 예정 후보를 한 문서에 묶되 완료 사실과 다음 개선 후보를 구분해 운영 백엔드 성장 흐름으로 작성합니다."],
+                      "problemGoal": ["캐시 적용 경험을 운영 안정성 관점의 포트폴리오 산출물로 확장하고, 아직 시작하지 않은 항목은 다음 개선 후보로 분리하는 것이 목표입니다."],
+                      "studyAndImplementation": ["Redis 공식 문서 정리 완료와 캐시 예제 진행 중 기록을 현재 구현 근거로 사용합니다."],
                       "techStack": ["Java", "Spring Boot", "Redis"],
-                      "lessons": ["최신 Spring API 개선 요약"],
-                      "nextImprovements": ["아직 시작하지 않은 모니터링 개선"],
+                      "lessons": ["최신 Spring API 개선 요약을 기준으로 캐시 적용과 모니터링 개선은 별도 단계로 관리해야 한다는 기술적 판단을 남깁니다."],
+                      "nextImprovements": ["아직 시작하지 않은 모니터링 개선은 완료 사실이 아니라 다음 개선 후보로 정리합니다."],
                       "memoCandidates": ["사용자가 직접 말한 학습 메모 후보"],
                       "recommendationCandidates": ["Coach가 추천한 다음 프로젝트 후보"],
                       "sourceSummary": ["로드맵 진도, GitHub 분석, Coach 후보를 근거로 사용했습니다."]


### PR DESCRIPTION
﻿## Summary
- 포트폴리오 초안 LLM 응답을 긴 markdown 3개 대신 variant별 section JSON으로 받도록 변경합니다.
- 서버가 section 배열을 기존 `draftPayload.variants[].content` markdown으로 조립합니다.
- 출력 목표를 단순 학습 요약이 아니라 프로젝트 기술서 초안으로 조정합니다.
- API 응답 shape, DB schema, 프론트 편집 흐름은 유지합니다.

## Changes
- LLM 프롬프트를 `sectionsByVariant` schema 중심으로 단순화
- section 배열을 markdown 섹션으로 렌더링하는 서버 조립 로직 추가
- `개요`, `문제/목표`, `기술적 판단과 배운 점`은 문단형으로 렌더링
- `구현 내용`, `사용 기술`, `다음 개선`, 후보/근거 섹션은 목록형 렌더링 유지
- IN_PROGRESS/TODO 근거를 완료 사실처럼 쓰지 않도록 프롬프트 제약 강화
- 기존 fallback 경로 유지 및 프로젝트 기술서 섹션 제목으로 정리
- section 조립, variant 범위, fallback, 문체 테스트 보강

## Test
- `./gradlew.bat compileTestJava --rerun-tasks`
- `./gradlew.bat integrationTest --tests "com.back.coach.domain.portfolio.*"`
- `git diff --check`
- 로컬 smoke: synthetic 사용자로 포트폴리오 초안 생성/목록/상세/PATCH API 확인
- 로컬 LLM smoke: draft #8 기준 3개 variant 저장 확인, 진행 중/예정 항목이 완료 사실이 아니라 진행 중/다음 개선 후보로 출력되는지 확인

Closes #346
