### PR TITLE
feat(portfolio): 포트폴리오 초안 탭별 생성 지원

### DIFF
--- a/backend/src/main/java/com/back/coach/domain/portfolio/controller/PortfolioDraftController.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/controller/PortfolioDraftController.java
@@ -35,6 +35,16 @@ public class PortfolioDraftController {
         return ApiResponse.success(portfolioDraftService.createDraft(user.userId()));
     }
 
+    @PostMapping("/{draftId}/variants/{variantKey}/generate")
+    public ApiResponse<PortfolioDraftDetailResponse> generateVariant(
+            Authentication authentication,
+            @PathVariable Long draftId,
+            @PathVariable String variantKey
+    ) {
+        AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();
+        return ApiResponse.success(portfolioDraftService.generateVariant(user.userId(), draftId, variantKey));
+    }
+
     @GetMapping
     public ApiResponse<List<PortfolioDraftSummaryResponse>> listDrafts(Authentication authentication) {
         AuthenticatedUser user = (AuthenticatedUser) authentication.getPrincipal();

--- a/backend/src/main/java/com/back/coach/domain/portfolio/dto/PortfolioDraftGenerationResult.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/dto/PortfolioDraftGenerationResult.java
@@ -1,7 +1,0 @@
-package com.back.coach.domain.portfolio.dto;
-
-public record PortfolioDraftGenerationResult(
-        String title,
-        PortfolioDraftPayload draftPayload
-) {
-}

--- a/backend/src/main/java/com/back/coach/domain/portfolio/dto/PortfolioDraftVariant.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/dto/PortfolioDraftVariant.java
@@ -1,10 +1,15 @@
 package com.back.coach.domain.portfolio.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record PortfolioDraftVariant(
         @NotBlank String key,
         @NotBlank String label,
-        @NotBlank String content
+        @NotNull String content,
+        Boolean generated
 ) {
+    public PortfolioDraftVariant(String key, String label, String content) {
+        this(key, label, content, content != null && !content.isBlank());
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/portfolio/entity/PortfolioDraft.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/entity/PortfolioDraft.java
@@ -58,4 +58,10 @@ public class PortfolioDraft extends BaseEntity {
         this.title = title;
         this.draftPayload = draftPayload;
     }
+
+    public void updateGeneratedContent(String title, String draftPayload, String sourceRefs) {
+        this.title = title;
+        this.draftPayload = draftPayload;
+        this.sourceRefs = sourceRefs;
+    }
 }

--- a/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
+++ b/backend/src/main/java/com/back/coach/domain/portfolio/service/PortfolioDraftService.java
@@ -7,7 +7,6 @@ import com.back.coach.domain.github.entity.GithubAnalysis;
 import com.back.coach.domain.github.repository.GithubAnalysisRepository;
 import com.back.coach.domain.github.service.GithubAnalysisPayloadJson;
 import com.back.coach.domain.portfolio.dto.PortfolioDraftDetailResponse;
-import com.back.coach.domain.portfolio.dto.PortfolioDraftGenerationResult;
 import com.back.coach.domain.portfolio.dto.PortfolioDraftPayload;
 import com.back.coach.domain.portfolio.dto.PortfolioDraftSummaryResponse;
 import com.back.coach.domain.portfolio.dto.PortfolioDraftUpdateRequest;
@@ -51,6 +50,8 @@ public class PortfolioDraftService {
     private static final int RECENT_GITHUB_ANALYSIS_LIMIT = 5;
     private static final int RECENT_CONVERSATION_LIMIT = 20;
     private static final int PORTFOLIO_DRAFT_MAX_TOKENS = 6000;
+    private static final String DEFAULT_DRAFT_TITLE = "포트폴리오 초안";
+    private static final List<String> VARIANT_KEYS = List.of("DONE", "DONE_IN_PROGRESS", "ALL");
     private static final List<SectionSpec> SECTION_SPECS = List.of(
             new SectionSpec("overview", "개요", SectionRenderMode.PARAGRAPH),
             new SectionSpec("problemGoal", "문제/목표", SectionRenderMode.PARAGRAPH),
@@ -90,17 +91,12 @@ public class PortfolioDraftService {
             Required JSON schema:
             {
               "title": "프로젝트 기술서 초안 제목",
-              "sectionsByVariant": {
-                "DONE": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] },
-                "DONE_IN_PROGRESS": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] },
-                "ALL": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] }
-              }
+              "sections": { "overview": [], "problemGoal": [], "studyAndImplementation": [], "techStack": [], "lessons": [], "nextImprovements": [], "memoCandidates": [], "recommendationCandidates": [], "sourceSummary": [] }
             }
 
             Hard output constraints:
-            - Top-level fields must be exactly title and sectionsByVariant.
+            - Top-level fields must be exactly title and sections.
             - Do not output fields named variants, content, draftPayload, data, markdown, or responseText.
-            - sectionsByVariant must contain exactly DONE, DONE_IN_PROGRESS, and ALL.
             - Every section field value must be an array of Korean strings. Never use objects or nested arrays.
             - Each array must contain 1 to 3 strings. Each string must be 260 Korean characters or fewer.
             - Do not include markdown headings such as ##. The server will render markdown later.
