### PR TITLE
feat(github): 분석 단계 추적 정보 저장

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
+++ b/backend/src/main/java/com/back/coach/domain/github/dto/GithubAnalysisPayload.java
@@ -13,8 +13,22 @@ public record GithubAnalysisPayload(
         List<DepthEstimate> depthEstimates,
         List<GithubEvidence> evidences,
         List<GithubUserCorrection> userCorrections,
-        FinalTechProfile finalTechProfile
+        FinalTechProfile finalTechProfile,
+        AnalysisTrace analysisTrace
 ) {
+
+    public GithubAnalysisPayload(
+            StaticSignals staticSignals,
+            List<RepoSummary> repoSummaries,
+            List<TechTag> techTags,
+            List<DepthEstimate> depthEstimates,
+            List<GithubEvidence> evidences,
+            List<GithubUserCorrection> userCorrections,
+            FinalTechProfile finalTechProfile
+    ) {
+        this(staticSignals, repoSummaries, techTags, depthEstimates, evidences,
+                userCorrections, finalTechProfile, null);
+    }
 
     public record StaticSignals(
             List<PrimaryLanguage> primaryLanguages,
@@ -74,6 +88,66 @@ public record GithubAnalysisPayload(
     public record FinalTechProfile(
             List<String> confirmedSkills,
             List<String> focusAreas
+    ) {
+    }
+
+    public record AnalysisTrace(
+            List<RepoMetadataTrace> repositories,
+            List<TriageTrace> triage,
+            List<RepoSummaryTrace> repoSummaries,
+            SynthesisTrace synthesis
+    ) {
+    }
+
+    public record RepoMetadataTrace(
+            String repoId,
+            String repoName,
+            Boolean core,
+            Integer commitCount,
+            Integer pullRequestCount,
+            Integer issueCount,
+            Integer languageCount,
+            Integer dependencyFileCount
+    ) {
+    }
+
+    public record TriageTrace(
+            String repoId,
+            String repoName,
+            String promptVersion,
+            Integer promptBytes,
+            Long elapsedMs,
+            Boolean fallback,
+            List<ChampionTrace> champions
+    ) {
+    }
+
+    public record ChampionTrace(
+            String kind,
+            String ref,
+            String reason
+    ) {
+    }
+
+    public record RepoSummaryTrace(
+            String repoId,
+            String repoName,
+            String promptVersion,
+            Integer promptBytes,
+            Long elapsedMs,
+            Integer highlightCount,
+            Integer summaryLength
+    ) {
+    }
+
+    public record SynthesisTrace(
+            String promptVersion,
+            Integer promptBytes,
+            Long elapsedMs,
+            Integer techTagCount,
+            Integer depthEstimateCount,
+            Integer evidenceCount,
+            Integer confirmedSkillCount
     ) {
     }
 }

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisDetailService.java
@@ -101,7 +101,8 @@ public class GithubAnalysisDetailService {
                 payload.depthEstimates(),
                 payload.evidences(),
                 request.userCorrections(),
-                request.finalTechProfile()
+                request.finalTechProfile(),
+                payload.analysisTrace()
         );
 
         githubAnalysis.updateAnalysisPayload(toJson(updatedPayload));

--- a/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/GithubAnalysisService.java
@@ -15,6 +15,7 @@ import com.back.coach.domain.github.service.summary.RepoSummaryResponseParser;
 import com.back.coach.domain.github.service.summary.ResolvedChampion;
 import com.back.coach.domain.github.service.synthesis.SynthesisPromptBuilder;
 import com.back.coach.domain.github.service.synthesis.SynthesisResponseParser;
+import com.back.coach.domain.github.service.triage.ChampionTriagePromptBuilder;
 import com.back.coach.domain.github.service.triage.ChampionTriageService;
 import com.back.coach.external.llm.LlmClient;
 import com.back.coach.external.llm.PromptDirectives;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -110,6 +112,14 @@ public class GithubAnalysisService {
         validateCoreMetadataUsable(inputs.coreProjects());
 
         List<GithubAnalysisPayload.RepoSummary> repoSummaries = new ArrayList<>();
+        Set<Long> coreRepoIdSet = inputs.coreProjects().stream()
+                .map(RepoAnalysisInput::id)
+                .collect(Collectors.toSet());
+        List<GithubAnalysisPayload.RepoMetadataTrace> repoMetadataTraces = inputs.selectedProjects().stream()
+                .map(repo -> toRepoMetadataTrace(repo, coreRepoIdSet.contains(repo.id())))
+                .toList();
+        List<GithubAnalysisPayload.TriageTrace> triageTraces = new ArrayList<>();
+        List<GithubAnalysisPayload.RepoSummaryTrace> repoSummaryTraces = new ArrayList<>();
         long triageElapsedMs = 0, summaryElapsedMs = 0;
         int triagePromptBytes = 0, summaryPromptBytes = 0;
 
@@ -124,9 +134,20 @@ public class GithubAnalysisService {
             try {
                 long triageStartMs = System.currentTimeMillis();
                 triage = triageService.triage(core.repoFullName(), core.repoUrl(), metadata);
-                triageElapsedMs += System.currentTimeMillis() - triageStartMs;
+                long currentTriageElapsedMs = System.currentTimeMillis() - triageStartMs;
+                triageElapsedMs += currentTriageElapsedMs;
+                triagePromptBytes += triage.promptBytes();
+                triageTraces.add(new GithubAnalysisPayload.TriageTrace(
+                        String.valueOf(core.id()),
+                        core.repoFullName(),
+                        ChampionTriagePromptBuilder.VERSION,
+                        triage.promptBytes(),
+                        currentTriageElapsedMs,
+                        triage.fallback(),
+                        toChampionTraces(triage.champions())
+                ));
                 log.debug("Triage completed: repo={}, elapsedMs={}, champions={}",
-                        core.repoFullName(), triageElapsedMs, triage.champions().size());
+                        core.repoFullName(), currentTriageElapsedMs, triage.champions().size());
             } catch (ServiceException e) {
                 log.warn("분석 skip: 기여 커밋 없음 repo={}", core.repoFullName());
                 continue;
@@ -136,11 +157,23 @@ public class GithubAnalysisService {
             String summaryPrompt = summaryPromptBuilder.build(
                     String.valueOf(core.id()), core.repoFullName(),
                     core.primaryLanguage(), resolved);
-            summaryPromptBytes += summaryPrompt.getBytes().length;
+            int currentSummaryPromptBytes = byteSize(summaryPrompt);
+            summaryPromptBytes += currentSummaryPromptBytes;
             long summaryStartMs = System.currentTimeMillis();
             String summaryResponse = llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, summaryPrompt);
-            summaryElapsedMs += System.currentTimeMillis() - summaryStartMs;
-            repoSummaries.add(summaryResponseParser.parse(summaryResponse));
+            long currentSummaryElapsedMs = System.currentTimeMillis() - summaryStartMs;
+            summaryElapsedMs += currentSummaryElapsedMs;
+            GithubAnalysisPayload.RepoSummary repoSummary = summaryResponseParser.parse(summaryResponse);
+            repoSummaries.add(repoSummary);
+            repoSummaryTraces.add(new GithubAnalysisPayload.RepoSummaryTrace(
+                    String.valueOf(core.id()),
+                    core.repoFullName(),
+                    RepoSummaryPromptBuilder.VERSION,
+                    currentSummaryPromptBytes,
+                    currentSummaryElapsedMs,
+                    size(repoSummary.highlights()),
+                    length(repoSummary.summary())
+            ));
             long repoElapsedMs = System.currentTimeMillis() - repoStartMs;
             log.debug("Repo analysis completed: repo={}, totalElapsedMs={}",
                     core.repoFullName(), repoElapsedMs);
@@ -153,17 +186,31 @@ public class GithubAnalysisService {
 
         long synthesisStartMs = System.currentTimeMillis();
         String synthesisPrompt = synthesisPromptBuilder.build(inputs.signals(), repoSummaries);
-        int synthesisPromptBytes = synthesisPrompt.getBytes().length;
+        int synthesisPromptBytes = byteSize(synthesisPrompt);
         log.debug("Synthesis prompt built: bytes={}", synthesisPromptBytes);
         String synthesisResponse = llmClient.complete(PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY, synthesisPrompt);
         SynthesisResponseParser.SynthesisResult synthesis = synthesisResponseParser.parse(synthesisResponse);
         long synthesisElapsedMs = System.currentTimeMillis() - synthesisStartMs;
         log.debug("Synthesis completed: elapsedMs={}", synthesisElapsedMs);
+        GithubAnalysisPayload.AnalysisTrace analysisTrace = new GithubAnalysisPayload.AnalysisTrace(
+                repoMetadataTraces,
+                triageTraces,
+                repoSummaryTraces,
+                new GithubAnalysisPayload.SynthesisTrace(
+                        SynthesisPromptBuilder.VERSION,
+                        synthesisPromptBytes,
+                        synthesisElapsedMs,
+                        size(synthesis.techTags()),
+                        size(synthesis.depthEstimates()),
+                        size(synthesis.evidences()),
+                        synthesis.finalTechProfile() == null ? 0 : size(synthesis.finalTechProfile().confirmedSkills())
+                )
+        );
 
         GithubAnalysisPayload payload = new GithubAnalysisPayload(
                 inputs.signals(), repoSummaries,
                 synthesis.techTags(), synthesis.depthEstimates(), synthesis.evidences(),
-                List.of(), synthesis.finalTechProfile()
+                List.of(), synthesis.finalTechProfile(), analysisTrace
         );
 
         GithubAnalysis saved = transactionTemplate.execute(status -> {
@@ -265,7 +312,7 @@ public class GithubAnalysisService {
                 .map(p -> new StaticSignalAggregator.RepoSignalInput(p.primaryLanguage(), p.metadata()))
                 .toList();
         GithubAnalysisPayload.StaticSignals signals = signalAggregator.aggregate(signalInputs);
-        return new AnalysisInputs(signals, coreProjects);
+        return new AnalysisInputs(signals, selected, coreProjects);
     }
 
     private RepoAnalysisInput toRepoInput(GithubProject project) {
@@ -337,6 +384,49 @@ public class GithubAnalysisService {
         return (metadata.commits() != null && !metadata.commits().isEmpty())
                 || (metadata.pullRequests() != null && !metadata.pullRequests().isEmpty())
                 || (metadata.issues() != null && !metadata.issues().isEmpty());
+    }
+
+    private GithubAnalysisPayload.RepoMetadataTrace toRepoMetadataTrace(RepoAnalysisInput input, boolean core) {
+        RepoMetadata metadata = input.metadata();
+        return new GithubAnalysisPayload.RepoMetadataTrace(
+                String.valueOf(input.id()),
+                input.repoFullName(),
+                core,
+                size(metadata.commits()),
+                size(metadata.pullRequests()),
+                size(metadata.issues()),
+                mapSize(metadata.languageBytes()),
+                size(metadata.dependencyFiles())
+        );
+    }
+
+    private List<GithubAnalysisPayload.ChampionTrace> toChampionTraces(List<Champion> champions) {
+        if (champions == null) {
+            return List.of();
+        }
+        return champions.stream()
+                .map(champion -> new GithubAnalysisPayload.ChampionTrace(
+                        champion.kind() == null ? null : champion.kind().name(),
+                        champion.ref(),
+                        champion.reason()
+                ))
+                .toList();
+    }
+
+    private static int byteSize(String value) {
+        return value == null ? 0 : value.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    private static int length(String value) {
+        return value == null ? 0 : value.length();
+    }
+
+    private static int size(List<?> values) {
+        return values == null ? 0 : values.size();
+    }
+
+    private static int mapSize(Map<?, ?> values) {
+        return values == null ? 0 : values.size();
     }
 
     private List<ResolvedChampion> resolveChampions(List<Champion> champions, RepoMetadata metadata) {
@@ -435,6 +525,7 @@ public class GithubAnalysisService {
 
     private record AnalysisInputs(
             GithubAnalysisPayload.StaticSignals signals,
+            List<RepoAnalysisInput> selectedProjects,
             List<RepoAnalysisInput> coreProjects
     ) {}
 

--- a/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageService.java
+++ b/backend/src/main/java/com/back/coach/domain/github/service/triage/ChampionTriageService.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,17 +36,18 @@ public class ChampionTriageService {
 
     public TriageResult triage(String repoName, String repoUrl, RepoMetadata metadata) {
         String prompt = promptBuilder.build(repoName, repoUrl, metadata);
+        int promptBytes = prompt.getBytes(StandardCharsets.UTF_8).length;
         try {
             String llmResponse = llmClient.complete(PromptDirectives.NO_REASONING_JSON_ONLY, prompt);
             List<Champion> champions = responseParser.parse(llmResponse);
-            return new TriageResult(champions, false);
+            return new TriageResult(champions, false, promptBytes);
         } catch (ServiceException e) {
             log.warn("Triage 실패 ({}), fallback 시도. repo={}", e.getErrorCode(), repoName);
-            return fallback(metadata);
+            return fallback(metadata, promptBytes);
         }
     }
 
-    private TriageResult fallback(RepoMetadata metadata) {
+    private TriageResult fallback(RepoMetadata metadata, int promptBytes) {
         List<RepoMetadata.CommitItem> commits = metadata.commits();
         if (commits == null || commits.isEmpty()) {
             // 의미 있는 분석이 불가능 — 호출자에게 명확하게 알림.
@@ -58,8 +60,8 @@ public class ChampionTriageService {
             RepoMetadata.CommitItem c = commits.get(commits.size() - 1 - i);
             fallbackChampions.add(new Champion(Champion.Kind.COMMIT, c.sha(), "fallback: 최신 활동"));
         }
-        return new TriageResult(fallbackChampions, true);
+        return new TriageResult(fallbackChampions, true, promptBytes);
     }
 
-    public record TriageResult(List<Champion> champions, boolean fallback) {}
+    public record TriageResult(List<Champion> champions, boolean fallback, int promptBytes) {}
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisDetailServiceTest.java
@@ -179,6 +179,19 @@ class GithubAnalysisDetailServiceTest {
                 .containsExactly("Java", "Spring Boot", "Redis", "PostgreSQL");
         assertThat(updatedPayload.finalTechProfile().focusAreas())
                 .containsExactly("백엔드", "성능 최적화");
+        assertThat(updatedPayload.analysisTrace()).isNotNull();
+        assertThat(updatedPayload.analysisTrace().repositories()).singleElement().satisfies(repo -> {
+            assertThat(repo.repoId()).isEqualTo("9001");
+            assertThat(repo.repoName()).isEqualTo("team06/ai-growth-coach");
+            assertThat(repo.core()).isTrue();
+            assertThat(repo.commitCount()).isEqualTo(5);
+        });
+        assertThat(updatedPayload.analysisTrace().triage()).singleElement().satisfies(stage -> {
+            assertThat(stage.promptVersion()).isEqualTo("triage-v1.0");
+            assertThat(stage.fallback()).isFalse();
+            assertThat(stage.champions()).singleElement().satisfies(champion ->
+                    assertThat(champion.ref()).isEqualTo("abc123"));
+        });
         assertThat(result.githubAnalysisId()).isEqualTo("40");
         assertThat(result.savedAt()).isEqualTo(FIXED_NOW);
         assertThat(result.finalTechProfile()).isEqualTo(request.finalTechProfile());
@@ -289,6 +302,53 @@ class GithubAnalysisDetailServiceTest {
                       "Backend",
                       "Performance"
                     ]
+                  },
+                  "analysisTrace": {
+                    "repositories": [
+                      {
+                        "repoId": "9001",
+                        "repoName": "team06/ai-growth-coach",
+                        "core": true,
+                        "commitCount": 5,
+                        "pullRequestCount": 3,
+                        "issueCount": 2,
+                        "languageCount": 2,
+                        "dependencyFileCount": 1
+                      }
+                    ],
+                    "triage": [
+                      {
+                        "repoId": "9001",
+                        "repoName": "team06/ai-growth-coach",
+                        "promptVersion": "triage-v1.0",
+                        "promptBytes": 1200,
+                        "elapsedMs": 30,
+                        "fallback": false,
+                        "champions": [
+                          {"kind": "COMMIT", "ref": "abc123", "reason": "OAuth2 handler"}
+                        ]
+                      }
+                    ],
+                    "repoSummaries": [
+                      {
+                        "repoId": "9001",
+                        "repoName": "team06/ai-growth-coach",
+                        "promptVersion": "repo-summary-v1.0",
+                        "promptBytes": 2300,
+                        "elapsedMs": 45,
+                        "highlightCount": 2,
+                        "summaryLength": 27
+                      }
+                    ],
+                    "synthesis": {
+                      "promptVersion": "synthesis-v1.0",
+                      "promptBytes": 980,
+                      "elapsedMs": 25,
+                      "techTagCount": 1,
+                      "depthEstimateCount": 1,
+                      "evidenceCount": 1,
+                      "confirmedSkillCount": 3
+                    }
                   }
                 }
                 """;

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisPayloadJsonTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisPayloadJsonTest.java
@@ -37,6 +37,7 @@ class GithubAnalysisPayloadJsonTest {
         GithubAnalysisPayload restored = json.fromJson(serialized);
 
         assertThat(restored).isEqualTo(original);
+        assertThat(restored.analysisTrace()).isNull();
     }
 
     @Test
@@ -58,5 +59,26 @@ class GithubAnalysisPayloadJsonTest {
         GithubAnalysisPayload restored = json.fromJson(jsonWithExtra);
 
         assertThat(restored.staticSignals().activeRepos()).isZero();
+    }
+
+    @Test
+    @DisplayName("analysisTrace가 없는 기존 payload도 역직렬화된다")
+    void deserialize_legacyPayloadWithoutTrace() {
+        String legacyPayload = """
+                {
+                  "staticSignals": {"primaryLanguages": [], "activeRepos": 1, "commitFrequency": "WEEKLY", "contributionPattern": "CONSISTENT"},
+                  "repoSummaries": [],
+                  "techTags": [],
+                  "depthEstimates": [],
+                  "evidences": [],
+                  "userCorrections": [],
+                  "finalTechProfile": {"confirmedSkills": ["Java"], "focusAreas": ["Backend"]}
+                }
+                """;
+
+        GithubAnalysisPayload restored = json.fromJson(legacyPayload);
+
+        assertThat(restored.finalTechProfile().confirmedSkills()).containsExactly("Java");
+        assertThat(restored.analysisTrace()).isNull();
     }
 }

--- a/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/GithubAnalysisServiceTest.java
@@ -1,5 +1,6 @@
 package com.back.coach.domain.github.service;
 
+import com.back.coach.domain.github.dto.GithubAnalysisPayload;
 import com.back.coach.domain.github.entity.GithubAnalysis;
 import com.back.coach.domain.github.entity.GithubConnection;
 import com.back.coach.domain.github.entity.GithubProject;
@@ -127,6 +128,45 @@ class GithubAnalysisServiceTest {
         assertThat(result.version()).isEqualTo(1);
         assertThat(result.id()).isEqualTo(7L);
         assertThat(result.payload().finalTechProfile().confirmedSkills()).contains("Spring Boot");
+        GithubAnalysisPayload.AnalysisTrace trace = result.payload().analysisTrace();
+        assertThat(trace).isNotNull();
+        assertThat(trace.repositories()).singleElement().satisfies(repo -> {
+            assertThat(repo.repoId()).isEqualTo("1");
+            assertThat(repo.repoName()).isEqualTo("user/a");
+            assertThat(repo.core()).isTrue();
+            assertThat(repo.commitCount()).isEqualTo(1);
+            assertThat(repo.pullRequestCount()).isZero();
+            assertThat(repo.issueCount()).isZero();
+            assertThat(repo.languageCount()).isEqualTo(1);
+            assertThat(repo.dependencyFileCount()).isZero();
+        });
+        assertThat(trace.triage()).singleElement().satisfies(stage -> {
+            assertThat(stage.promptVersion()).isEqualTo(ChampionTriagePromptBuilder.VERSION);
+            assertThat(stage.promptBytes()).isPositive();
+            assertThat(stage.elapsedMs()).isNotNegative();
+            assertThat(stage.fallback()).isFalse();
+            assertThat(stage.champions()).singleElement().satisfies(champion -> {
+                assertThat(champion.kind()).isEqualTo("COMMIT");
+                assertThat(champion.ref()).isEqualTo("abc");
+                assertThat(champion.reason()).isEqualTo("OAuth");
+            });
+        });
+        assertThat(trace.repoSummaries()).singleElement().satisfies(stage -> {
+            assertThat(stage.promptVersion()).isEqualTo(RepoSummaryPromptBuilder.VERSION);
+            assertThat(stage.promptBytes()).isPositive();
+            assertThat(stage.elapsedMs()).isNotNegative();
+            assertThat(stage.highlightCount()).isEqualTo(1);
+            assertThat(stage.summaryLength()).isEqualTo("Spring Boot".length());
+        });
+        assertThat(trace.synthesis()).satisfies(stage -> {
+            assertThat(stage.promptVersion()).isEqualTo(SynthesisPromptBuilder.VERSION);
+            assertThat(stage.promptBytes()).isPositive();
+            assertThat(stage.elapsedMs()).isNotNegative();
+            assertThat(stage.techTagCount()).isEqualTo(1);
+            assertThat(stage.depthEstimateCount()).isEqualTo(1);
+            assertThat(stage.evidenceCount()).isEqualTo(1);
+            assertThat(stage.confirmedSkillCount()).isEqualTo(1);
+        });
     }
 
     @Test
@@ -160,6 +200,9 @@ class GithubAnalysisServiceTest {
 
         assertThat(result.version()).isEqualTo(1);
         assertThat(result.payload().finalTechProfile()).isNotNull();
+        assertThat(result.payload().analysisTrace().triage())
+                .singleElement()
+                .satisfies(stage -> assertThat(stage.fallback()).isTrue());
     }
 
     @Test

--- a/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageServiceTest.java
+++ b/backend/src/test/java/com/back/coach/domain/github/service/triage/ChampionTriageServiceTest.java
@@ -46,6 +46,7 @@ class ChampionTriageServiceTest {
         ChampionTriageService.TriageResult result = service.triage("user/r", "https://u", metadataWithCommits(10));
 
         assertThat(result.fallback()).isFalse();
+        assertThat(result.promptBytes()).isPositive();
         assertThat(result.champions()).hasSize(2);
         assertThat(result.champions().get(0).ref()).isEqualTo("abc");
     }
@@ -59,6 +60,7 @@ class ChampionTriageServiceTest {
         ChampionTriageService.TriageResult result = service.triage("r", "u", metadataWithCommits(10));
 
         assertThat(result.fallback()).isTrue();
+        assertThat(result.promptBytes()).isPositive();
         assertThat(result.champions()).hasSize(6);
         assertThat(result.champions()).allMatch(c -> c.kind() == Champion.Kind.COMMIT);
         // 가장 최신 (sha9, sha8, ..., sha4) 6개


### PR DESCRIPTION
## 원인
- 같은 저장소를 다시 분석했을 때 결과 차이를 나중에 확인할 수 있는 단계별 근거가 부족했습니다.
- raw prompt/LLM 응답을 저장하면 운영 저장량과 민감 정보 노출 리스크가 커집니다.

## 변경 내용
- `analysis_payload`에 optional `analysisTrace`를 추가해 repo metadata count와 triage/summary/synthesis 단계 요약을 저장합니다.
- `ChampionTriageService.TriageResult`에 `promptBytes`를 추가해 triage prompt byte metrics를 실제 값으로 채웁니다.
- 보정 저장 시 기존 trace를 보존합니다.
- public API 응답에는 trace를 추가하지 않았습니다.

## 제외
- raw prompt/response/diff 원문은 저장하지 않습니다.
- `COMMIT_LIMIT` 변경은 포함하지 않았습니다.
- 분석 품질 안정화, temperature/seed, prompt 강화는 후속 작업입니다.

## 테스트
- `backend`: `./gradlew.bat test --tests *GithubAnalysisServiceTest --tests *GithubAnalysisDetailServiceTest --tests *GithubAnalysisPayloadJsonTest --tests *ChampionTriageServiceTest`
- `backend`: `./gradlew.bat test`

Closes #356