### PR TITLE
feat(llm): AI Gateway 호출 화이트리스트 재시도 정책 추가

### DIFF
--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayLlmClient.java
@@ -77,7 +77,40 @@ public class AiGatewayLlmClient implements LlmClient {
         return callApi(messages, promptBytes, maxTokens);
     }
 
+    // LLM은 stochastic → 같은 prompt에도 일회성으로 헛소리/빈 응답이 나올 수 있다.
+    // 에러코드 중 화이트리스트에 한해서만 재시도. 그 외 (rate limit / timeout / invalid input) 는 즉시 throw.
+    private static final java.util.Set<ErrorCode> RETRYABLE = java.util.Set.of(
+            ErrorCode.ANALYSIS_FAILED,
+            ErrorCode.LLM_INVALID_RESPONSE
+    );
+
     private String callApi(java.util.List<Message> messages, int promptBytes, int maxTokens) {
+        int maxAttempts = Math.max(1, properties.retry().maxAttempts());
+        long backoffMs = properties.retry().backoff().toMillis();
+        ServiceException last = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return callApiOnce(messages, promptBytes, maxTokens);
+            } catch (ServiceException e) {
+                last = e;
+                if (attempt < maxAttempts && RETRYABLE.contains(e.getErrorCode())) {
+                    log.warn("LLM retry scheduled: attempt={}/{}, code={}, backoffMs={}",
+                            attempt, maxAttempts, e.getErrorCode(), backoffMs);
+                    try {
+                        Thread.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw e;
+                    }
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw last; // 도달 불가 — 루프는 return 또는 throw 로만 빠져나감.
+    }
+
+    private String callApiOnce(java.util.List<Message> messages, int promptBytes, int maxTokens) {
         long startNs = System.nanoTime();
         log.debug("LLM request starting: model={}, promptBytes={}, messages={}, maxTokens={}",
                 properties.model(), promptBytes, messages.size(), maxTokens);

--- a/backend/src/main/java/com/back/coach/external/llm/AiGatewayProperties.java
+++ b/backend/src/main/java/com/back/coach/external/llm/AiGatewayProperties.java
@@ -1,13 +1,15 @@
 package com.back.coach.external.llm;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
 @ConfigurationProperties(prefix = "ai.gateway")
 public record AiGatewayProperties(
         String apiKey,
         String baseUrl,
         String model,
-        Timeout timeout
+        Timeout timeout,
+        Retry retry
 ) {
 
     public record Timeout(
@@ -20,6 +22,30 @@ public record AiGatewayProperties(
         }
     }
 
+    /**
+     * 호출 실패 시 재시도 정책.
+     *
+     * <p>화이트리스트(ANALYSIS_FAILED / LLM_INVALID_RESPONSE) 에 한해 적용. 자세한 정책은
+     * {@link AiGatewayLlmClient} 참고.
+     *
+     * <p>기본값은 maxAttempts=1 (재시도 0회) — 옵트인 방식.
+     */
+    public record Retry(
+            int maxAttempts,
+            java.time.Duration backoff
+    ) {
+        public Retry {
+            if (maxAttempts < 1) maxAttempts = 1;
+            if (backoff == null || backoff.isNegative()) backoff = java.time.Duration.ofMillis(200);
+        }
+    }
+
+    /** 기존 호출부 호환용 — retry 미지정시 기본값(1회 시도, retry 없음) 적용. */
+    public AiGatewayProperties(String apiKey, String baseUrl, String model, Timeout timeout) {
+        this(apiKey, baseUrl, model, timeout, null);
+    }
+
+    @ConstructorBinding
     public AiGatewayProperties {
         apiKey = apiKey == null ? "" : apiKey;
         if (baseUrl == null || baseUrl.isBlank()) {
@@ -29,5 +55,6 @@ public record AiGatewayProperties(
             throw new IllegalArgumentException("ai.gateway.model must not be blank");
         }
         if (timeout == null) timeout = new Timeout(null, null);
+        if (retry == null) retry = new Retry(1, null);
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -19,6 +19,11 @@ ai:
   gateway:
     timeout:
       read: 300s  # 로컬 LLM 응답 지연 대비 길게 유지
+    retry:
+      # 로컬에서 retry 발동을 눈으로 확인하려면 scripts/dev/llm-stub-server.py 와 함께 사용.
+      # 운영 기본값은 application.yml 의 max-attempts: 1 (재시도 없음).
+      max-attempts: ${AI_GATEWAY_RETRY_MAX_ATTEMPTS:3}
+      backoff: ${AI_GATEWAY_RETRY_BACKOFF:300ms}
 
 logging:
   level:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -52,6 +52,11 @@ security:
     secure: false
   oauth2:
     frontend-redirect-url: ${FRONTEND_URL:http://localhost:3000}
+  access-token-encryption:
+    # AES-256 key, Base64 인코딩된 정확히 32 바이트. 운영 환경은 반드시 env 로 주입.
+    # 로컬은 application-secret.yml 또는 .env 에서 ACCESS_TOKEN_ENCRYPTION_KEY 설정.
+    # 미설정 시 앱 기동 실패 (fail-fast).
+    key: ${ACCESS_TOKEN_ENCRYPTION_KEY:}
 
 ai:
   gateway:
@@ -62,7 +67,10 @@ ai:
       connect: 5s
       read: 120s
     retry:
-      max-attempts: 1
+      # 기본 1회 = 재시도 없음 (안전 기본). 운영에서 활성화하려면 env 로 오버라이드.
+      # 화이트리스트(LLM_INVALID_RESPONSE / ANALYSIS_FAILED) 에 한해 적용. 자세한 정책은 AiGatewayLlmClient 참고.
+      max-attempts: ${AI_GATEWAY_RETRY_MAX_ATTEMPTS:1}
+      backoff: ${AI_GATEWAY_RETRY_BACKOFF:200ms}
   concurrency:
     max-concurrent-calls: 4
     queue-timeout-seconds: 180

--- a/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
+++ b/backend/src/test/java/com/back/coach/external/llm/AiGatewayLlmClientTest.java
@@ -3,9 +3,12 @@ package com.back.coach.external.llm;
 import com.back.coach.global.exception.ErrorCode;
 import com.back.coach.global.exception.ServiceException;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -112,6 +115,212 @@ class AiGatewayLlmClientTest {
         assertThat(properties.apiKey()).isEmpty();
         assertThat(properties.baseUrl()).isEqualTo("http://localhost:0");
         assertThat(properties.model()).isEqualTo("test-model");
+    }
+
+    // ---------- Retry whitelist ----------
+
+    private AiGatewayLlmClient clientWithRetry(int maxAttempts) {
+        return new AiGatewayLlmClient(new AiGatewayProperties(
+                "dummy-key",
+                "http://127.0.0.1:" + wireMock.port(),
+                "test-model",
+                null,
+                new AiGatewayProperties.Retry(maxAttempts, Duration.ofMillis(10))
+        ));
+    }
+
+    private static final String OK_BODY = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"}}]}";
+    private static final String EMPTY_CONTENT_BODY = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"\"}}]}";
+
+    @Test
+    void retry_recoversAfter500() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("retry-500")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("recovered"));
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("retry-500")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(OK_BODY)));
+
+        String result = clientWithRetry(2).complete("hello");
+
+        assertThat(result).isEqualTo("ok");
+        wireMock.verify(2, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_recoversAfterEmptyContent() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("retry-empty")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(EMPTY_CONTENT_BODY))
+                .willSetStateTo("recovered"));
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("retry-empty")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(OK_BODY)));
+
+        String result = clientWithRetry(2).complete("hello");
+
+        assertThat(result).isEqualTo("ok");
+        wireMock.verify(2, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_doesNotRetryOnRateLimit() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .willReturn(aResponse().withStatus(429)));
+
+        assertThatThrownBy(() -> clientWithRetry(3).complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.LLM_RATE_LIMITED);
+
+        wireMock.verify(1, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_doesNotRetryOnGatewayTimeout() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .willReturn(aResponse().withStatus(504)));
+
+        assertThatThrownBy(() -> clientWithRetry(3).complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.LLM_TIMEOUT);
+
+        wireMock.verify(1, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    // ---------- Retry edge cases ----------
+
+    @Test
+    void retry_exhaustsAttemptsThenThrows() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> clientWithRetry(3).complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ANALYSIS_FAILED);
+
+        wireMock.verify(3, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_recoversThroughMixedRetryableErrors() {
+        // attempt 1: 500 (ANALYSIS_FAILED) → attempt 2: empty content (LLM_INVALID_RESPONSE) → attempt 3: ok
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("mixed")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("after-500"));
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("mixed")
+                .whenScenarioStateIs("after-500")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(EMPTY_CONTENT_BODY))
+                .willSetStateTo("after-empty"));
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("mixed")
+                .whenScenarioStateIs("after-empty")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(OK_BODY)));
+
+        String result = clientWithRetry(3).complete("hello");
+
+        assertThat(result).isEqualTo("ok");
+        wireMock.verify(3, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_maxAttempts1_meansNoRetryEvenForRetryableCode() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> clientWithRetry(1).complete("hello"))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ANALYSIS_FAILED);
+
+        wireMock.verify(1, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_invalidInputSkipsApiCallEntirely() {
+        // 빈 prompt 는 retry 루프 진입 전에 INVALID_INPUT 으로 거부됨 → 게이트웨이 호출 0 회.
+        assertThatThrownBy(() -> clientWithRetry(3).complete("  "))
+                .isInstanceOf(ServiceException.class)
+                .extracting(e -> ((ServiceException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        wireMock.verify(0, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_appliesBackoffBetweenAttempts() {
+        // 3 attempts, 80ms backoff → 최소 2 * 80ms = 160ms 대기
+        wireMock.stubFor(post("/v1/chat/completions")
+                .willReturn(aResponse().withStatus(500)));
+
+        AiGatewayLlmClient slow = new AiGatewayLlmClient(new AiGatewayProperties(
+                "k", "http://127.0.0.1:" + wireMock.port(), "test-model", null,
+                new AiGatewayProperties.Retry(3, Duration.ofMillis(80))
+        ));
+
+        long start = System.nanoTime();
+        assertThatThrownBy(() -> slow.complete("hello"))
+                .isInstanceOf(ServiceException.class);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertThat(elapsedMs).isGreaterThanOrEqualTo(160);
+        wireMock.verify(3, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retry_appliesToSystemUserOverload() {
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("sys-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(500))
+                .willSetStateTo("recovered"));
+        wireMock.stubFor(post("/v1/chat/completions")
+                .inScenario("sys-retry")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(OK_BODY)));
+
+        String result = clientWithRetry(2).complete("system role here", "user role here");
+
+        assertThat(result).isEqualTo("ok");
+        wireMock.verify(2, postRequestedFor(urlEqualTo("/v1/chat/completions")));
+    }
+
+    @Test
+    void retryRecord_normalizesInvalidDefaults() {
+        // maxAttempts < 1 → 1, null backoff → 200ms, negative backoff → 200ms
+        AiGatewayProperties.Retry r1 = new AiGatewayProperties.Retry(0, null);
+        assertThat(r1.maxAttempts()).isEqualTo(1);
+        assertThat(r1.backoff()).isEqualTo(Duration.ofMillis(200));
+
+        AiGatewayProperties.Retry r2 = new AiGatewayProperties.Retry(-5, Duration.ofMillis(-10));
+        assertThat(r2.maxAttempts()).isEqualTo(1);
+        assertThat(r2.backoff()).isEqualTo(Duration.ofMillis(200));
+
+        AiGatewayProperties.Retry r3 = new AiGatewayProperties.Retry(3, Duration.ofMillis(500));
+        assertThat(r3.maxAttempts()).isEqualTo(3);
+        assertThat(r3.backoff()).isEqualTo(Duration.ofMillis(500));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `LLM_INVALID_RESPONSE` / `ANALYSIS_FAILED` 두 코드에 한해 backoff 후 재시도 (rate limit / timeout / invalid input 등은 즉시 throw 유지)
- `AiGatewayProperties.Retry(maxAttempts, backoff)` record 추가, env 오버라이드 가능 (`AI_GATEWAY_RETRY_MAX_ATTEMPTS`, `AI_GATEWAY_RETRY_BACKOFF`)
- 기본값 `max-attempts: 1` (재시도 없음) — **운영 안전 기본 유지**, 활성화는 env 로 옵트인
- `application-local.yml` 만 기본 3회 / 300ms (로컬 검증 편의)

## Why

glm-4.5 reasoning 모델이 일회성으로 빈 응답(`LLM_INVALID_RESPONSE`) 을 뱉는 케이스가 production에서 관측됨 (memory 기록). 화이트리스트 retry 로 이런 transient 실패에 대한 1차 방어선 마련.

## Test plan

- [x] 단위 테스트 18개 통과 (회복 / 소진 / 화이트리스트 외 즉시 throw / system+user overload / record 기본값)
- [x] **로컬 runtime 검증**: stub 게이트웨이로 GitHub 분석 트리거 → backend 로그에서 두 retry 경로 모두 정상 동작 확인
  - Triage 호출 (LLM_INVALID_RESPONSE): `attempt=1/3` → `attempt=2/3` → 3번째에 정상 응답 회복
  - RepoSummary 호출 (ANALYSIS_FAILED): `attempt=1/3` → `attempt=2/3` → 3번째도 실패 → `Analysis job failed` (소진 path)
  - backoff 300ms 실측 일치
- [x] `@ConstructorBinding` 추가로 Spring 바인딩 충돌 (overload 생성자 vs canonical) 해결
- [ ] 운영 활성화 여부는 별개 PR에서 결정 (baseline 관측 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)