@@ -140,27 +136,63 @@ public class PortfolioDraftService {
 
     public PortfolioDraftDetailResponse createDraft(Long userId) {
         PortfolioSource source = buildSource(userId);
-        PortfolioDraftGenerationResult generated = generateDraft(source.sourcePayload());
         PortfolioDraft draft = portfolioDraftRepository.save(PortfolioDraft.create(
                 userId,
-                generated.title(),
-                writeJson(generated.draftPayload()),
+                DEFAULT_DRAFT_TITLE,
+                writeJson(emptyDraftPayload()),
                 writeJson(source.sourceRefs())
         ));
         return toDetailResponse(draft);
     }
 
-    private PortfolioDraftGenerationResult generateDraft(ObjectNode sourcePayload) {
+    @Transactional
+    public PortfolioDraftDetailResponse generateVariant(Long userId, Long draftId, String variantKey) {
+        VariantSpec spec = variantSpec(variantKey);
+        PortfolioDraft draft = findOwnedDraft(userId, draftId);
+        PortfolioDraftPayload currentPayload = parseDraftPayload(draft.getDraftPayload());
+        PortfolioDraftVariant currentVariant = findVariant(currentPayload, spec.key());
+        if (isGenerated(currentVariant)) {
+            return toDetailResponse(draft);
+        }
+
+        PortfolioSource source = buildSource(userId);
+        ObjectNode variantSource = filterSourceForVariant(source.sourcePayload(), spec);
+        GeneratedVariant generated = generateVariantContent(variantSource, spec);
+        PortfolioDraftPayload updatedPayload = mergeVariant(
+                currentPayload,
+                new PortfolioDraftVariant(spec.key(), spec.label(), generated.content(), true)
+        );
+        draft.updateGeneratedContent(
+                nextTitle(draft.getTitle(), generated.title()),
+                writeJson(updatedPayload),
+                writeJson(source.sourceRefs())
+        );
+        return toDetailResponse(draft);
+    }
+
+    private PortfolioDraftPayload emptyDraftPayload() {
+        return new PortfolioDraftPayload(
+                "PROJECT_WRITEUP",
+                VARIANT_KEYS.stream()
+                        .map(key -> new PortfolioDraftVariant(key, variantLabel(key), "", false))
+                        .toList()
+        );
+    }
+
+    private GeneratedVariant generateVariantContent(ObjectNode sourcePayload, VariantSpec spec) {
         try {
             String raw = llmClient.complete(
                     PromptDirectives.USER_VISIBLE_KOREAN_JSON_ONLY + "\n\n" + SYSTEM_PROMPT,
-                    buildUserPrompt(sourcePayload),
+                    buildVariantUserPrompt(sourcePayload, spec),
                     PORTFOLIO_DRAFT_MAX_TOKENS
             );
-            return parseGeneration(raw);
+            return parseVariantGeneration(raw);
         } catch (ServiceException e) {
             if (isFallbackAllowed(e.getErrorCode())) {
-                return buildFallbackDraft(sourcePayload);
+                return new GeneratedVariant(
+                        "로드맵 기반 포트폴리오 초안",
+                        buildFallbackContent(sourcePayload, spec.includeDone(), spec.includeInProgress(), spec.includePlanned())
+                );
             }
             throw e;
         }
@@ -195,6 +227,101 @@ public class PortfolioDraftService {
     private PortfolioDraft findOwnedDraft(Long userId, Long draftId) {
         return portfolioDraftRepository.findByIdAndUserId(draftId, userId)
                 .orElseThrow(() -> new ServiceException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private PortfolioDraftPayload parseDraftPayload(String draftPayload) {
+        try {
+            return objectMapper.readValue(draftPayload, PortfolioDraftPayload.class);
+        } catch (JsonProcessingException e) {
+            throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private PortfolioDraftVariant findVariant(PortfolioDraftPayload payload, String key) {
+        if (payload == null || payload.variants() == null) {
+            return null;
+        }
+        return payload.variants().stream()
+                .filter(variant -> key.equals(variant.key()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean isGenerated(PortfolioDraftVariant variant) {
+        if (variant == null) {
+            return false;
+        }
+        return Boolean.TRUE.equals(variant.generated())
+                || (variant.content() != null && !variant.content().isBlank());
+    }
+
+    private PortfolioDraftPayload mergeVariant(PortfolioDraftPayload payload, PortfolioDraftVariant generatedVariant) {
+        LinkedHashMap<String, PortfolioDraftVariant> byKey = new LinkedHashMap<>();
+        if (payload != null && payload.variants() != null) {
+            for (PortfolioDraftVariant variant : payload.variants()) {
+                byKey.put(variant.key(), variant);
+            }
+        }
+        byKey.put(generatedVariant.key(), generatedVariant);
+
+        List<PortfolioDraftVariant> variants = new ArrayList<>();
+        for (String key : VARIANT_KEYS) {
+            variants.add(byKey.getOrDefault(key, new PortfolioDraftVariant(key, variantLabel(key), "", false)));
+        }
+        for (Map.Entry<String, PortfolioDraftVariant> entry : byKey.entrySet()) {
+            if (!VARIANT_KEYS.contains(entry.getKey())) {
+                variants.add(entry.getValue());
+            }
+        }
+        String format = payload == null || payload.format() == null || payload.format().isBlank()
+                ? "PROJECT_WRITEUP"
+                : payload.format();
+        return new PortfolioDraftPayload(format, variants);
+    }
+
+    private String nextTitle(String currentTitle, String generatedTitle) {
+        if (generatedTitle == null || generatedTitle.isBlank()) {
+            return currentTitle == null || currentTitle.isBlank() ? DEFAULT_DRAFT_TITLE : currentTitle;
+        }
+        if (currentTitle == null || currentTitle.isBlank()
+                || DEFAULT_DRAFT_TITLE.equals(currentTitle)
+                || "로드맵 기반 포트폴리오 초안".equals(currentTitle)) {
+            return generatedTitle;
+        }
+        return currentTitle;
+    }
+
+    private VariantSpec variantSpec(String key) {
+        return switch (key) {
+            case "DONE" -> new VariantSpec(
+                    "DONE",
+                    "완료 기반",
+                    true,
+                    false,
+                    false,
+                    false,
+                    "Use only DONE progress records as official study evidence. Exclude in-progress, planned, and coach recommendations."
+            );
+            case "DONE_IN_PROGRESS" -> new VariantSpec(
+                    "DONE_IN_PROGRESS",
+                    "완료 + 진행 중",
+                    true,
+                    true,
+                    false,
+                    false,
+                    "Use DONE and IN_PROGRESS records. Treat in-progress work as ongoing, never as completed. Exclude planned and coach recommendations."
+            );
+            case "ALL" -> new VariantSpec(
+                    "ALL",
+                    "전체 계획 포함",
+                    true,
+                    true,
+                    true,
+                    true,
+                    "Use done, in-progress, planned, and coach recommendations. Planned and recommendation items must be future plans only."
+            );
+            default -> throw new ServiceException(ErrorCode.INVALID_INPUT, "지원하지 않는 포트폴리오 초안 버전입니다.");
+        };
     }
 
     private PortfolioSource buildSource(Long userId) {
@@ -413,19 +540,43 @@ public class PortfolioDraftService {
         progressIds.forEach(id -> progressRefs.add(String.valueOf(id)));
     }
 
-    private String buildUserPrompt(ObjectNode sourcePayload) {
+    private ObjectNode filterSourceForVariant(ObjectNode sourcePayload, VariantSpec spec) {
+        ObjectNode filtered = sourcePayload.deepCopy();
+        ObjectNode official = (ObjectNode) filtered.path("officialStudyRecords");
+        official.set("done", spec.includeDone()
+                ? sourcePayload.path("officialStudyRecords").path("done").deepCopy()
+                : objectMapper.createArrayNode());
+        official.set("inProgress", spec.includeInProgress()
+                ? sourcePayload.path("officialStudyRecords").path("inProgress").deepCopy()
+                : objectMapper.createArrayNode());
+        official.set("planned", spec.includePlanned()
+                ? sourcePayload.path("officialStudyRecords").path("planned").deepCopy()
+                : objectMapper.createArrayNode());
+
+        ObjectNode coach = (ObjectNode) filtered.path("coachConversationCandidates");
+        coach.set("coachRecommendations", spec.includeCoachRecommendations()
+                ? sourcePayload.path("coachConversationCandidates").path("coachRecommendations").deepCopy()
+                : objectMapper.createArrayNode());
+        filtered.put("targetVariant", spec.key());
+        filtered.put("targetVariantLabel", spec.label());
+        return filtered;
+    }
+
+    private String buildVariantUserPrompt(ObjectNode sourcePayload, VariantSpec spec) {
         return """
-                Create the required sectionsByVariant JSON from this source JSON only.
+                Create only the %s portfolio draft variant.
+                Variant label: %s
+                Allowed evidence policy: %s
                 Write for a Korean project write-up draft, not a study checklist.
                 The server renders markdown later, so return section arrays only.
-                Repeat: do not return variants[].content and do not write markdown.
+                Repeat: do not return sectionsByVariant, variants[].content, or markdown.
 
                 Source JSON:
                 %s
-                """.formatted(sourcePayload.toPrettyString());
+                """.formatted(spec.key(), spec.label(), spec.policy(), sourcePayload.toPrettyString());
     }
 
-    private PortfolioDraftGenerationResult parseGeneration(String llmRaw) {
+    private GeneratedVariant parseVariantGeneration(String llmRaw) {
         JsonNode root;
         try {
             root = objectMapper.readTree(LlmJsonResponseExtractor.extractJson(llmRaw));
@@ -437,19 +588,11 @@ public class PortfolioDraftService {
             title = "포트폴리오 기술서 초안";
         }
 
-        JsonNode sectionsByVariant = root.path("sectionsByVariant");
-        if (!sectionsByVariant.isObject()) {
+        JsonNode sections = root.path("sections");
+        if (!sections.isObject()) {
             throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
         }
-        List<PortfolioDraftVariant> variants = new ArrayList<>();
-        for (String key : List.of("DONE", "DONE_IN_PROGRESS", "ALL")) {
-            JsonNode sectionNode = sectionsByVariant.path(key);
-            if (!sectionNode.isObject()) {
-                throw new ServiceException(ErrorCode.LLM_INVALID_RESPONSE);
-            }
-            variants.add(new PortfolioDraftVariant(key, variantLabel(key), renderSections(sectionNode)));
-        }
-        return new PortfolioDraftGenerationResult(title, new PortfolioDraftPayload("PROJECT_WRITEUP", variants));
+        return new GeneratedVariant(title, renderSections(sections));
     }
 
     private String renderSections(JsonNode sectionNode) {
@@ -511,30 +654,6 @@ public class PortfolioDraftService {
             case "ALL" -> "전체 계획 포함";
             default -> key;
         };
-    }
-
-    private PortfolioDraftGenerationResult buildFallbackDraft(ObjectNode sourcePayload) {
-        List<PortfolioDraftVariant> variants = List.of(
-                new PortfolioDraftVariant(
-                        "DONE",
-                        "완료 기반",
-                        buildFallbackContent(sourcePayload, true, false, false)
-                ),
-                new PortfolioDraftVariant(
-                        "DONE_IN_PROGRESS",
-                        "완료 + 진행 중",
-                        buildFallbackContent(sourcePayload, true, true, false)
-                ),
-                new PortfolioDraftVariant(
-                        "ALL",
-                        "전체 계획 포함",
-                        buildFallbackContent(sourcePayload, true, true, true)
-                )
-        );
-        return new PortfolioDraftGenerationResult(
-                "로드맵 기반 포트폴리오 초안",
-                new PortfolioDraftPayload("PROJECT_WRITEUP", variants)
-        );
     }
 
     private String buildFallbackContent(
@@ -751,6 +870,20 @@ public class PortfolioDraftService {
     }
 
     private record PortfolioSource(ObjectNode sourcePayload, ObjectNode sourceRefs) {
+    }
+
+    private record GeneratedVariant(String title, String content) {
+    }
+
+    private record VariantSpec(
+            String key,
+            String label,
+            boolean includeDone,
+            boolean includeInProgress,
+            boolean includePlanned,
+            boolean includeCoachRecommendations,
+            String policy
+    ) {
     }
 
     private enum SectionRenderMode {

--- a/backend/src/test/java/com/back/coach/domain/portfolio/controller/PortfolioDraftControllerTest.java
+++ b/backend/src/test/java/com/back/coach/domain/portfolio/controller/PortfolioDraftControllerTest.java
@@ -49,15 +49,30 @@ class PortfolioDraftControllerTest extends ApiTestBase {
     @Test
     void createDraft_whenAuthenticated_returnsSavedDraft() throws Exception {
         User user = createUser();
-        given(portfolioDraftService.createDraft(user.getId())).willReturn(detailResponse("10"));
+        given(portfolioDraftService.createDraft(user.getId())).willReturn(emptyDetailResponse("10"));
 
         mockMvc.perform(post("/api/portfolio/drafts")
                         .cookie(accessTokenCookie(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.draftId").value("10"))
-                .andExpect(jsonPath("$.data.title").value("백엔드 성장 포트폴리오 초안"))
+                .andExpect(jsonPath("$.data.title").value("포트폴리오 초안"))
                 .andExpect(jsonPath("$.data.draftPayload.variants[0].key").value("DONE"))
+                .andExpect(jsonPath("$.data.draftPayload.variants[0].content").value(""))
+                .andExpect(jsonPath("$.data.draftPayload.variants[0].generated").value(false))
                 .andExpect(jsonPath("$.data.sourceRefs.progressLogIds[0]").value("1"));
+    }
+
+    @Test
+    void generateVariant_whenAuthenticated_returnsGeneratedDraft() throws Exception {
+        User user = createUser();
+        given(portfolioDraftService.generateVariant(user.getId(), 10L, "ALL")).willReturn(detailResponse("10"));
+
+        mockMvc.perform(post("/api/portfolio/drafts/{draftId}/variants/{variantKey}/generate", 10, "ALL")
+                        .cookie(accessTokenCookie(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.draftId").value("10"))
+                .andExpect(jsonPath("$.data.draftPayload.variants[2].key").value("ALL"))
+                .andExpect(jsonPath("$.data.draftPayload.variants[2].generated").value(true));
     }
 
     @Test
@@ -132,6 +147,24 @@ class PortfolioDraftControllerTest extends ApiTestBase {
                                 new PortfolioDraftVariant("DONE", "완료 기반", "완료 내용"),
                                 new PortfolioDraftVariant("DONE_IN_PROGRESS", "완료 + 진행 중", "진행 내용"),
                                 new PortfolioDraftVariant("ALL", "전체 계획 포함", "전체 내용")
+                        )
+                ),
+                Map.of("progressLogIds", List.of("1")),
+                Instant.parse("2026-05-13T00:00:00Z"),
+                Instant.parse("2026-05-13T01:00:00Z")
+        );
+    }
+
+    private PortfolioDraftDetailResponse emptyDetailResponse(String draftId) throws Exception {
+        return new PortfolioDraftDetailResponse(
+                draftId,
+                "포트폴리오 초안",
+                new PortfolioDraftPayload(
+                        "PROJECT_WRITEUP",
+                        List.of(
+                                new PortfolioDraftVariant("DONE", "완료 기반", "", false),
+                                new PortfolioDraftVariant("DONE_IN_PROGRESS", "완료 + 진행 중", "", false),
+                                new PortfolioDraftVariant("ALL", "전체 계획 포함", "", false)
                         )
                 ),
                 Map.of("progressLogIds", List.of("1")),

--- a/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
+++ b/backend/src/test/java/com/back/coach/domain/portfolio/service/PortfolioDraftServiceIntegrationTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @IntegrationTest
@@ -86,19 +87,23 @@ class PortfolioDraftServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("createDraft: 로드맵 진도, GitHub 분석, Coach 후보를 근거로 3개 초안을 저장한다")
-    void createDraftBuildsSourcesAndSavesThreeVariants() {
+    @DisplayName("createDraft: LLM 호출 없이 3개 빈 초안 틀과 sourceRefs를 저장한다")
+    void createDraftSavesEmptyVariantsWithoutLlmCall() {
         Long userId = createUser();
         PortfolioFixture fixture = seedPortfolioFixture(userId);
-        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(generationResponse());
 
         PortfolioDraftDetailResponse response = portfolioDraftService.createDraft(userId);
 
-        assertThat(response.title()).isEqualTo("백엔드 성장 포트폴리오 초안");
+        assertThat(response.title()).isEqualTo("포트폴리오 초안");
         assertThat(response.draftPayload().format()).isEqualTo("PROJECT_WRITEUP");
         assertThat(response.draftPayload().variants())
                 .extracting(PortfolioDraftVariant::key)
                 .containsExactly("DONE", "DONE_IN_PROGRESS", "ALL");
+        assertThat(response.draftPayload().variants())
+                .allSatisfy(variant -> {
+                    assertThat(variant.content()).isEmpty();
+                    assertThat(variant.generated()).isFalse();
+                });
 
         assertThat(portfolioDraftService.listDrafts(userId)).hasSize(1);
         assertThat(refObjects(response, "githubAnalyses"))
@@ -110,6 +115,22 @@ class PortfolioDraftServiceIntegrationTest {
                 .contains(String.valueOf(fixture.doneProgressLogId()), String.valueOf(fixture.inProgressProgressLogId()));
         assertThat(refStrings(response, "coachConversationIds"))
                 .contains(String.valueOf(fixture.userConversationId()), String.valueOf(fixture.coachConversationId()));
+        verify(llmClient, never()).complete(anyString(), anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("generateVariant: DONE은 완료 근거만 prompt에 넣고 해당 탭만 생성한다")
+    void generateVariantDoneUsesOnlyDoneEvidence() {
+        Long userId = createUser();
+        seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(singleVariantResponse(
+                "완료 기반 포트폴리오 초안",
+                "Redis 공식 문서 정리를 통해 캐시 적용 전 기준을 정리했습니다."
+        ));
+
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "DONE");
 
         ArgumentCaptor<String> systemCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
@@ -118,7 +139,7 @@ class PortfolioDraftServiceIntegrationTest {
         assertThat(systemCaptor.getValue()).contains("JSON-only output assistant for Korean users");
         assertThat(systemCaptor.getValue()).contains("coachConversationCandidates.userMemos");
         assertThat(systemCaptor.getValue()).contains("Do not invent URLs");
-        assertThat(systemCaptor.getValue()).contains("sectionsByVariant");
+        assertThat(systemCaptor.getValue()).contains("sections");
         assertThat(systemCaptor.getValue()).contains("Do not output fields named variants");
         assertThat(systemCaptor.getValue()).contains("project write-up");
         assertThat(systemCaptor.getValue()).contains("not a study checklist");
@@ -128,15 +149,14 @@ class PortfolioDraftServiceIntegrationTest {
         assertThat(maxTokensCaptor.getValue()).isEqualTo(6000);
 
         String prompt = userPromptCaptor.getValue();
-        assertThat(prompt).contains("sectionsByVariant");
+        assertThat(prompt).contains("Create only the DONE portfolio draft variant");
         assertThat(prompt).contains("project write-up draft");
         assertThat(prompt).contains("not a study checklist");
         assertThat(prompt).contains("Redis 공식 문서 정리 완료");
-        assertThat(prompt).contains("캐시 예제 진행 중");
-        assertThat(prompt).contains("장애 대응 회고 작성");
-        assertThat(prompt).contains("아직 시작하지 않은 모니터링 개선");
-        assertThat(prompt).contains("사용자가 직접 말한 학습 메모 후보");
-        assertThat(prompt).contains("Coach가 추천한 다음 프로젝트 후보");
+        assertThat(prompt).doesNotContain("캐시 예제 진행 중");
+        assertThat(prompt).doesNotContain("장애 대응 회고 작성");
+        assertThat(prompt).doesNotContain("아직 시작하지 않은 모니터링 개선");
+        assertThat(prompt).doesNotContain("Coach가 추천한 다음 프로젝트 후보");
         assertThat(prompt).contains("최신 Spring API 개선 요약");
         assertThat(prompt).doesNotContain("오래된 Spring API 요약");
 
@@ -144,17 +164,112 @@ class PortfolioDraftServiceIntegrationTest {
         String inProgressContent = response.draftPayload().variants().get(1).content();
         String allContent = response.draftPayload().variants().get(2).content();
         assertThat(doneContent)
-                .contains("## 개요\nRedis 공식 문서 정리를 통해", "## 구현 내용", "## 기술적 판단과 배운 점", "Redis 공식 문서 정리 완료")
-                .doesNotContain("## 개요\n-")
-                .doesNotContain("## 진행한 학습과 구현")
-                .doesNotContain("캐시 예제 진행 중")
-                .doesNotContain("아직 시작하지 않은 모니터링 개선");
-        assertThat(inProgressContent)
-                .contains("캐시 예제 진행 중")
-                .doesNotContain("아직 시작하지 않은 모니터링 개선");
-        assertThat(allContent)
-                .contains("아직 시작하지 않은 모니터링 개선")
-                .contains("Coach가 추천한 다음 프로젝트 후보");
+                .contains("## 개요\nRedis 공식 문서 정리를 통해", "## 구현 내용", "## 기술적 판단과 배운 점");
+        assertThat(response.draftPayload().variants().get(0).generated()).isTrue();
+        assertThat(inProgressContent).isEmpty();
+        assertThat(allContent).isEmpty();
+    }
+
+    @Test
+    @DisplayName("generateVariant: DONE_IN_PROGRESS는 완료와 진행 중 근거만 사용한다")
+    void generateVariantDoneInProgressExcludesPlannedAndCoachRecommendations() {
+        Long userId = createUser();
+        seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(singleVariantResponse(
+                "진행 중 포함 포트폴리오 초안",
+                "완료한 Redis 정리와 캐시 예제 진행 중 기록을 연결했습니다."
+        ));
+
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "DONE_IN_PROGRESS");
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(anyString(), userPromptCaptor.capture(), anyInt());
+        String prompt = userPromptCaptor.getValue();
+        assertThat(prompt).contains("Create only the DONE_IN_PROGRESS portfolio draft variant");
+        assertThat(prompt).contains("Redis 공식 문서 정리 완료");
+        assertThat(prompt).contains("캐시 예제 진행 중");
+        assertThat(prompt).doesNotContain("아직 시작하지 않은 모니터링 개선");
+        assertThat(prompt).doesNotContain("Coach가 추천한 다음 프로젝트 후보");
+
+        assertThat(response.draftPayload().variants().get(0).content()).isEmpty();
+        assertThat(response.draftPayload().variants().get(1).content())
+                .contains("## 개요\n완료한 Redis 정리와 캐시 예제 진행 중 기록");
+        assertThat(response.draftPayload().variants().get(1).generated()).isTrue();
+        assertThat(response.draftPayload().variants().get(2).content()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("generateVariant: ALL은 예정과 Coach 추천을 미래 계획 근거로 포함한다")
+    void generateVariantAllIncludesPlannedAndCoachRecommendationsAsFuturePlans() {
+        Long userId = createUser();
+        seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(singleVariantResponse(
+                "전체 계획 포트폴리오 초안",
+                "완료, 진행 중, 예정 후보를 구분해 운영 백엔드 성장 흐름으로 정리했습니다."
+        ));
+
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "ALL");
+
+        ArgumentCaptor<String> userPromptCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClient).complete(anyString(), userPromptCaptor.capture(), anyInt());
+        String prompt = userPromptCaptor.getValue();
+        assertThat(prompt).contains("Create only the ALL portfolio draft variant");
+        assertThat(prompt).contains("Planned and recommendation items must be future plans only");
+        assertThat(prompt).contains("Redis 공식 문서 정리 완료");
+        assertThat(prompt).contains("캐시 예제 진행 중");
+        assertThat(prompt).contains("아직 시작하지 않은 모니터링 개선");
+        assertThat(prompt).contains("Coach가 추천한 다음 프로젝트 후보");
+
+        assertThat(response.draftPayload().variants().get(0).content()).isEmpty();
+        assertThat(response.draftPayload().variants().get(1).content()).isEmpty();
+        assertThat(response.draftPayload().variants().get(2).content())
+                .contains("## 개요\n완료, 진행 중, 예정 후보를 구분");
+        assertThat(response.draftPayload().variants().get(2).generated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("generateVariant: 이미 생성된 탭과 다른 탭의 편집 내용은 덮어쓰지 않는다")
+    void generateVariantDoesNotOverwriteExistingVariantContent() {
+        Long userId = createUser();
+        seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
+        PortfolioDraftPayload editedPayload = new PortfolioDraftPayload(
+                "PROJECT_WRITEUP",
+                List.of(
+                        new PortfolioDraftVariant("DONE", "완료 기반", "사용자가 직접 쓴 완료 초안", true),
+                        new PortfolioDraftVariant("DONE_IN_PROGRESS", "완료 + 진행 중", "", false),
+                        new PortfolioDraftVariant("ALL", "전체 계획 포함", "전체 탭 편집 내용", true)
+                )
+        );
+        portfolioDraftService.updateDraft(userId, Long.valueOf(draft.draftId()),
+                new PortfolioDraftUpdateRequest(draft.title(), editedPayload));
+        given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(singleVariantResponse(
+                "진행 중 포함 포트폴리오 초안",
+                "진행 중 탭 새 내용"
+        ));
+
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "DONE_IN_PROGRESS");
+
+        assertThat(response.draftPayload().variants())
+                .extracting(PortfolioDraftVariant::content)
+                .containsExactly(
+                        "사용자가 직접 쓴 완료 초안",
+                        response.draftPayload().variants().get(1).content(),
+                        "전체 탭 편집 내용"
+                );
+        assertThat(response.draftPayload().variants().get(1).content())
+                .contains("진행 중 탭 새 내용");
+
+        PortfolioDraftDetailResponse noOverwrite =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "DONE");
+        assertThat(noOverwrite.draftPayload().variants().get(0).content())
+                .isEqualTo("사용자가 직접 쓴 완료 초안");
+        verify(llmClient).complete(anyString(), anyString(), anyInt());
     }
 
     @Test
@@ -192,41 +307,43 @@ class PortfolioDraftServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("createDraft: LLM 응답이 깨져도 저장 근거 기반 fallback 초안을 저장한다")
-    void createDraftFallsBackWhenLlmResponseIsInvalid() {
+    @DisplayName("generateVariant: LLM 응답이 깨져도 해당 탭만 fallback 초안을 저장한다")
+    void generateVariantFallsBackWhenLlmResponseIsInvalid() {
         Long userId = createUser();
         seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
         given(llmClient.complete(anyString(), anyString(), anyInt()))
                 .willThrow(new ServiceException(ErrorCode.LLM_INVALID_RESPONSE));
 
-        PortfolioDraftDetailResponse response = portfolioDraftService.createDraft(userId);
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "ALL");
 
         assertThat(response.title()).isEqualTo("로드맵 기반 포트폴리오 초안");
         assertThat(response.draftPayload().variants())
                 .extracting(PortfolioDraftVariant::key)
                 .containsExactly("DONE", "DONE_IN_PROGRESS", "ALL");
         assertThat(response.draftPayload().variants().get(0).content())
+                .isEmpty();
+        assertThat(response.draftPayload().variants().get(1).content())
+                .isEmpty();
+        assertThat(response.draftPayload().variants().get(2).content())
                 .contains("## 구현 내용", "## 기술적 판단과 배운 점")
                 .contains("Redis 공식 문서 정리 완료")
-                .doesNotContain("## 진행한 학습과 구현")
-                .doesNotContain("## 배운 점")
-                .doesNotContain("캐시 예제 진행 중");
-        assertThat(response.draftPayload().variants().get(1).content())
                 .contains("캐시 예제 진행 중")
-                .doesNotContain("아직 시작하지 않은 모니터링 개선");
-        assertThat(response.draftPayload().variants().get(2).content())
                 .contains("아직 시작하지 않은 모니터링 개선")
                 .contains("Coach가 추천한 다음 프로젝트 후보");
     }
 
     @Test
-    @DisplayName("createDraft: LLM section 일부가 비어도 markdown 섹션을 안전하게 조립한다")
-    void createDraftRendersEmptySectionsWithPlaceholder() {
+    @DisplayName("generateVariant: LLM section 일부가 비어도 markdown 섹션을 안전하게 조립한다")
+    void generateVariantRendersEmptySectionsWithPlaceholder() {
         Long userId = createUser();
         seedPortfolioFixture(userId);
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
         given(llmClient.complete(anyString(), anyString(), anyInt())).willReturn(partialSectionsResponse());
 
-        PortfolioDraftDetailResponse response = portfolioDraftService.createDraft(userId);
+        PortfolioDraftDetailResponse response =
+                portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "DONE");
 
         assertThat(response.draftPayload().variants())
                 .extracting(PortfolioDraftVariant::key)
@@ -236,6 +353,19 @@ class PortfolioDraftServiceIntegrationTest {
                 .contains("## 문제/목표\n작성 가능한 근거가 없습니다.")
                 .contains("## 구현 내용\n- 작성 가능한 근거가 없습니다.")
                 .doesNotContain("## 개요\n-");
+        assertThat(response.draftPayload().variants().get(1).content()).isEmpty();
+        assertThat(response.draftPayload().variants().get(2).content()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("generateVariant: 지원하지 않는 variantKey는 INVALID_INPUT")
+    void generateVariantRejectsInvalidVariantKey() {
+        Long userId = createUser();
+        PortfolioDraftDetailResponse draft = portfolioDraftService.createDraft(userId);
+
+        assertThatThrownBy(() -> portfolioDraftService.generateVariant(userId, Long.valueOf(draft.draftId()), "UNKNOWN"))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
     }
 
     @Test
@@ -254,6 +384,26 @@ class PortfolioDraftServiceIntegrationTest {
         ));
 
         assertThatThrownBy(() -> portfolioDraftService.getDraft(otherUserId, draft.getId()))
+                .isInstanceOf(ServiceException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("generateVariant: 다른 사용자의 초안은 생성할 수 없다")
+    void generateVariantRejectsOtherUser() throws Exception {
+        Long ownerId = createUser();
+        Long otherUserId = createUser();
+        PortfolioDraft draft = portfolioDraftRepository.save(PortfolioDraft.create(
+                ownerId,
+                "소유자 초안",
+                objectMapper.writeValueAsString(new PortfolioDraftPayload(
+                        "PROJECT_WRITEUP",
+                        List.of(new PortfolioDraftVariant("DONE", "완료 기반", "", false))
+                )),
+                "{}"
+        ));
+
+        assertThatThrownBy(() -> portfolioDraftService.generateVariant(otherUserId, draft.getId(), "DONE"))
                 .isInstanceOf(ServiceException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RESOURCE_NOT_FOUND);
     }
@@ -480,6 +630,25 @@ class PortfolioDraftServiceIntegrationTest {
         return Timestamp.from(instant);
     }
 
+    private String singleVariantResponse(String title, String overview) {
+        return """
+                {
+                  "title": "%s",
+                  "sections": {
+                    "overview": ["%s"],
+                    "problemGoal": ["로드맵 진도를 프로젝트 기술서 맥락으로 재구성하는 것이 목표입니다."],
+                    "studyAndImplementation": ["선택한 초안 버전의 근거만 사용해 구현 경험 후보를 정리했습니다."],
+                    "techStack": ["Java", "Spring Boot"],
+                    "lessons": ["GitHub 분석 근거를 함께 보며 기술 선택과 다음 개선 지점을 분리했습니다."],
+                    "nextImprovements": ["아직 확정되지 않은 항목은 다음 개선 후보로 남깁니다."],
+                    "memoCandidates": ["학습 메모 후보는 완료 사실이 아닌 보조 자료로 둡니다."],
+                    "recommendationCandidates": ["추천 후보는 미래 계획으로만 정리합니다."],
+                    "sourceSummary": ["선택한 variant 범위의 근거만 사용했습니다."]
+                  }
+                }
+                """.formatted(title, overview);
+    }
+
     private String generationResponse() {
         return """
                 {
@@ -527,16 +696,8 @@ class PortfolioDraftServiceIntegrationTest {
         return """
                 {
                   "title": "부분 section 포트폴리오 초안",
-                  "sectionsByVariant": {
-                    "DONE": {
-                      "overview": ["완료한 Redis 문서 정리를 중심으로 기술합니다."]
-                    },
-                    "DONE_IN_PROGRESS": {
-                      "overview": ["진행 중인 캐시 예제를 함께 기술합니다."]
-                    },
-                    "ALL": {
-                      "overview": ["예정 후보까지 전체 계획으로 기술합니다."]
-                    }
+                  "sections": {
+                    "overview": ["완료한 Redis 문서 정리를 중심으로 기술합니다."]
                   }
                 }
                 """;

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -377,12 +377,12 @@ paths:
     post:
       tags:
         - Portfolio
-      summary: Generate portfolio draft from current learning evidence
+      summary: Create empty portfolio draft shell from current learning evidence
       operationId: createPortfolioDraft
       x-implementation-status: implemented
       responses:
         '200':
-          description: Portfolio draft generated and saved
+          description: Empty portfolio draft shell saved
           content:
             application/json:
               schema:
@@ -456,6 +456,34 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/ResourceNotFound'
+
+  /api/portfolio/drafts/{draftId}/variants/{variantKey}/generate:
+    post:
+      tags:
+        - Portfolio
+      summary: Generate one portfolio draft variant
+      operationId: generatePortfolioDraftVariant
+      x-implementation-status: implemented
+      parameters:
+        - $ref: '#/components/parameters/PortfolioDraftId'
+        - $ref: '#/components/parameters/PortfolioDraftVariantKey'
+      responses:
+        '200':
+          description: Portfolio draft detail with generated variant content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortfolioDraftDetailApiResponse'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
 
   /api/jobs/{jobId}/status:
     get:
@@ -687,6 +715,17 @@ components:
       schema:
         type: string
       example: '9001'
+    PortfolioDraftVariantKey:
+      name: variantKey
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - DONE
+          - DONE_IN_PROGRESS
+          - ALL
+      example: ALL
     CoachSessionId:
       name: sessionId
       in: path
@@ -2169,6 +2208,11 @@ components:
         content:
           type: string
           description: Markdown project write-up draft content.
+        generated:
+          type: boolean
+          nullable: true
+          description: Whether this variant content has been generated or manually started.
+          example: true
 
     PortfolioDraftPayload:
       type: object

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3611,6 +3611,32 @@ a {
   line-height: 1.6;
 }
 
+.portfolio-draft-empty-variant {
+  display: grid;
+  place-items: center;
+  gap: 14px;
+  min-height: 360px;
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  background: #f8fafc;
+  padding: 24px;
+  text-align: center;
+}
+
+.portfolio-draft-empty-variant p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.portfolio-draft-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
 .portfolio-draft-editor-footer {
   display: flex;
   align-items: center;
@@ -3677,7 +3703,8 @@ a {
   }
 
   .portfolio-draft-action-panel .action-link,
-  .portfolio-draft-editor-footer .action-link {
+  .portfolio-draft-editor-footer .action-link,
+  .portfolio-draft-empty-actions .action-link {
     width: 100%;
   }
 }

--- a/frontend/src/features/portfolio/api.ts
+++ b/frontend/src/features/portfolio/api.ts
@@ -10,6 +10,12 @@ export function createPortfolioDraft() {
   return apiClient.post<PortfolioDraftDetail>("/api/portfolio/drafts");
 }
 
+export function generatePortfolioDraftVariant(draftId: string, variantKey: string) {
+  return apiClient.post<PortfolioDraftDetail>(
+    `/api/portfolio/drafts/${encodeURIComponent(draftId)}/variants/${encodeURIComponent(variantKey)}/generate`
+  );
+}
+
 export function listPortfolioDrafts() {
   return apiClient.get<PortfolioDraftSummary[]>("/api/portfolio/drafts");
 }

--- a/frontend/src/features/portfolio/portfolio-drafts-view.tsx
+++ b/frontend/src/features/portfolio/portfolio-drafts-view.tsx
@@ -6,6 +6,7 @@ import { AuthRequiredPanel } from "@/components/auth-required-panel";
 import { StatePanel } from "@/components/state-panel";
 import {
   createPortfolioDraft,
+  generatePortfolioDraftVariant,
   getPortfolioDraft,
   listPortfolioDrafts,
   updatePortfolioDraft
@@ -42,14 +43,15 @@ export function PortfolioDraftsView() {
   const [activeVariantKey, setActiveVariantKey] = useState("DONE");
   const [loadingDraftId, setLoadingDraftId] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [generatingVariantKey, setGeneratingVariantKey] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const applyDetail = useCallback((draft: PortfolioDraftDetail) => {
+  const applyDetail = useCallback((draft: PortfolioDraftDetail, nextVariantKey?: string) => {
     setSelectedDraft(draft);
     setDraftPayload(draft.draftPayload);
     setTitle(draft.title);
-    setActiveVariantKey(firstVariantKey(draft.draftPayload));
+    setActiveVariantKey(nextVariantKey ?? firstVariantKey(draft.draftPayload));
   }, []);
 
   useEffect(() => {
@@ -93,6 +95,7 @@ export function PortfolioDraftsView() {
       ?? draftPayload?.variants[0]
       ?? null;
   }, [activeVariantKey, draftPayload]);
+  const activeVariantGenerated = activeVariant ? isVariantGenerated(activeVariant) : false;
 
   async function handleSelectDraft(draftId: string) {
     if (selectedDraft?.draftId === draftId || loadingDraftId === draftId) {
@@ -132,6 +135,31 @@ export function PortfolioDraftsView() {
       setActionError(getErrorMessage(error, "초안을 생성하지 못했습니다."));
     } finally {
       setIsGenerating(false);
+    }
+  }
+
+  async function handleGenerateVariant() {
+    if (!selectedDraft || !activeVariant) {
+      return;
+    }
+    setActionError(null);
+    setGeneratingVariantKey(activeVariant.key);
+    try {
+      const saved = await generatePortfolioDraftVariant(selectedDraft.draftId, activeVariant.key);
+      setDrafts((current) =>
+        current.map((item) =>
+          item.draftId === saved.draftId ? toSummary(saved) : item
+        )
+      );
+      applyDetail(saved, activeVariant.key);
+    } catch (error) {
+      if (isUnauthorizedError(error)) {
+        setState({ status: "auth-required" });
+        return;
+      }
+      setActionError(getErrorMessage(error, "초안 버전을 생성하지 못했습니다."));
+    } finally {
+      setGeneratingVariantKey(null);
     }
   }
 
@@ -177,7 +205,22 @@ export function PortfolioDraftsView() {
         ...current,
         variants: current.variants.map((variant) =>
           variant.key === activeVariant.key
-            ? { ...variant, content: nextContent }
+            ? { ...variant, content: nextContent, generated: true }
+            : variant
+        )
+      };
+    });
+  }
+
+  function handleStartManualInput() {
+    if (!activeVariant) return;
+    setDraftPayload((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        variants: current.variants.map((variant) =>
+          variant.key === activeVariant.key
+            ? { ...variant, generated: true }
             : variant
         )
       };
@@ -211,7 +254,7 @@ export function PortfolioDraftsView() {
       <section className="portfolio-draft-action-panel" aria-label="초안 생성">
         <div>
           <h2>최신 학습 기록으로 초안 생성</h2>
-          <p>생성된 초안은 3가지 버전으로 저장되고, 아래 편집 영역에서 바로 다듬을 수 있습니다.</p>
+          <p>빈 초안 틀을 만든 뒤 필요한 버전만 탭별로 생성하고 편집합니다.</p>
         </div>
         <button
           className="action-link primary"
@@ -219,7 +262,7 @@ export function PortfolioDraftsView() {
           type="button"
           onClick={handleGenerateDraft}
         >
-          {isGenerating ? "생성 중" : "초안 생성"}
+          {isGenerating ? "생성 중" : "빈 초안 생성"}
         </button>
       </section>
 
@@ -305,11 +348,36 @@ export function PortfolioDraftsView() {
                 ))}
               </div>
 
-              <textarea
-                className="portfolio-draft-textarea"
-                value={activeVariant.content}
-                onChange={(event) => handleVariantContentChange(event.target.value)}
-              />
+              {activeVariantGenerated ? (
+                <textarea
+                  className="portfolio-draft-textarea"
+                  value={activeVariant.content}
+                  onChange={(event) => handleVariantContentChange(event.target.value)}
+                />
+              ) : (
+                <div className="portfolio-draft-empty-variant">
+                  <p>아직 생성되지 않은 버전입니다.</p>
+                  <div className="portfolio-draft-empty-actions">
+                    <button
+                      className="action-link primary"
+                      disabled={generatingVariantKey === activeVariant.key}
+                      type="button"
+                      onClick={() => void handleGenerateVariant()}
+                    >
+                      {generatingVariantKey === activeVariant.key
+                        ? "생성 중"
+                        : `${variantLabels[activeVariant.key] ?? activeVariant.label} 생성`}
+                    </button>
+                    <button
+                      className="action-link"
+                      type="button"
+                      onClick={handleStartManualInput}
+                    >
+                      직접 입력
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div className="portfolio-draft-editor-footer">
                 <span>최근 저장 {formatDateTime(selectedDraft.updatedAt)}</span>
@@ -341,9 +409,19 @@ export function PortfolioDraftsView() {
 }
 
 function firstVariantKey(payload: PortfolioDraftPayload) {
+  const generatedKey = preferredVariantOrder.find((key) =>
+    payload.variants.some((variant) => variant.key === key && isVariantGenerated(variant))
+  );
+  if (generatedKey) {
+    return generatedKey;
+  }
   return preferredVariantOrder.find((key) =>
     payload.variants.some((variant) => variant.key === key)
   ) ?? payload.variants[0]?.key ?? "DONE";
+}
+
+function isVariantGenerated(variant: PortfolioDraftVariant) {
+  return variant.generated === true || variant.content.trim().length > 0;
 }
 
 function sortedVariants(variants: PortfolioDraftVariant[]) {

--- a/frontend/src/features/portfolio/types.ts
+++ b/frontend/src/features/portfolio/types.ts
@@ -4,6 +4,7 @@ export type PortfolioDraftVariant = {
   key: PortfolioDraftVariantKey | string;
   label: string;
   content: string;
+  generated?: boolean | null;
 };
 
 export type PortfolioDraftPayload = {


### PR DESCRIPTION
﻿## Summary
- 3개 버전 동시 LLM 생성을 제거하고 빈 초안 틀을 먼저 저장합니다.
- `DONE`, `DONE_IN_PROGRESS`, `ALL` 탭을 각각 별도 endpoint로 생성합니다.
- DB migration 없이 기존 `draft_payload`/`source_refs` JSONB를 유지합니다.
- 기존 저장 초안은 `generated` 필드가 없어도 content가 있으면 생성된 초안처럼 호환합니다.

## Notes
- raw source/prompt 구조는 public API에 새로 노출하지 않습니다.
- GitHub 분석 품질 개선이나 `COMMIT_LIMIT` 변경은 포함하지 않았습니다.

## Tests
- `./gradlew.bat integrationTest --tests "*PortfolioDraftServiceIntegrationTest" --tests "*PortfolioDraftControllerTest"`
- `npm run lint`
- 로컬 API smoke: 빈 초안 생성 -> `ALL` 생성 -> 저장 -> `DONE` 생성, `ALL` 편집 내용 보존 및 `DONE_IN_PROGRESS` 빈 상태 유지 확인

Closes #358
