### PR TITLE
fix(deploy): 기본값 있는 timeout env 검증 완화

### DIFF
--- a/scripts/deploy/validate-deploy-env.sh
+++ b/scripts/deploy/validate-deploy-env.sh
@@ -64,6 +64,9 @@ required_keys=(
   AI_GATEWAY_API_KEY
   AI_GATEWAY_BASE_URL
   AI_GATEWAY_MODEL
+)
+
+defaulted_keys=(
   AI_GATEWAY_TIMEOUT_CONNECT
   AI_GATEWAY_TIMEOUT_READ
   API_PROXY_CONNECT_TIMEOUT
@@ -103,9 +106,21 @@ for key in "${required_keys[@]}"; do
   fi
 done
 
+for key in "${defaulted_keys[@]}"; do
+  if [[ ! -v "values[$key]" ]]; then
+    echo "::warning::${key} is not set in $env_file; repository default will be used" >&2
+    continue
+  fi
+
+  if is_placeholder "${values[$key]}"; then
+    echo "::error::${key} must be set to a non-placeholder value or omitted to use the repository default" >&2
+    error_count=$((error_count + 1))
+  fi
+done
+
 if [ "$error_count" -gt 0 ]; then
   echo "::error::Deploy env validation failed with ${error_count} problem(s)" >&2
   exit 1
 fi
 
-echo "Deploy env validation passed (${#required_keys[@]} keys checked)."
+echo "Deploy env validation passed (${#required_keys[@]} required keys checked)."


### PR DESCRIPTION
﻿## Summary
- Blue-Green CD env validation에서 기본값이 있는 timeout key 누락만으로 배포가 중단되지 않도록 조정합니다.

## Changes
- 필수 secret/env 검증은 유지합니다.
- `AI_GATEWAY_TIMEOUT_*`, `API_PROXY_*`는 누락 시 repository default 사용 warning만 출력합니다.
- timeout key가 존재하지만 placeholder 값이면 계속 실패합니다.

## Test
- `bash -n scripts/deploy/validate-deploy-env.sh`
- timeout key 없는 임시 env validation success
- `docker/.env.deploy.example` validation fail 확인
- `git diff --check`

Closes #352
