### PR TITLE
fix(auth): 로그인 상태와 배포 env 검증 안정화

### DIFF
--- a/.github/workflows/deploy-demo-bluegreen.yml
+++ b/.github/workflows/deploy-demo-bluegreen.yml
@@ -143,6 +143,7 @@ jobs:
           cp docker/docker-compose.deploy.yml "$bundle_dir/docker/docker-compose.deploy.yml"
           printf '%s\n' "$DEPLOY_ENV_FILE" > "$bundle_dir/docker/.env.deploy"
           sed -i 's/\r$//' "$bundle_dir/docker/.env.deploy"
+          bash scripts/deploy/validate-deploy-env.sh "$bundle_dir/docker/.env.deploy"
           cp scripts/smoke/deploy-smoke.ps1 "$bundle_dir/scripts/smoke/deploy-smoke.ps1"
           cp scripts/deploy/*.sh "$bundle_dir/scripts/deploy/"
 

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -2,13 +2,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
-import { api } from "@/lib/api";
-
-type Me = { userId: number; email: string; authProvider: string };
+import { ApiError } from "@/lib/api";
+import {
+  getCurrentUser,
+  logoutSession,
+  refreshSession,
+  type CurrentUser
+} from "@/features/auth/api";
 
 export default function MePage() {
   const router = useRouter();
-  const [me, setMe] = useState<Me | null>(null);
+  const [me, setMe] = useState<CurrentUser | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [authRequired, setAuthRequired] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -20,16 +24,20 @@ export default function MePage() {
     }
     setError(null);
     setAuthRequired(false);
-    const res = await api<Me>("/api/v1/auth/me");
-    if (res.ok && res.data) {
-      setMe(res.data);
-    } else if (res.status === 401) {
+    try {
+      setMe(await getCurrentUser());
+    } catch (caught) {
       setMe(null);
-      setAuthRequired(true);
-    } else {
-      setError(`HTTP ${res.status}`);
+      if (caught instanceof ApiError && caught.status === 401) {
+        setAuthRequired(true);
+      } else if (caught instanceof ApiError) {
+        setError(`HTTP ${caught.status}`);
+      } else {
+        setError("계정 정보를 불러오지 못했습니다.");
+      }
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -42,20 +50,25 @@ export default function MePage() {
   }, [load]);
 
   const refresh = async () => {
-    const res = await api("/api/v1/auth/refresh", { method: "POST" });
-    if (res.ok) await load();
-    else if (res.status === 401) {
-      setError(null);
-      setAuthRequired(true);
-    }
-    else {
-      setAuthRequired(false);
-      setError(`refresh 실패: HTTP ${res.status}`);
+    try {
+      await refreshSession();
+      await load();
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.status === 401) {
+        setError(null);
+        setAuthRequired(true);
+      } else if (caught instanceof ApiError) {
+        setAuthRequired(false);
+        setError(`refresh 실패: HTTP ${caught.status}`);
+      } else {
+        setAuthRequired(false);
+        setError("refresh 실패");
+      }
     }
   };
 
   const logout = async () => {
-    await api("/api/v1/auth/logout", { method: "POST" });
+    await logoutSession();
     router.push("/");
   };
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2,9 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-import { authNavigationItem, isNavigationItemActive, navigationItems } from "@/config/routes";
+import { isNavigationItemActive, navigationItems } from "@/config/routes";
+import { getCurrentUser } from "@/features/auth/api";
 import { CoachWidget } from "@/features/coach/coach-widget";
 
 type AppShellProps = {
@@ -14,6 +16,29 @@ type AppShellProps = {
 export function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const isLoginPage = pathname === "/login";
+  const [authState, setAuthState] = useState<"checking" | "authenticated" | "anonymous">(
+    "checking"
+  );
+
+  useEffect(() => {
+    let ignore = false;
+
+    getCurrentUser()
+      .then(() => {
+        if (!ignore) {
+          setAuthState("authenticated");
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setAuthState("anonymous");
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [pathname]);
 
   if (isLoginPage) {
     return <>{children}</>;
@@ -43,18 +68,35 @@ export function AppShell({ children }: AppShellProps) {
           })}
         </nav>
         <div className="topbar-actions">
-          <Link
-            aria-current={isNavigationItemActive(authNavigationItem, pathname) ? "page" : undefined}
-            className="nav-link"
-            data-active={isNavigationItemActive(authNavigationItem, pathname)}
-            href={authNavigationItem.href}
-          >
-            {authNavigationItem.label}
-          </Link>
+          <AuthStatusLink authState={authState} pathname={pathname} />
         </div>
       </header>
       <main className="page">{children}</main>
       <CoachWidget />
     </div>
+  );
+}
+
+type AuthStatusLinkProps = {
+  authState: "checking" | "authenticated" | "anonymous";
+  pathname: string;
+};
+
+function AuthStatusLink({ authState, pathname }: AuthStatusLinkProps) {
+  const item =
+    authState === "anonymous"
+      ? { exact: true, href: "/login", label: "로그인" }
+      : { exact: true, href: "/me", label: authState === "checking" ? "계정" : "내 계정" };
+  const isActive = isNavigationItemActive(item, pathname);
+
+  return (
+    <Link
+      aria-current={isActive ? "page" : undefined}
+      className="nav-link"
+      data-active={isActive}
+      href={item.href}
+    >
+      {item.label}
+    </Link>
   );
 }

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "@/lib/api";
+import type { ApiRequestOptions } from "@/lib/api";
+
+export type CurrentUser = {
+  authProvider: string;
+  email: string;
+  userId: number;
+};
+
+export function getCurrentUser(options?: ApiRequestOptions) {
+  return apiClient.get<CurrentUser>("/api/v1/auth/me", options);
+}
+
+export function refreshSession() {
+  return apiClient.post<void>("/api/v1/auth/refresh", undefined, {
+    skipAuthRefresh: true
+  });
+}
+
+export function logoutSession() {
+  return apiClient.post<void>("/api/v1/auth/logout", undefined, {
+    skipAuthRefresh: true
+  });
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -19,8 +19,11 @@ type ApiErrorParams = {
 };
 
 const JSON_CONTENT_TYPE = "application/json";
+const AUTH_REFRESH_PATH = "/api/v1/auth/refresh";
+const AUTH_LOGOUT_PATH = "/api/v1/auth/logout";
 
 let tokenProvider: ApiTokenProvider | null = null;
+let refreshPromise: Promise<void> | null = null;
 
 export class ApiError extends Error {
   readonly code?: string;
@@ -64,16 +67,42 @@ async function request<TData>(
   path: string,
   options: ApiRequestOptions = {}
 ) {
-  const { body, token, headers, credentials = "include", ...requestInit } = options;
-  const resolvedToken = token ?? (await tokenProvider?.()) ?? undefined;
-  const response = await fetch(resolveApiUrl(path), {
-    ...requestInit,
-    body: serializeBody(body),
-    credentials,
-    headers: buildHeaders(headers, body, resolvedToken),
-    method
-  });
-  const payload = await parseJson(response);
+  const {
+    body,
+    skipAuthRefresh = false,
+    token,
+    headers,
+    credentials = "include",
+    ...requestInit
+  } = options;
+  const requestBody = serializeBody(body);
+  const send = async () => {
+    const resolvedToken = token ?? (await tokenProvider?.()) ?? undefined;
+
+    return fetch(resolveApiUrl(path), {
+      ...requestInit,
+      body: requestBody,
+      credentials,
+      headers: buildHeaders(headers, body, resolvedToken),
+      method
+    });
+  };
+
+  let response = await send();
+  let payload = await parseJson(response);
+
+  if (
+    response.status === 401 &&
+    !skipAuthRefresh &&
+    shouldAttemptAuthRefresh(path, credentials)
+  ) {
+    const refreshed = await refreshAccessToken();
+
+    if (refreshed) {
+      response = await send();
+      payload = await parseJson(response);
+    }
+  }
 
   if (!response.ok) {
     throw new ApiError({
@@ -128,6 +157,43 @@ function isNativeBody(body: unknown): body is BodyInit {
     (typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams) ||
     (typeof ArrayBuffer !== "undefined" && body instanceof ArrayBuffer)
   );
+}
+
+function shouldAttemptAuthRefresh(path: string, credentials: RequestCredentials) {
+  const url = resolveApiUrl(path);
+
+  return (
+    credentials !== "omit" &&
+    !url.endsWith(AUTH_REFRESH_PATH) &&
+    !url.endsWith(AUTH_LOGOUT_PATH)
+  );
+}
+
+async function refreshAccessToken() {
+  if (!refreshPromise) {
+    refreshPromise = fetch(resolveApiUrl(AUTH_REFRESH_PATH), {
+      credentials: "include",
+      headers: {
+        Accept: JSON_CONTENT_TYPE
+      },
+      method: "POST"
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Auth refresh failed");
+        }
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  try {
+    await refreshPromise;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function parseJson(response: Response) {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -23,5 +23,6 @@ export type ApiErrorBody = {
 
 export type ApiRequestOptions = Omit<RequestInit, "body" | "method"> & {
   body?: unknown;
+  skipAuthRefresh?: boolean;
   token?: string;
 };

--- a/scripts/deploy/validate-deploy-env.sh
+++ b/scripts/deploy/validate-deploy-env.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file="${1:-docker/.env.deploy}"
+
+if [ ! -f "$env_file" ]; then
+  echo "::error::Deploy env file not found: $env_file" >&2
+  exit 1
+fi
+
+declare -A values=()
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+strip_quotes() {
+  local value="$1"
+  if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "$value"
+}
+
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+  line="${raw_line%$'\r'}"
+  line="${line#$'\ufeff'}"
+  line="$(trim "$line")"
+
+  if [ -z "$line" ] || [[ "$line" == \#* ]] || [[ "$line" != *=* ]]; then
+    continue
+  fi
+
+  key="$(trim "${line%%=*}")"
+  value="$(trim "${line#*=}")"
+  value="$(strip_quotes "$value")"
+
+  if [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    values["$key"]="$value"
+  fi
+done < "$env_file"
+
+required_keys=(
+  POSTGRES_DB
+  POSTGRES_USER
+  POSTGRES_PASSWORD
+  DATABASE_URL
+  DATABASE_USERNAME
+  DATABASE_PASSWORD
+  REDIS_HOST
+  REDIS_PORT
+  CORS_ALLOWED_ORIGINS
+  FRONTEND_URL
+  JWT_SECRET
+  GITHUB_CLIENT_ID
+  GITHUB_CLIENT_SECRET
+  GITHUB_CONNECTION_CLIENT_ID
+  GITHUB_CONNECTION_CLIENT_SECRET
+  AI_GATEWAY_API_KEY
+  AI_GATEWAY_BASE_URL
+  AI_GATEWAY_MODEL
+  AI_GATEWAY_TIMEOUT_CONNECT
+  AI_GATEWAY_TIMEOUT_READ
+  API_PROXY_CONNECT_TIMEOUT
+  API_PROXY_SEND_TIMEOUT
+  API_PROXY_READ_TIMEOUT
+)
+
+is_placeholder() {
+  local value="$1"
+  local normalized
+  normalized="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+
+  [ -z "$normalized" ] ||
+    [[ "$normalized" == *change-me* ]] ||
+    [[ "$normalized" == your-* ]] ||
+    [[ "$normalized" == *your-production* ]] ||
+    [[ "$normalized" == dummy ]] ||
+    [[ "$normalized" == example ]] ||
+    [[ "$normalized" == *example.com* ]] ||
+    [[ "$normalized" == *replace-me* ]] ||
+    [[ "$normalized" == *paste* ]] ||
+    [[ "$normalized" == todo ]]
+}
+
+error_count=0
+
+for key in "${required_keys[@]}"; do
+  if [[ ! -v "values[$key]" ]]; then
+    echo "::error::${key} is required in $env_file" >&2
+    error_count=$((error_count + 1))
+    continue
+  fi
+
+  if is_placeholder "${values[$key]}"; then
+    echo "::error::${key} must be set to a non-placeholder value" >&2
+    error_count=$((error_count + 1))
+  fi
+done
+
+if [ "$error_count" -gt 0 ]; then
+  echo "::error::Deploy env validation failed with ${error_count} problem(s)" >&2
+  exit 1
+fi
+
+echo "Deploy env validation passed (${#required_keys[@]} keys checked)."


### PR DESCRIPTION
﻿## Summary
- 로그인 상태에 따라 상단 계정 링크를 `계정` / `내 계정` / `로그인`으로 표시합니다.
- API client에서 access token 401 응답 시 refresh 후 원 요청을 1회 재시도합니다.
- Blue-Green 배포 전에 `.env.deploy` 필수값과 placeholder를 검증합니다.

## Changes
- `AppShell`과 `/me` 페이지가 공통 auth API helper를 사용하도록 정리했습니다.
- refresh/logout 요청은 자동 refresh 대상에서 제외해 무한 루프를 막았습니다.
- `scripts/deploy/validate-deploy-env.sh`를 추가하고 CD workflow에서 배포 env 파일 작성 직후 실행합니다.

## Test
- `npm run lint`
- `npm run build`
- `bash -n scripts/deploy/validate-deploy-env.sh`
- placeholder 없는 임시 env validation success
- `docker/.env.deploy.example` validation fail 확인
- `git diff --check`

Closes #348
