### PR TITLE
feat(profile): 프로필 입력과 GitHub 인증 UX 개선

### DIFF
--- a/backend/src/main/resources/db/migration/V11__seed_fullstack_job_role.sql
+++ b/backend/src/main/resources/db/migration/V11__seed_fullstack_job_role.sql
@@ -1,0 +1,39 @@
+INSERT INTO job_roles (role_code, role_name, description, is_active)
+VALUES
+    (
+        'FULLSTACK_DEVELOPER',
+        '풀스택 개발자',
+        'React와 Next.js 기반 UI, Java와 Spring Boot 기반 API, 데이터 저장소와 배포 흐름을 함께 진단하는 v1 확장 직무',
+        TRUE
+    )
+ON CONFLICT (role_code) DO UPDATE
+SET role_name = EXCLUDED.role_name,
+    description = EXCLUDED.description,
+    is_active = EXCLUDED.is_active,
+    updated_at = now();
+
+WITH fullstack_role AS (
+    SELECT id
+    FROM job_roles
+    WHERE role_code = 'FULLSTACK_DEVELOPER'
+)
+INSERT INTO skill_requirements (job_role_id, skill_name, category, importance)
+SELECT fullstack_role.id, seed.skill_name, seed.category, seed.importance
+FROM fullstack_role
+CROSS JOIN (
+    VALUES
+        ('TypeScript', 'LANGUAGE', 5),
+        ('React', 'FRONTEND', 5),
+        ('Next.js', 'FRAMEWORK', 5),
+        ('Java', 'LANGUAGE', 4),
+        ('Spring Boot', 'FRAMEWORK', 4),
+        ('REST API', 'API', 4),
+        ('PostgreSQL', 'DATABASE', 3),
+        ('Docker', 'INFRA', 3),
+        ('Git/GitHub', 'COLLABORATION', 3),
+        ('CI/CD', 'DELIVERY', 3)
+) AS seed(skill_name, category, importance)
+ON CONFLICT (job_role_id, skill_name) DO UPDATE
+SET category = EXCLUDED.category,
+    importance = EXCLUDED.importance,
+    updated_at = now();

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -995,6 +995,40 @@ a {
   font-weight: 700;
 }
 
