### PR TITLE
feat(security): GitHub access_token DB 컬럼 AES-256-GCM 자동 암호화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ REDIS_PORT=6380
 # Backend security
 JWT_SECRET=change-me-to-a-long-random-local-secret
 FRONTEND_URL=http://localhost:3000
+# AES-256 key (Base64, 정확히 32바이트). 생성: `openssl rand -base64 32`
+ACCESS_TOKEN_ENCRYPTION_KEY=generate-with-openssl-rand-base64-32
 
 # GitHub OAuth - login
 GITHUB_CLIENT_ID=your-github-oauth-client-id

--- a/backend/src/main/java/com/back/coach/domain/github/entity/GithubConnection.java
+++ b/backend/src/main/java/com/back/coach/domain/github/entity/GithubConnection.java
@@ -2,7 +2,9 @@ package com.back.coach.domain.github.entity;
 
 import com.back.coach.global.code.GithubAccessType;
 import com.back.coach.global.jpa.entity.BaseEntity;
+import com.back.coach.global.security.crypto.AccessTokenEncryptor;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -36,6 +38,7 @@ public class GithubConnection extends BaseEntity {
     @Column(name = "access_type", nullable = false, length = 30)
     private GithubAccessType accessType;
 
+    @Convert(converter = AccessTokenEncryptor.class)
     @Column(name = "access_token", length = 500)
     private String accessToken;
 

--- a/backend/src/main/java/com/back/coach/global/security/crypto/AccessTokenEncryptor.java
+++ b/backend/src/main/java/com/back/coach/global/security/crypto/AccessTokenEncryptor.java
@@ -1,0 +1,117 @@
+package com.back.coach.global.security.crypto;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * GitHub OAuth access_token 의 DB 저장 값을 AES-256-GCM 으로 자동 암복호화하는 JPA converter.
+ *
+ * <p>저장 포맷: {@code enc:{base64(iv)}:{base64(ciphertext+tag)}}.
+ * IV 는 12 바이트(96-bit, GCM 권장), tag 는 128-bit.
+ *
+ * <h3>Legacy plaintext 호환</h3>
+ * 마이그레이션 부담 회피를 위해, DB 에 이미 들어있는 plaintext (= "enc:" prefix 없음) 는
+ * 그대로 읽어 반환한다. 다음 update 시 자동으로 암호화된 형태로 다시 저장된다.
+ *
+ * <h3>키 관리</h3>
+ * {@code security.access-token-encryption.key} 프로퍼티 (env: {@code ACCESS_TOKEN_ENCRYPTION_KEY})
+ * 로 주입한다. Base64 로 인코딩된 정확히 32 바이트(AES-256). 누락/형식 오류 시 ApplicationContext
+ * 로딩이 실패한다 (fail-fast).
+ *
+ * <p>대부분의 호출 코드는 {@code @Convert} 이외에 어떤 변경도 필요하지 않다 —
+ * JPA 가 entity read/write 시 본 converter 를 자동 적용한다.
+ */
+@Component
+@Converter
+public class AccessTokenEncryptor implements AttributeConverter<String, String> {
+
+    /** "enc:" prefix 로 암호화된 값임을 식별. */
+    static final String PREFIX = "enc:";
+    private static final String CIPHER_ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH_BYTES = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int AES_KEY_LENGTH_BYTES = 32; // AES-256
+
+    private final SecretKey secretKey;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AccessTokenEncryptor(@Value("${security.access-token-encryption.key:}") String base64Key) {
+        this.secretKey = loadKey(base64Key);
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String raw) {
+        if (raw == null) return null;
+        if (raw.isEmpty()) return raw;
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH_BYTES];
+            secureRandom.nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            byte[] cipherText = cipher.doFinal(raw.getBytes(StandardCharsets.UTF_8));
+
+            Base64.Encoder enc = Base64.getEncoder().withoutPadding();
+            return PREFIX + enc.encodeToString(iv) + ":" + enc.encodeToString(cipherText);
+        } catch (GeneralSecurityException secException) {
+            throw new IllegalStateException("access_token 암호화 실패", secException);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String db) {
+        if (db == null) return null;
+        if (!db.startsWith(PREFIX)) {
+            // Legacy plaintext (마이그레이션 전 값). 그대로 반환 → 다음 save 시 자동 암호화.
+            return db;
+        }
+        String payload = db.substring(PREFIX.length());
+        int sep = payload.indexOf(':');
+        if (sep < 0) {
+            throw new IllegalStateException("access_token DB 값 포맷이 잘못됨 (IV separator 누락)");
+        }
+        try {
+            byte[] iv = Base64.getDecoder().decode(payload.substring(0, sep));
+            byte[] cipherText = Base64.getDecoder().decode(payload.substring(sep + 1));
+
+            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            byte[] plainBytes = cipher.doFinal(cipherText);
+            return new String(plainBytes, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException | IllegalArgumentException secException) {
+            throw new IllegalStateException("access_token 복호화 실패 (탬퍼링 또는 키 불일치)", secException);
+        }
+    }
+
+    private static SecretKey loadKey(String base64Key) {
+        if (base64Key == null || base64Key.isBlank()) {
+            throw new IllegalStateException(
+                    "security.access-token-encryption.key 가 설정되지 않았습니다 (env: ACCESS_TOKEN_ENCRYPTION_KEY)");
+        }
+        byte[] keyBytes;
+        try {
+            keyBytes = Base64.getDecoder().decode(base64Key.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException(
+                    "security.access-token-encryption.key 가 Base64 형식이 아닙니다", ex);
+        }
+        if (keyBytes.length != AES_KEY_LENGTH_BYTES) {
+            throw new IllegalStateException(
+                    "security.access-token-encryption.key 는 AES-256 용 32 바이트여야 합니다. 현재: "
+                            + keyBytes.length + " 바이트");
+        }
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+
+}

--- a/backend/src/main/resources/application-secret.yml.example
+++ b/backend/src/main/resources/application-secret.yml.example
@@ -19,7 +19,13 @@ ai:
     api-key: 그렙-스레드-키
     base-url: https://aigw.alpha.grepp.co
     model: glm-4.7
-    
+
+# GitHub OAuth access_token DB 컬럼 AES-256-GCM 암호화 키. 필수.
+# 생성: `openssl rand -base64 32` → 정확히 32바이트 Base64. 운영/스테이지는 env 로.
+security:
+  access-token-encryption:
+    key: PASTE_BASE64_32BYTE_KEY_HERE
+
 # (선택) JWT 비밀키를 로컬에서 고정하고 싶을 때만:
 # security:
 #   jwt:

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -12,3 +12,8 @@ ai:
     api-key: test-key
     base-url: http://localhost:0
     model: test-model
+
+security:
+  # 테스트 전용 고정 AES-256 키 (정확히 32 bytes, Base64 인코딩). 운영용 아님.
+  access-token-encryption:
+    key: dW5pdC10ZXN0LTMyYnl0ZS1hZXMta2V5LXBhZGRpbjA=

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -52,6 +52,11 @@ security:
     secure: false
   oauth2:
     frontend-redirect-url: ${FRONTEND_URL:http://localhost:3000}
+  access-token-encryption:
+    # AES-256 key, Base64 인코딩된 정확히 32 바이트. 운영 환경은 반드시 env 로 주입.
+    # 로컬은 application-secret.yml 또는 .env 에서 ACCESS_TOKEN_ENCRYPTION_KEY 설정.
+    # 미설정 시 앱 기동 실패 (fail-fast).
+    key: ${ACCESS_TOKEN_ENCRYPTION_KEY:}
 
 ai:
   gateway:

--- a/backend/src/test/java/com/back/coach/global/security/crypto/AccessTokenEncryptorTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/crypto/AccessTokenEncryptorTest.java
@@ -1,0 +1,118 @@
+package com.back.coach.global.security.crypto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AccessTokenEncryptorTest {
+
+    /** 정확히 32 바이트 짜리 Base64 키 (테스트 전용). */
+    private static final String TEST_KEY_BASE64 =
+            Base64.getEncoder().encodeToString("unit-test-32byte-aes-key-paddin0".getBytes());
+
+    private final AccessTokenEncryptor sut = new AccessTokenEncryptor(TEST_KEY_BASE64);
+
+    @Test
+    void plain_to_db_to_plain_round_trips() {
+        String plain = "ghp_1234567890abcdefABCDEF1234567890";
+
+        String db = sut.convertToDatabaseColumn(plain);
+        String back = sut.convertToEntityAttribute(db);
+
+        assertThat(db).startsWith(AccessTokenEncryptor.PREFIX);
+        assertThat(db).isNotEqualTo(plain);
+        assertThat(back).isEqualTo(plain);
+    }
+
+    @Test
+    void each_encryption_uses_new_iv_so_outputs_differ() {
+        String plain = "ghp_same_token_value";
+        String db1 = sut.convertToDatabaseColumn(plain);
+        String db2 = sut.convertToDatabaseColumn(plain);
+
+        assertThat(db1).isNotEqualTo(db2); // GCM IV 가 매번 새로 생성되므로 ciphertext 가 다름
+        assertThat(sut.convertToEntityAttribute(db1)).isEqualTo(plain);
+        assertThat(sut.convertToEntityAttribute(db2)).isEqualTo(plain);
+    }
+
+    @Test
+    void null_in_yields_null_out() {
+        assertThat(sut.convertToDatabaseColumn(null)).isNull();
+        assertThat(sut.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void empty_string_in_yields_empty_string_out() {
+        assertThat(sut.convertToDatabaseColumn("")).isEmpty();
+    }
+
+    @Test
+    void legacy_plaintext_without_prefix_is_returned_as_is() {
+        // 마이그레이션 전 plaintext 데이터 호환 시나리오
+        String legacy = "ghp_legacy_plaintext_before_migration";
+
+        String result = sut.convertToEntityAttribute(legacy);
+
+        assertThat(result).isEqualTo(legacy);
+    }
+
+    @Test
+    void tampered_ciphertext_throws() {
+        String plain = "ghp_token";
+        String db = sut.convertToDatabaseColumn(plain);
+        // 마지막 글자를 살짝 바꾸면 GCM auth tag 검증 실패
+        String tampered = db.substring(0, db.length() - 1) + (db.endsWith("A") ? "B" : "A");
+
+        assertThatThrownBy(() -> sut.convertToEntityAttribute(tampered))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("복호화 실패");
+    }
+
+    @Test
+    void malformed_db_value_missing_iv_separator_throws() {
+        String malformed = AccessTokenEncryptor.PREFIX + "nocolon";
+
+        assertThatThrownBy(() -> sut.convertToEntityAttribute(malformed))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("IV separator");
+    }
+
+    @Test
+    void missing_key_property_fails_fast_on_construction() {
+        assertThatThrownBy(() -> new AccessTokenEncryptor(""))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("설정되지 않았습니다");
+
+        assertThatThrownBy(() -> new AccessTokenEncryptor(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("설정되지 않았습니다");
+    }
+
+    @Test
+    void non_base64_key_fails_fast() {
+        assertThatThrownBy(() -> new AccessTokenEncryptor("!!! not base64 !!!"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Base64");
+    }
+
+    @Test
+    void wrong_length_key_fails_fast() {
+        // 16 바이트 → AES-128, 본 컨버터는 32 바이트만 허용
+        String short16 = Base64.getEncoder().encodeToString(new byte[16]);
+
+        assertThatThrownBy(() -> new AccessTokenEncryptor(short16))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("32 바이트");
+    }
+
+    @Test
+    void encrypted_value_fits_in_500_char_db_column() {
+        // GithubConnection.access_token 컬럼 length=500. GitHub PAT 최대 ~93자 까지 검증.
+        String longishToken = "ghp_" + "x".repeat(89); // 93 chars
+        String db = sut.convertToDatabaseColumn(longishToken);
+        assertThat(db.length()).isLessThanOrEqualTo(500);
+    }
+}

--- a/backend/src/test/java/com/back/coach/global/security/crypto/AccessTokenEncryptorTest.java
+++ b/backend/src/test/java/com/back/coach/global/security/crypto/AccessTokenEncryptorTest.java
@@ -63,8 +63,11 @@ class AccessTokenEncryptorTest {
     void tampered_ciphertext_throws() {
         String plain = "ghp_token";
         String db = sut.convertToDatabaseColumn(plain);
-        // 마지막 글자를 살짝 바꾸면 GCM auth tag 검증 실패
-        String tampered = db.substring(0, db.length() - 1) + (db.endsWith("A") ? "B" : "A");
+        // ciphertext base64 의 첫 글자(패딩 아님)를 변조 → GCM auth tag 검증 실패.
+        // 마지막 글자를 변조하면 base64 padding 위치에 걸려 디코더가 silent truncation 할 수 있음.
+        int ctStart = db.indexOf(':', AccessTokenEncryptor.PREFIX.length()) + 1;
+        char orig = db.charAt(ctStart);
+        String tampered = db.substring(0, ctStart) + (orig == 'A' ? 'B' : 'A') + db.substring(ctStart + 1);
 
         assertThatThrownBy(() -> sut.convertToEntityAttribute(tampered))
                 .isInstanceOf(IllegalStateException.class)

--- a/backend/src/test/resources/application-wiring-test.yml
+++ b/backend/src/test/resources/application-wiring-test.yml
@@ -23,6 +23,9 @@ security:
     secret: wiring-test-jwt-secret-key-for-tests-only-do-not-use-in-production-0123456789
     access-ttl-seconds: 900
     refresh-ttl-seconds: 86400
+  # wiring-test 전용 고정 AES-256 키 (정확히 32 bytes, Base64 인코딩). 운영용 아님.
+  access-token-encryption:
+    key: dW5pdC10ZXN0LTMyYnl0ZS1hZXMta2V5LXBhZGRpbjA=
 
 management:
   health:

--- a/docker/.env.deploy.example
+++ b/docker/.env.deploy.example
@@ -40,6 +40,8 @@ SPRING_PROFILES_ACTIVE=prod,oauth
 CORS_ALLOWED_ORIGINS=http://localhost
 FRONTEND_URL=http://localhost
 JWT_SECRET=change-me-to-a-long-random-production-secret
+# AES-256 key (Base64, 정확히 32바이트). 생성: `openssl rand -base64 32`. 운영 필수.
+ACCESS_TOKEN_ENCRYPTION_KEY=change-me-base64-32-byte-key
 
 # GitHub OAuth - login
 GITHUB_CLIENT_ID=your-production-login-oauth-client-id


### PR DESCRIPTION
## Summary

`github_connections.access_token` 이 plaintext 로 저장돼 DB 덤프나 운영자 SELECT 만으로 사용자 GitHub OAuth 토큰이 그대로 노출되던 문제를 해결한다. 호출 코드를 건드리지 않고 JPA AttributeConverter 만으로 처리해 회귀 위험을 최소화했다.

## 구현

- **AccessTokenEncryptor** (신규): JPA AttributeConverter. AES-256-GCM 으로 read/write 시점에 자동 암복호화. 저장 포맷 `enc:{base64(iv)}:{base64(ciphertext+tag)}`. 96-bit IV 는 매 저장마다 새로 생성하므로 동일 plaintext 라도 ciphertext 가 매번 달라진다.
- `GithubConnection.accessToken` 필드에 `@Convert` 1줄만 추가. service / repository 호출 코드는 0줄 변경.
- 키 주입: `security.access-token-encryption.key` (env `ACCESS_TOKEN_ENCRYPTION_KEY`). Base64 인코딩된 정확히 32 바이트. 미설정 / 형식 오류 / 길이 불일치 → ApplicationContext 로딩 시 fail-fast.
- `application-test.yml` 에 테스트 전용 고정 키 추가.

## Legacy plaintext 호환

마이그레이션 스크립트 없이 무중단 전환: `convertToEntityAttribute` 가 `enc:` prefix 없는 값은 plaintext 로 그대로 반환. 다음 save 시점에 자동으로 암호화된 포맷으로 다시 저장된다.

## Test plan

- [x] **단위 테스트 11 cases 모두 통과**
  - 평문 → 암호문 → 평문 round-trip
  - IV 재사용 방지 (같은 평문 2회 암호화 시 ciphertext 다름)
  - null / 빈 문자열 처리
  - legacy plaintext (prefix 없음) 그대로 반환
  - 탬퍼링된 ciphertext 감지 (GCM auth tag 검증 실패)
  - 잘못된 포맷 (IV separator 없음) 감지
  - 키 누락 / 비-Base64 / 잘못된 길이 모두 fail-fast
  - 암호화 결과가 access_token 컬럼 length=500 안에 들어감 (PAT 최대 길이 검증)
- [x] **추가 fix 1건**: `tampered_ciphertext_throws` 가 9바이트 plaintext 의 base64 padding 위치를 변조해서 silent truncation 으로 throw 가 안 되던 latent bug 수정 (commit `7153a8a` 참고).

## 위험

매우 낮음: JPA 경계에서만 동작, 호출 코드 시그니처 무변경, 마이그레이션 스크립트 없음, legacy plaintext 자동 호환.

## 비고

이 PR 은 main 의 #342 와 동일 코드를 dev 에 반영하며, 위 테스트 수정 1건이 추가됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)