+.profile-skill-presets,
+.profile-date-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.profile-skill-presets button,
+.profile-date-shortcuts button {
+  min-height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #344054;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.profile-skill-presets button:hover:not(:disabled),
+.profile-date-shortcuts button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.profile-skill-presets button[aria-pressed="true"],
+.profile-skill-presets button:disabled,
+.profile-date-shortcuts button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .profile-inline-fields {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -1940,6 +1974,7 @@ a {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
   letter-spacing: -0.3px;
+  text-decoration: none;
 }
 
 .github-connection-cta-button:hover:not(:disabled) {

--- a/frontend/src/features/github-connection/github-connection-view.tsx
+++ b/frontend/src/features/github-connection/github-connection-view.tsx
@@ -168,20 +168,25 @@ export function GithubConnectionView() {
               </p>
             </div>
 
-            <a href={connectUrl} className="github-connection-cta-link">
-              <button
-                className="github-connection-cta-button"
-                disabled={!connectUrl}
-              >
+            {connectUrl ? (
+              <a href={connectUrl} className="github-connection-cta-button">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                   <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
                 </svg>
-                GitHub 연결하기
+                GitHub 인증하기
+              </a>
+            ) : (
+              <button
+                className="github-connection-cta-button"
+                disabled
+                type="button"
+              >
+                GitHub 인증 설정 필요
               </button>
-            </a>
+            )}
 
             <p className="github-connection-hero-note">
-              GitHub OAuth를 통해 안전하게 연결됩니다. public repository만 조회됩니다.
+              GitHub OAuth를 통해 안전하게 연결됩니다. 인증 설정이 보이지 않으면 관리자에게 환경 변수 확인을 요청해 주세요.
             </p>
           </div>
         </div>
@@ -336,7 +341,7 @@ export function GithubConnectionView() {
           onClick={reconnect}
           title="현재 GitHub 계정을 변경하려면 클릭하세요"
         >
-          계정 변경
+          다른 GitHub 계정으로 연결
         </button>
       </div>
     </div>

--- a/frontend/src/features/profile/profile-view.tsx
+++ b/frontend/src/features/profile/profile-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 
 import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
@@ -28,6 +28,33 @@ type ProfileState =
   | { status: "auth-required" }
   | { status: "error"; message: string }
   | { profile: ProfileDetail | null; status: "ready" };
+
+const roleSkillPresets: Record<string, string[]> = {
+  BACKEND_DEVELOPER: [
+    "Java",
+    "Spring Boot",
+    "REST API",
+    "JPA",
+    "SQL",
+    "PostgreSQL",
+    "Redis",
+    "JUnit",
+    "Docker",
+    "Git/GitHub"
+  ],
+  FULLSTACK_DEVELOPER: [
+    "TypeScript",
+    "React",
+    "Next.js",
+    "Java",
+    "Spring Boot",
+    "REST API",
+    "PostgreSQL",
+    "Docker",
+    "Git/GitHub",
+    "CI/CD"
+  ]
+};
 
 export function ProfileView() {
   const [state, setState] = useState<ProfileState>({ status: "loading" });
@@ -174,6 +201,43 @@ function ProfileForm({
   saveResult: ProfileSaveResponse | null;
   saving: boolean;
 }) {
+  const defaultTargetRole = profile?.targetRole ?? jobRoles[0]?.roleCode ?? "";
+  const defaultSkills = formatSkillLines(profile?.skills ?? []);
+  const defaultTargetDate = profile?.targetDate ?? addMonthsToDateInput(new Date(), 1);
+  const minTargetDate = getTomorrowDateInput();
+  const [targetRole, setTargetRole] = useState(defaultTargetRole);
+  const [skillsText, setSkillsText] = useState(defaultSkills);
+  const [targetDate, setTargetDate] = useState(defaultTargetDate);
+  const recommendedSkills = roleSkillPresets[targetRole] ?? [];
+  const skillNames = useMemo(
+    () =>
+      new Set(
+        splitLines(skillsText).map((line) => line.split("|")[0].trim().toLowerCase())
+      ),
+    [skillsText]
+  );
+  const canAddMoreSkills = skillNames.size < 20;
+  const canDecreaseTargetDate = canShiftTargetDate(targetDate, -1, minTargetDate);
+
+  function addRecommendedSkill(skillName: string) {
+    if (!canAddMoreSkills || skillNames.has(skillName.toLowerCase())) {
+      return;
+    }
+
+    setSkillsText((current) => {
+      const lines = splitLines(current);
+      return [...lines, `${skillName}|BASIC`].join("\n");
+    });
+  }
+
+  function shiftTargetDate(months: number) {
+    const baseDate = parseDateInput(targetDate) ?? new Date();
+    const shifted = addCalendarMonths(baseDate, months);
+    const shiftedValue = toDateInputValue(shifted);
+
+    setTargetDate(shiftedValue < minTargetDate ? minTargetDate : shiftedValue);
+  }
+
   return (
     <form
       className="profile-form"
@@ -190,7 +254,8 @@ function ProfileForm({
           <span>목표 직무</span>
           {jobRoles.length > 0 ? (
             <select
-              defaultValue={profile?.targetRole ?? jobRoles[0]?.roleCode ?? ""}
+              onChange={(event) => setTargetRole(event.target.value)}
+              value={targetRole}
               name="targetRole"
               required
             >
@@ -226,19 +291,40 @@ function ProfileForm({
         <div className="profile-section-heading">
           <h2>기술 스택</h2>
           <p>
-            한 줄에 하나씩 입력합니다. 숙련도를 함께 쓰려면
-            <code>기술명|숙련도</code> 형식을 사용합니다.
+            직무별 추천 기술을 눌러 추가하거나, 한 줄에 하나씩 직접
+            입력합니다. 숙련도는 <code>기술명|숙련도</code> 형식입니다.
           </p>
         </div>
+
+        {recommendedSkills.length > 0 ? (
+          <div className="profile-skill-presets" aria-label="직무별 추천 기술">
+            {recommendedSkills.map((skillName) => {
+              const isSelected = skillNames.has(skillName.toLowerCase());
+
+              return (
+                <button
+                  aria-pressed={isSelected}
+                  disabled={isSelected || !canAddMoreSkills}
+                  key={skillName}
+                  onClick={() => addRecommendedSkill(skillName)}
+                  type="button"
+                >
+                  {skillName}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
 
         <label>
           <span>기술 목록</span>
           <textarea
-            defaultValue={formatSkillLines(profile?.skills ?? [])}
             name="skills"
+            onChange={(event) => setSkillsText(event.target.value)}
             placeholder={`Spring Boot|BASIC\nPostgreSQL|WORKING`}
             required
             rows={6}
+            value={skillsText}
           />
         </label>
 
@@ -254,11 +340,14 @@ function ProfileForm({
       <section className="panel profile-form-section">
         <div className="profile-section-heading">
           <h2>학습 조건</h2>
-          <p>관심 분야와 주당 학습 가능 시간을 입력합니다.</p>
+          <p>
+            관심 분야는 선택 항목입니다. 비워도 목표 직무, 기술 스택,
+            GitHub 분석을 기준으로 진단과 로드맵을 만들 수 있습니다.
+          </p>
         </div>
 
         <label>
-          <span>관심 분야</span>
+          <span>관심 분야 (선택)</span>
           <textarea
             defaultValue={(profile?.interestAreas ?? []).join("\n")}
             maxLength={600}
@@ -284,10 +373,30 @@ function ProfileForm({
           <label>
             <span>목표 날짜</span>
             <input
-              defaultValue={profile?.targetDate ?? ""}
+              min={minTargetDate}
               name="targetDate"
+              onChange={(event) => setTargetDate(event.target.value)}
               type="date"
+              value={targetDate}
             />
+            <div className="profile-date-shortcuts" aria-label="목표 날짜 빠른 조정">
+              <button
+                disabled={!canDecreaseTargetDate}
+                onClick={() => shiftTargetDate(-1)}
+                type="button"
+              >
+                -1개월
+              </button>
+              <button onClick={() => shiftTargetDate(1)} type="button">
+                +1개월
+              </button>
+              <button onClick={() => shiftTargetDate(2)} type="button">
+                +2개월
+              </button>
+              <button onClick={() => shiftTargetDate(3)} type="button">
+                +3개월
+              </button>
+            </div>
           </label>
         </div>
       </section>
@@ -438,7 +547,7 @@ function parseTargetDate(value: string) {
     return null;
   }
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = toDateInputValue(new Date());
 
   if (targetDate <= today) {
     throw new Error("목표 날짜는 내일 이후로 선택해 주세요.");
@@ -472,4 +581,56 @@ function formatDateTime(value: string) {
     dateStyle: "medium",
     timeStyle: "short"
   }).format(new Date(value));
+}
+
+function addMonthsToDateInput(date: Date, months: number) {
+  return toDateInputValue(addCalendarMonths(date, months));
+}
+
+function addCalendarMonths(date: Date, months: number) {
+  const result = new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
+
+  if (result.getDate() !== date.getDate()) {
+    result.setDate(0);
+  }
+
+  return result;
+}
+
+function getTomorrowDateInput() {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return toDateInputValue(tomorrow);
+}
+
+function toDateInputValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateInput(value: string) {
+  if (!value) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+
+  if (!year || !month || !day) {
+    return null;
+  }
+
+  return new Date(year, month - 1, day);
+}
+
+function canShiftTargetDate(value: string, months: number, minTargetDate: string) {
+  const parsed = parseDateInput(value);
+
+  if (!parsed) {
+    return false;
+  }
+
+  return addMonthsToDateInput(parsed, months) >= minTargetDate;
 }


### PR DESCRIPTION
﻿## Summary
- 프로필 입력에서 풀스택 개발자 목표와 직무별 추천 기술 선택을 지원합니다.
- 목표 날짜 기본값/빠른 조정과 관심 분야 선택 안내를 추가합니다.
- GitHub 연결 CTA를 실제 사용자 행동에 맞게 정리합니다.

## Changes
- `FULLSTACK_DEVELOPER` job role과 주요 skill requirement seed를 추가했습니다.
- 프로필 화면에 추천 기술 chip, 목표 날짜 +1개월 기본값, 월 단위 조정 버튼, 내일 이후 하한 검증을 추가했습니다.
- 관심 분야를 선택 항목으로 명확히 안내했습니다.
- GitHub 미연결/계정 변경 CTA 문구를 `GitHub 인증하기`, `다른 GitHub 계정으로 연결`로 변경했습니다.

## Test
- `npm run lint`
- `npm run build`
- `./gradlew.bat compileTestJava --rerun-tasks`
- `./gradlew.bat test --tests "com.back.coach.domain.jobrole.controller.JobRoleControllerTest"`
- `git diff --check`

Closes #350
